### PR TITLE
Fix(eos_designs)!: Remove eBGP LAN outbound route-map for WAN

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -24,9 +24,9 @@ Breaking changes may require modifications to the inventory or playbook.
 The eBGP LAN feature for WAN routers introduced in AVD 4.7.0 is not working for connected and static redistributed routes inside a VRF (outside of the VRF default) as the RM-BGP-UNDERLAY-PEERS-OUT outbound route-map would not match these routes.
 Similarly the routes coming from an eBGP peering in any VRF (including default) would be blocked out by the route-map.
 
-For all these reasons, the route-map is being removed.
+For these reasons, the route-map was removed as a bug fix.
 
-To keep the broken route-map, structured_configuration can be used.
+To keep the broken route-map, `structured_config` can be used.
 
 ## Release 4.8.0
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -13,6 +13,20 @@ title: Release Notes for AVD 4.x.x
 - Documentation for AVD version `4.x.x` [available here](https://www.avd.sh/en/stable/)
 
 <!-- Release notes generated using configuration in .github/release.yml at devel -->
+## Release 4.9.0
+
+### Breaking or behavioral changes in eos_designs
+
+Breaking changes may require modifications to the inventory or playbook.
+
+#### Removed the BGP outbound route-map for eBGP LAN on WAN routers
+
+The eBGP LAN feature for WAN routers introduced in AVD 4.7.0 is not working for connected and static redistributed routes inside a VRF (outside of the VRF default) as the RM-BGP-UNDERLAY-PEERS-OUT outbound route-map would not match these routes.
+Similarly the routes coming from an eBGP peering in any VRF (including default) would be blocked out by the route-map.
+
+For all these reasons, the route-map is being removed.
+
+To keep the broken route-map, structured_configuration can be used.
 
 ## Release 4.8.0
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
@@ -217,14 +217,6 @@ route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.42.1:511 additive
 !
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
-!
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    set extcommunity soo 192.168.42.1:511 additive
@@ -252,7 +244,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
@@ -217,14 +217,6 @@ route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.42.2:511 additive
 !
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
-!
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    set extcommunity soo 192.168.42.2:511 additive
@@ -252,7 +244,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
@@ -186,14 +186,6 @@ route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.42.3:511 additive
 !
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
-!
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    set extcommunity soo 192.168.42.3:511 additive
@@ -221,7 +213,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
@@ -251,7 +251,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -522,14 +522,6 @@ route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.42.1:511 additive
 !
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
-!
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    set extcommunity soo 192.168.42.1:511 additive

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -572,14 +572,6 @@ route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.42.2:511 additive
 !
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
-!
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    set extcommunity soo 192.168.42.2:511 additive
@@ -607,7 +599,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -378,18 +378,6 @@ route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.42.2:423 additive
 !
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 30
-   description Advertise WAN HA prefixes towards LAN
-   match ip address prefix-list PL-WAN-HA-PREFIXES
-!
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    set extcommunity soo 192.168.42.2:423 additive
@@ -421,7 +409,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -390,18 +390,6 @@ route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.42.2:423 additive
 !
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 30
-   description Advertise WAN HA prefixes towards LAN
-   match ip address prefix-list PL-WAN-HA-PREFIXES
-!
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    set extcommunity soo 192.168.42.2:423 additive
@@ -433,7 +421,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -352,7 +352,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -341,7 +341,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -354,7 +354,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -454,18 +454,6 @@ route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.43.1:422 additive
 !
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 30
-   description Advertise WAN HA prefixes towards LAN
-   match ip address prefix-list PL-WAN-HA-PREFIXES
-!
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    set extcommunity soo 192.168.43.1:422 additive
@@ -497,7 +485,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -420,18 +420,6 @@ route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.43.1:422 additive
 !
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 30
-   description Advertise WAN HA prefixes towards LAN
-   match ip address prefix-list PL-WAN-HA-PREFIXES
-!
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    set extcommunity soo 192.168.43.1:422 additive
@@ -463,7 +451,6 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
-   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
     update_source: Dps1
@@ -171,18 +170,6 @@ route_maps:
     description: Mark prefixes originated from the LAN
     set:
     - extcommunity soo 192.168.42.1:511 additive
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
     update_source: Dps1
@@ -171,18 +170,6 @@ route_maps:
     description: Mark prefixes originated from the LAN
     set:
     - extcommunity soo 192.168.42.2:511 additive
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
     update_source: Dps1
@@ -171,18 +170,6 @@ route_maps:
     description: Mark prefixes originated from the LAN
     set:
     - extcommunity soo 192.168.42.3:511 additive
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
     update_source: Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -280,18 +280,6 @@ route_maps:
     description: Mark prefixes originated from the LAN
     set:
     - extcommunity soo 192.168.42.1:511 additive
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
     update_source: Dps1
@@ -267,18 +266,6 @@ route_maps:
     description: Mark prefixes originated from the LAN
     set:
     - extcommunity soo 192.168.42.2:511 additive
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
     allowas_in:
       enabled: true
       times: 1
@@ -345,23 +344,6 @@ route_maps:
     - as-path ASPATH-WAN
     set:
     - community no-advertise
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
-  - sequence: 30
-    type: permit
-    description: Advertise WAN HA prefixes towards LAN
-    match:
-    - ip address prefix-list PL-WAN-HA-PREFIXES
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
     allowas_in:
       enabled: true
       times: 1
@@ -344,23 +343,6 @@ route_maps:
     - as-path ASPATH-WAN
     set:
     - community no-advertise
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
-  - sequence: 30
-    type: permit
-    description: Advertise WAN HA prefixes towards LAN
-    match:
-    - ip address prefix-list PL-WAN-HA-PREFIXES
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
     update_source: Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
     update_source: Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
     update_source: Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
     allowas_in:
       enabled: true
       times: 1
@@ -324,23 +323,6 @@ route_maps:
     - as-path ASPATH-WAN
     set:
     - community no-advertise
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
-  - sequence: 30
-    type: permit
-    description: Advertise WAN HA prefixes towards LAN
-    match:
-    - ip address prefix-list PL-WAN-HA-PREFIXES
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -16,7 +16,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
     allowas_in:
       enabled: true
       times: 1
@@ -322,23 +321,6 @@ route_maps:
     - as-path ASPATH-WAN
     set:
     - community no-advertise
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
-  - sequence: 30
-    type: permit
-    description: Advertise WAN HA prefixes towards LAN
-    match:
-    - ip address prefix-list PL-WAN-HA-PREFIXES
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
@@ -17,7 +17,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
     allowas_in:
       enabled: true
       times: 1
@@ -237,23 +236,6 @@ route_maps:
     - as-path ASPATH-WAN
     set:
     - community no-advertise
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
-  - sequence: 30
-    type: permit
-    description: Advertise WAN HA prefixes towards LAN
-    match:
-    - ip address prefix-list PL-WAN-HA-PREFIXES
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
@@ -17,7 +17,6 @@ router_bgp:
     maximum_routes: 12000
     send_community: all
     route_map_in: RM-BGP-UNDERLAY-PEERS-IN
-    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
     allowas_in:
       enabled: true
       times: 1
@@ -237,23 +236,6 @@ route_maps:
     - as-path ASPATH-WAN
     set:
     - community no-advertise
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
-  - sequence: 30
-    type: permit
-    description: Advertise WAN HA prefixes towards LAN
-    match:
-    - ip address prefix-list PL-WAN-HA-PREFIXES
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -67,6 +67,7 @@ Please familiarize yourself with the Arista WAN terminology before proceeding:
 - The name of the AVT policies and AVT profiles are configurable in the input variables. The Load Balance policies are named `LB-<profile_name>` and are not configurable.
 - LAN support is limited to single L2 using `uplink_type: lan` and eBGP L3 using `uplink_type: p2p-vrfs` in conjunction of `underlay_routing_protocol: ebgp`.
 - All the WAN routers must have a common path-group with at least one WAN route server to be able to inject the default control-plane match statement in the VRF default WAN policy.
+- For the default VRF, routes received over BGP peering configured under tenants in `network_services` will not be automatically advertised to the WAN (they will be advertised toward the LAN if eBGP is used). To advertise them towards the WAN, they need to be injected in EVPN and this can be achieved by adding a route-map to mark them with the site SOO.
 
 ### Future work
 
@@ -639,13 +640,11 @@ The following LAN scenarios are in PREVIEW:
 - the Site of Origin (SoO) extended community is configured as <router_id>:<site_id>
     note: site id is unique per zone (only a default zone supported today).
 - the routes redistributed into BGP via the route-map `RM-CONN-2-BGP` are tagged with the SoO.
-- the Underlay peer group (towards the LAN) is configured with two route-maps reused from existing designed but configured differently
-  - one outbound route-map `RM-BGP-UNDERLAY-PEERS-OUT`:
-    - advertised the local routes tagged with the SoO extended community.
-    - advertised the routes received from iBGP (WAN) towards the LAN also marked with the SoO community.
+- the Underlay peer group (towards the LAN) is configured with one inbound route-map
   - one inbound route-map `RM-BGP-UNDERLAY-PEERS-IN`:
     - deny routes received from LAN that already contain the WAN AS in the path.
     - accept routes coming from the LAN and set the SoO extended community on them.
+- the Underlay peer group (towards the LAN) is not configured with any outbound route-map.
 - For VRF default, there is a requirement to explicitly redistribute the routes for EVPN. The `RM-EVPN-EXPORT-VRF-DEFAULT` is configured to export the routes tagged with the SoO.
 
 ##### HA (PREVIEW)
@@ -659,17 +658,12 @@ for eBGP LAN routing protocol the following is done to enable HA:
 - the uplink interfaces are used as HA interfaces.
 - the subnets of the HA interfaces are redistributed to BGP via the `RM-CONN-2-BGP` route-map
 BGP underlay peer group is configured with `allowas-in 1` to be able to learn the HA peer uplink interface subnet over the LAN as well as learning WAN routes from other sites (as backup in case all WAN links are lost).
-- the Underlay peer group is configured with two route-maps
-  - one inbound route-map `RM-UNDERLAY-PEERS-IN`
+- the Underlay peer group is configured with one inbound route-map
+  - one inbound route-map `RM-BGP-UNDERLAY-PEERS-IN`
     - Match HA peer's uplink subnets (not marked) to be able to form HA tunnel (not exported to EVPN).
     - Match HA peer's originated prefixes, set longer AS path and mark with SoO to export to EVPN. These will be used as backup from other sites to destinations on HA Peer Router in case all WAN connections on Peer are down.
     - Match all WAN routes using AS path and set no-advertise community. This will be used as backup routes to the WAN in case this router looses all WAN connections.
     - Match anything else (LAN prefixes) and mark with the SoO `<bgp_as>:<wan_site_id>` to export to EVPN.
-  - one outbound route-map `RM-UNDERLAY-PEERS-OUT`
-    - allowing local routes marked with SoO (routes/interfaces defined via tenants + router-id)
-    - allowing subnets of uplink interfaces.
-    - allow all routes learned from iBGP (WAN)
-    - Implicitly denying other routes which could be learned from BGP towards a WAN provider or redistributed without marking with SoO.
 
 #### OSPF LAN (NOT SUPPORTED)
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/route_maps.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/route_maps.py
@@ -130,31 +130,7 @@ class RouteMapsMixin(UtilsMixin):
                 )
             route_maps.append({"name": "RM-BGP-UNDERLAY-PEERS-IN", "sequence_numbers": sequence_numbers})
 
-            # RM-BGP-UNDERLAY-PEERS-OUT
-            sequence_numbers = [
-                {
-                    "sequence": 10,
-                    "type": "permit",
-                    "description": "Advertise local routes towards LAN",
-                    "match": ["extcommunity ECL-EVPN-SOO"],
-                },
-                {
-                    "sequence": 20,
-                    "type": "permit",
-                    "description": "Advertise routes received from WAN iBGP towards LAN",
-                    "match": ["route-type internal"],
-                },
-            ]
-            if self.shared_utils.wan_ha:
-                sequence_numbers.append(
-                    {
-                        "sequence": 30,
-                        "type": "permit",
-                        "description": "Advertise WAN HA prefixes towards LAN",
-                        "match": ["ip address prefix-list PL-WAN-HA-PREFIXES"],
-                    },
-                )
-            route_maps.append({"name": "RM-BGP-UNDERLAY-PEERS-OUT", "sequence_numbers": sequence_numbers})
+            # TODO: No RM-BGP-UNDERLAY-PEERS-OUT, sending everything out. There will be one added for HA support in a future PR
 
         if route_maps:
             return route_maps

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
@@ -45,7 +45,7 @@ class RouterBgpMixin(UtilsMixin):
 
         if self.shared_utils.overlay_routing_protocol == "ibgp" and self.shared_utils.is_cv_pathfinder_router:
             peer_group["route_map_in"] = "RM-BGP-UNDERLAY-PEERS-IN"
-            peer_group["route_map_out"] = "RM-BGP-UNDERLAY-PEERS-OUT"
+            # TODO: no RM-BGP-UNDERLAY-PEERS-OUT route-map, one will be added in a future PR for HA.
             if self.shared_utils.wan_ha:
                 # For HA need to add allowas_in 1
                 peer_group["allowas_in"] = {"enabled": True, "times": 1}


### PR DESCRIPTION
## Change Summary

The shipped eBGP LAN feature for WAN routers is not working for connected and static redistributed routes inside a VRF as the route-map would not match these routes. Similarly the routes coming from an eBGP peering in any VRF (including default) would be blocked out by the RM-BGP-UNDERLAY-PEERS-OUT route-map.

This PR is a breaking change to fix this situation.

## Related Issue(s)

Discovered while working on #3720 and following review comments, separated in its own PR in order to be able to communicate with clarity about the breaking change.

## Component(s) name

`arista.avd.eos_design`

## Proposed changes

* Removing the outbound route-map for eBGP LAN peers on WAN routers
* Editing doc
* Adding limitation for eBGP peering in `network_services` received routes in VRF default that would not be advertised to the WAN.

## How to test

molecule + test on existing lab

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
