### PR TITLE
Feat(eos_designs): Enforce unicity of region IDs and per-region site IDs for CV Pathfinder

### DIFF
--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -701,6 +701,8 @@ keys:
     description: Define the CV Pathfinder hierarchy.
     type: list
     primary_key: name
+    unique_keys:
+    - id
     items:
       type: dict
       $ref: eos_cli_config_gen#/keys/router_adaptive_virtual_topology/keys/region
@@ -719,6 +721,8 @@ keys:
           description: All sites are placed in a default zone "<region_name>-ZONE"
             with ID 1.
           primary_key: name
+          unique_keys:
+          - id
           items:
             type: dict
             $ref: eos_cli_config_gen#/keys/router_adaptive_virtual_topology/keys/site

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -703,6 +703,7 @@ keys:
     primary_key: name
     unique_keys:
     - id
+    - sites.name
     items:
       type: dict
       $ref: eos_cli_config_gen#/keys/router_adaptive_virtual_topology/keys/region

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_regions.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_regions.schema.yml
@@ -12,6 +12,8 @@ keys:
     description: Define the CV Pathfinder hierarchy.
     type: list
     primary_key: name
+    unique_keys:
+      - id
     items:
       type: dict
       $ref: "eos_cli_config_gen#/keys/router_adaptive_virtual_topology/keys/region"
@@ -31,6 +33,8 @@ keys:
           description: |-
             All sites are placed in a default zone "<region_name>-ZONE" with ID 1.
           primary_key: name
+          unique_keys:
+            - id
           items:
             type: dict
             $ref: "eos_cli_config_gen#/keys/router_adaptive_virtual_topology/keys/site"

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_regions.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_regions.schema.yml
@@ -14,6 +14,7 @@ keys:
     primary_key: name
     unique_keys:
       - id
+      - sites.name
     items:
       type: dict
       $ref: "eos_cli_config_gen#/keys/router_adaptive_virtual_topology/keys/region"

--- a/python-avd/pyavd/_eos_designs/shared_utils/wan.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/wan.py
@@ -269,8 +269,6 @@ class WanMixin:
         """
         WAN region for CV Pathfinder
 
-        Also checking if site names are unique across all regions.
-
         The region is required for edges, but optional for pathfinders
         """
         node_defined_region = get(
@@ -285,17 +283,6 @@ class WanMixin:
         regions = get(
             self.hostvars, "cv_pathfinder_regions", required=True, org_key="'cv_pathfinder_regions' key must be set when 'wan_mode' is 'cv-pathfinder'."
         )
-
-        # Verify that site names are unique across all regions.
-        site_names = [site["name"] for region in regions for site in region["sites"]]
-        if len(site_names) != len(set(site_names)):
-            # We have some site names that are not unique
-            # Now find them (slow so no need to do if we don't have duplicates)
-            duplicate_site_names = [site_name for site_name in site_names if site_names.count(site_name) > 1]
-            raise AristaAvdError(
-                "WAN Site names must be unique across all regions. "
-                f"Found the following duplicate site name(s) under 'cv_pathfinder_regions.[].sites. {duplicate_site_names}"
-            )
 
         return get_item(
             regions,

--- a/python-avd/pyavd/_schema/avd_meta_schema.json
+++ b/python-avd/pyavd/_schema/avd_meta_schema.json
@@ -216,7 +216,7 @@
                         },
                         "unique_keys": {
                             "type": "array",
-                            "description": "List of types to auto-convert from.\nFor 'list of dicts' auto-conversion is supported from 'dict' if 'primary_key' is set on the list schema\nFor other list item types conversion from dict will use the keys as list items.",
+                            "description": "List of keys or dot-notation path keys that must be unique in addition to primary_key.",
                             "items": {
                                 "type": "string",
                                 "$comment": "The regex here matches valid key names",


### PR DESCRIPTION
## Change Summary

Leverage `unique_keys` introduced in #3725 as planned

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

CF schema fragment changes

## How to test

Tested locally by triggering conflicting scenario (`unique_keys` work as expected)

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
