### PR TITLE
Fix: Change the required arguments for eos_cli_config_gen action plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can also open an [issue](https://github.com/aristanetworks/avd/issues) to re
 
 ## License
 
+
 Copyright (c) 2019-2024 Arista Networks, Inc.
 
 The project is published under [Apache 2.0 License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ You can also open an [issue](https://github.com/aristanetworks/avd/issues) to re
 
 ## License
 
-
 Copyright (c) 2019-2024 Arista Networks, Inc.
 
 The project is published under [Apache 2.0 License](LICENSE)

--- a/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/eos_cli_config_gen.md
+++ b/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/eos_cli_config_gen.md
@@ -27,10 +27,11 @@ The `arista.avd.eos_cli_config_gen` module is an Ansible Action Plugin providing
 
 | Argument | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-| <samp>structured_config_filename</samp> | str | True | None |  | The path of the structured config to load if read_structured_config_from_file is true. |
-| <samp>config_filename</samp> | str | True | None |  | The path to save the generated config to. |
-| <samp>documentation_filename</samp> | str | True | None |  | The path to save the generated documentation to if generate_device_doc is true. |
+| <samp>structured_config_filename</samp> | str | optional | None |  | The path of the structured config to load. Required if read_structured_config_from_file is true. |
+| <samp>config_filename</samp> | str | optional | None |  | The path to save the generated config to. Required if generate_device_config is true. |
+| <samp>documentation_filename</samp> | str | optional | None |  | The path to save the generated documentation. Required if generate_device_doc is true. |
 | <samp>read_structured_config_from_file</samp> | bool | optional | True |  | Flag to indicate if the structured config should be read from a file or not. |
+| <samp>generate_device_config</samp> | bool | optional | True |  | Flag to generate the device configuration. |
 | <samp>generate_device_doc</samp> | bool | optional | True |  | Flag to generate the device documentation. |
 | <samp>device_doc_toc</samp> | bool | optional | True |  | Flag to generate the table of content for the device documentation. |
 | <samp>conversion_mode</samp> | str | False | debug | Valid values:<br>- <code>error</code><br>- <code>warning</code><br>- <code>info</code><br>- <code>debug</code><br>- <code>quiet</code><br>- <code>disabled</code> | Run data conversion in either &#34;error&#34;, &#34;warning&#34;, &#34;info&#34;, &#34;debug&#34;, &#34;quiet&#34; or &#34;disabled&#34; mode.<br>Conversion will perform type conversion of input variables as defined in the schema.<br>Conversion is intended to help the user to identify minor issues with the input data, while still allowing the data to be validated.<br>During conversion, messages will be generated with information about the host(s) and key(s) which required conversion.<br>conversion_mode:disabled means that conversion will not run.<br>conversion_mode:error will produce error messages and fail the task.<br>conversion_mode:warning will produce warning messages.<br>conversion_mode:info will produce regular log messages.<br>conversion_mode:debug will produce hidden messages viewable with -v.<br>conversion_mode:quiet will not produce any messages. |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/converge.yml
@@ -5,6 +5,7 @@
   connection: local
   vars:
     tacacs_key_set_as_play_var: "071B245F5A"
+    read_structured_config_from_file: False
   tasks:
 
     - name: Generate device intended config and documentation

--- a/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
@@ -13,7 +13,7 @@ import yaml
 from ansible.errors import AnsibleActionFail
 from ansible.plugins.action import ActionBase, display
 
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import PythonToAnsibleContextFilter, PythonToAnsibleHandler, cprofile, get_templar, YamlLoard
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import PythonToAnsibleContextFilter, PythonToAnsibleHandler, YamlLoard, cprofile, get_templar
 
 try:
     from pyavd import get_device_config, get_device_doc, validate_structured_config

--- a/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
@@ -13,7 +13,7 @@ import yaml
 from ansible.errors import AnsibleActionFail
 from ansible.plugins.action import ActionBase, display
 
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import PythonToAnsibleContextFilter, PythonToAnsibleHandler, YamlLoard, cprofile, get_templar
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import PythonToAnsibleContextFilter, PythonToAnsibleHandler, YamlLoader, cprofile, get_templar
 
 try:
     from pyavd import get_device_config, get_device_doc, validate_structured_config

--- a/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
@@ -13,12 +13,7 @@ import yaml
 from ansible.errors import AnsibleActionFail
 from ansible.plugins.action import ActionBase, display
 
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import PythonToAnsibleContextFilter, PythonToAnsibleHandler, cprofile, get_templar
-
-try:
-    from yaml import CLoader as YamlLoader
-except ImportError:
-    from yaml import Loader as YamlLoader
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import PythonToAnsibleContextFilter, PythonToAnsibleHandler, cprofile, get_templar, YamlLoard
 
 try:
     from pyavd import get_device_config, get_device_doc, validate_structured_config

--- a/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
@@ -42,9 +42,9 @@ LOGGER = logging.getLogger("ansible_collections.arista.avd")
 LOGGER.propagate = False
 
 ARGUMENT_SPEC = {
-    "structured_config_filename": {"type": "str", "required": True},
-    "config_filename": {"type": "str", "required": True},
-    "documentation_filename": {"type": "str", "required": True},
+    "structured_config_filename": {"type": "str"},
+    "config_filename": {"type": "str"},
+    "documentation_filename": {"type": "str"},
     "read_structured_config_from_file": {"type": "bool", "default": True},
     "conversion_mode": {"type": "str", "default": "debug"},
     "validation_mode": {"type": "str", "default": "warning"},
@@ -88,7 +88,7 @@ class ActionModule(ActionBase):
             # Read structured config from file or task_vars and run templating to handle inline jinja.
             LOGGER.debug("Preparing task vars...")
             task_vars = self.prepare_task_vars(
-                task_vars, validated_args["structured_config_filename"], read_structured_config_from_file=validated_args["read_structured_config_from_file"]
+                task_vars, validated_args.get("structured_config_filename"), read_structured_config_from_file=validated_args["read_structured_config_from_file"]
             )
             LOGGER.debug("Preparing task vars [done].")
 
@@ -148,7 +148,14 @@ class ActionModule(ActionBase):
 
     def validate_args(self) -> dict:
         """Get task arguments and validate them."""
-        validation_result, validated_args = self.validate_argument_spec(ARGUMENT_SPEC)
+        validation_result, validated_args = self.validate_argument_spec(
+            ARGUMENT_SPEC,
+            required_if=[
+                ("read_structured_config_from_file", True, ("structured_config_filename",)),
+                ("generate_device_config", True, ("config_filename",)),
+                ("generate_device_doc", True, ("documentation_filename",)),
+            ],
+        )
         validated_args = strip_empties_from_dict(validated_args)
 
         # Converting to json and back to remove any AnsibeUnsafe types

--- a/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
@@ -18,7 +18,7 @@ from ansible_collections.arista.avd.plugins.plugin_utils.utils import PythonToAn
 try:
     from yaml import CLoader as YamlLoader
 except ImportError:
-    from yaml import YamlLoader
+    from yaml import Loader as YamlLoader
 
 try:
     from pyavd import get_device_config, get_device_doc, validate_structured_config

--- a/ansible_collections/arista/avd/plugins/modules/eos_cli_config_gen.py
+++ b/ansible_collections/arista/avd/plugins/modules/eos_cli_config_gen.py
@@ -16,19 +16,20 @@ description: |-
   - Optionallu generates device documentation and saves it to file
 options:
   structured_config_filename:
-    description: The path of the structured config to load if read_structured_config_from_file is true.
+    description: The path of the structured config to load. Required if read_structured_config_from_file is true.
     type: str
-    required: true
   config_filename:
-    description: The path to save the generated config to.
+    description: The path to save the generated config to. Required if generate_device_config is true.
     type: str
-    required: true
   documentation_filename:
-    description: The path to save the generated documentation to if generate_device_doc is true.
+    description: The path to save the generated documentation. Required if generate_device_doc is true.
     type: str
-    required: true
   read_structured_config_from_file:
     description: Flag to indicate if the structured config should be read from a file or not.
+    type: bool
+    default: true
+  generate_device_config:
+    description: Flag to generate the device configuration.
     type: bool
     default: true
   generate_device_doc:


### PR DESCRIPTION
## Change Summary

For people using the arista.avd.eos_cli_config_gen action plugin directly some 

## Component(s) name

`plugins`
`arista.avd.eos_cli_config_gen`

## Proposed changes

Leverage `required_if` for config, structured_config and documentation filenames
## How to test

Tested locally using argspec

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
