### PR TITLE
Refactor: Deprecate Python3.9 support

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -35,6 +35,9 @@ To keep the broken route-map, `structured_config` can be used.
 
 ### Deprecations
 
+- AVD version 5.0.0 will drop support for Python version 3.9. The decision has been taken to remove Python version 3.9 support in AVD collection to anticipate its removal in `ansible-core`.
+  `ansible-core` version 2.15 End-Of-Life is scheduled for November 2024 and it will be the last `ansible-core` version supporting Python version 3.9 as documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix.
+
 - The following Ansible plugins are no longer being used by AVD and have been deprecated for removal in AVD 5.0.0. See the plugin docs for possible replacements.
 
   Filters:

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -58,9 +58,9 @@ def _validate_python_version(info: dict, result: dict) -> bool:
         result.setdefault("deprecations", []).append(
             {
                 "msg": (
-                    f"You are currently running Python {running_version}. AVD 5.0.0 will drop support for Python {min_version}. "
-                    "The decision has been taken to remove Python 3.9 support in AVD collection to anticipate its removal in ansible-core."
-                    "Ansible 2.15 End Of Life is scheduled for November 2024 and it will be the last version supporting Python 3.9 as "
+                    f"You are currently running Python version {running_version}. AVD version 5.0.0 will drop support for Python version {min_version}. "
+                    "The decision has been taken to remove Python version 3.9 support in AVD collection to anticipate its removal in `ansible-core`. "
+                    "`ansible-core` version 2.15 End-Of-Life is scheduled for November 2024 and it will be the last `ansible-core` version supporting Python version 3.9 as "
                     "documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix."
                 )
             }

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -58,10 +58,13 @@ def _validate_python_version(info: dict, result: dict) -> bool:
         result.setdefault("deprecations", []).append(
             {
                 "msg": (
-                    f"You are currently running Python version {running_version}. AVD version 5.0.0 will drop support for Python version {min_version}. "
-                    "The decision has been taken to remove Python version 3.9 support in AVD collection to anticipate its removal in `ansible-core`. "
-                    "`ansible-core` version 2.15 End-Of-Life is scheduled for November 2024 and it will be the last `ansible-core` version supporting Python version 3.9 as "
-                    "documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix."
+                    f"You are currently running Python version {running_version}. "
+                    "AVD version 5.0.0 will drop support for Python version {min_version}. "
+                    "The decision has been taken to remove Python version 3.9 support in AVD "
+                    "collection to anticipate its removal in `ansible-core`. `ansible-core` "
+                    "version 2.15 End-Of-Life is scheduled for November 2024 and it will be the "
+                    "last `ansible-core` version supporting Python version 3.9 as documented here: "
+                    "https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix."
                 )
             }
         )

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -54,16 +54,17 @@ def _validate_python_version(info: dict, result: dict) -> bool:
         display.error(f"Python Version running {running_version} - Minimum Version required is {min_version}", False)
         return False
     # Keeping this for next deprecation adjust the message as required
-    # elif sys.version_info[:2] == MIN_PYTHON_SUPPORTED_VERSION:
-    #     result.setdefault("deprecations", []).append(
-    #         {
-    #             "msg": (
-    #                 f"You are currently running Python {running_version}. The next minor release of AVD after November 6th 2023 will drop support for Python"
-    #                 f" {min_version} as it will be dropping support for ansible-core<2.14 and ansible-core>=2.14 does not support Python {min_version} as"
-    #                 " documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix"
-    #             )
-    #         }
-    #     )
+    elif sys.version_info[:2] == MIN_PYTHON_SUPPORTED_VERSION:
+        result.setdefault("deprecations", []).append(
+            {
+                "msg": (
+                    f"You are currently running Python {running_version}. AVD 5.0.0 will drop support for Python {min_version}. "
+                    "The decision has been taken to remove Python 3.9 support in AVD collection to anticipate its removal in ansible-core."
+                    "Ansible 2.15 End Of Life is scheduled for November 2024 and it will be the last version supporting Python 3.9 as "
+                    "documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix."
+                )
+            }
+        )
 
     return True
 


### PR DESCRIPTION
## Change Summary

Prepare removal of 3.9 support in 5.0.0


## Component(s) name

`requirements`
`plugins`

## Proposed changes

Add warning when running verify requirements

## How to test

Run with python 3.9 and watch

![Screenshot 2024-07-03 at 15 32 46](https://github.com/aristanetworks/avd/assets/3007422/303c661f-a4d0-412a-89bb-1030cdd2d2d8)

## Checklist

### User Checklist

- [x] Add to release notes in deprecation

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
