### PR TITLE
Fix(plugins): Fix deprecation warning after reformatting

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -59,7 +59,7 @@ def _validate_python_version(info: dict, result: dict) -> bool:
             {
                 "msg": (
                     f"You are currently running Python version {running_version}. "
-                    "AVD version 5.0.0 will drop support for Python version {min_version}. "
+                    f"AVD version 5.0.0 will drop support for Python version {min_version}. "
                     "The decision has been taken to remove Python version 3.9 support in AVD "
                     "collection to anticipate its removal in `ansible-core`. `ansible-core` "
                     "version 2.15 End-Of-Life is scheduled for November 2024 and it will be the "


### PR DESCRIPTION
## Change Summary

f string is missing ..

## Related Issue(s)

Fixes issue reported from the field

## Component(s) name

`plugins`

## Proposed changes

Making fstring great again

## How to test

run with python 3.9 and see the correct message

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
