### PR TITLE
Doc: Mkdocs cleanup v5.6

### DIFF
--- a/docs/pyavd/pyavd.md
+++ b/docs/pyavd/pyavd.md
@@ -80,88 +80,75 @@ pip install pyavd[ansible]
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.get_avd_facts
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.get_device_structured_config
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.validate_structured_config
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.get_fabric_documentation
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.get_device_config
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.get_device_doc
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.get_device_test_catalog
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.validation_result
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.api.fabric_documentation
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.api.interface_descriptions
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.api.ip_addressing
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd
 
 ::: pyavd.api.pool_manager
     options:
       heading_level: 3
       show_root_toc_entry: false
       show_object_full_path: true
-      paths: ../../../../python-avd

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -35,379 +35,384 @@ title: Release Notes for AVD 5.x.x
 
 - The role `arista.avd.dhcp_provisioner` will be removed in AVD version 6.0.0.
 
+#### Direct usage of `eos_cli_config_gen` keys when running `eos_designs`
+
+- Starting AVD 5.6.0, `eos_designs` role outputs deprecation warnings when detecting `eos_cli_config_gen` keys in the inputs.
+- A detailed explanation can be found in this [document](../warn-eos-cli-config-keys-usage-in-eos-designs.md).
+
 ## Release 5.5.1
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Fix documentation generation when using vrf default for SSH (#5592) by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5593
+- Fix(eos_cli_config_gen): Fix documentation generation when using vrf default for SSH (#5592) by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5593>
 
 ## Release 5.5.0
 
 ### Breaking Changes
 
-- Fix(eos_designs)!: l3_edge with rfc5549 underlay and 'ebgp: true' should not have next-hop address-family ipv6 by @nathanmusser in https://github.com/aristanetworks/avd/pull/4491
-- Fix(eos_designs)!: Add missing underlay OSPF authentication on MLAG peer-link by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5431
-- Fix(eos_cli_config_gen)!: Fixing j2 templates for router_bgp/bgp_additional_paths and mac-address-table-static-entries by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5518
+- Fix(eos_designs)!: l3_edge with rfc5549 underlay and 'ebgp: true' should not have next-hop address-family ipv6 by @nathanmusser in <https://github.com/aristanetworks/avd/pull/4491>
+- Fix(eos_designs)!: Add missing underlay OSPF authentication on MLAG peer-link by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5431>
+- Fix(eos_cli_config_gen)!: Fixing j2 templates for router_bgp/bgp_additional_paths and mac-address-table-static-entries by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5518>
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Change interface srlg data model to allow more than one srlg by @emilarista in https://github.com/aristanetworks/avd/pull/5497
+- Fix(eos_cli_config_gen): Change interface srlg data model to allow more than one srlg by @emilarista in <https://github.com/aristanetworks/avd/pull/5497>
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs): Snmp-settings enable only specific traps by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5371
+- Fix(eos_designs): Snmp-settings enable only specific traps by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5371>
 
 ### Other Fixed issues
 
-- Fix(anta_runner): Remove VerifyBFDPeersHealth by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5400
-- Fix(anta_runner): Add ZTP cause to VerifyReloadCause by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5408
-- Fix(anta_runner): Remove input_dict from TestSpec by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5424
-- Fix(anta_runner): Update Ansible task failed criteria and various logging issues by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5341
-- Fix(anta_runner): AVD-catalog filters now default to all devices targeted by the run by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5411
-- Fix(anta_runner): Skip IP unnumbered interfaces in P2P reachability test by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5406
-- Fix(dhcp_provisioner): Add ztp_bootstrap_file option when used with cv_settings by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5560
+- Fix(anta_runner): Remove VerifyBFDPeersHealth by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5400>
+- Fix(anta_runner): Add ZTP cause to VerifyReloadCause by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5408>
+- Fix(anta_runner): Remove input_dict from TestSpec by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5424>
+- Fix(anta_runner): Update Ansible task failed criteria and various logging issues by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5341>
+- Fix(anta_runner): AVD-catalog filters now default to all devices targeted by the run by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5411>
+- Fix(anta_runner): Skip IP unnumbered interfaces in P2P reachability test by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5406>
+- Fix(dhcp_provisioner): Add ztp_bootstrap_file option when used with cv_settings by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5560>
 
 ### Documentation
 
-- Doc(eos_designs): Add `vrf_id` in l2ls-fabric example by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5370
-- Doc: Update porting guide for routed ports by @gmuloc in https://github.com/aristanetworks/avd/pull/5488
-- Doc: Align examples with common username for device connectivity by @joelbreton2 in https://github.com/aristanetworks/avd/pull/5404
-- Doc: Updated eos_cli_config_gen contribution guide to use host1 as centric testing by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5483
-- Doc: Fix quotes for new_key in yaml schema docs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5529
-- Doc: Update doc for ISIS encryption by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5553
-- Doc(eos_designs): Describe `use_default_mgmt_method_vrf` under logging and dns settings by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5563
-- Doc(eos_designs): Fix typo in SNMP settings documentation for source_interface by @gmuloc in https://github.com/aristanetworks/avd/pull/5577
+- Doc(eos_designs): Add `vrf_id` in l2ls-fabric example by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5370>
+- Doc: Update porting guide for routed ports by @gmuloc in <https://github.com/aristanetworks/avd/pull/5488>
+- Doc: Align examples with common username for device connectivity by @joelbreton2 in <https://github.com/aristanetworks/avd/pull/5404>
+- Doc: Updated eos_cli_config_gen contribution guide to use host1 as centric testing by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5483>
+- Doc: Fix quotes for new_key in yaml schema docs by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5529>
+- Doc: Update doc for ISIS encryption by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5553>
+- Doc(eos_designs): Describe `use_default_mgmt_method_vrf` under logging and dns settings by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5563>
+- Doc(eos_designs): Fix typo in SNMP settings documentation for source_interface by @gmuloc in <https://github.com/aristanetworks/avd/pull/5577>
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen): Added Support for Spanning Tree Port ID Allocation by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5286
-- Feat(eos_cli_config_gen): Added support for ip virtual router mac-address mlag-peer by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5405
-- Feat(eos_cli_config_gen): Add support for pim ipv4 neighbor filter by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5433
-- Feat(eos_cli_config_gen): Add support for software forwarding hardware offload MTU  under router general by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5439
-- Feat(eos_cli_config_gen): Add support for transceiver dom-thresholds by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5390
-- Feat(eos_cli_config_gen): Add support to generate 'tunnel source <ip_address>' under Tunnel Interfaces by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5453
-- Feat(eos_cli_config_gen): Add cli_config_gen support for E-Tree options by @colinmacgiolla in https://github.com/aristanetworks/avd/pull/5452
-- Feat(eos_cli_config_gen): Add Diffie-Hellman Group 19 as a valid value for ip security configuration by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5463
-- Feat(eos_cli_config_gen): Added support for DLB on ECMP groups by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5450
-- Feat(eos_cli_config_gen): Add support for static mac-address configuration by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5409
-- Feat(eos_cli_config_gen): add support for signature-verification extension by @KrasenKolev in https://github.com/aristanetworks/avd/pull/5465
-- Feat(eos_cli_config_gen): Add support for queue-monitor length mirror by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5451
-- Feat(eos_cli_config_gen): Add support for VRRP peer_authentication under ethernet_interfaces by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5460
-- Feat(eos_cli_config_gen): Adding support for platform trident mmu headroom-pool limit by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5459
-- Feat(eos_cli_config_gen): Added Support for Management Active interface HA in modular devices by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5486
-- Feat(eos_cli_config_gen): Add support for platform fap buffering command by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5468
-- Feat(eos_cli_config_gen): Added support for Mirror on drop export to sflow collector by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5466
-- Feat(eos_cli_config_gen): SVI support for IGMP Querier Virtual Address by @ctyrider in https://github.com/aristanetworks/avd/pull/5523
-- Feat(eos_cli_config_gen): Adding support for ingress for platform MMU profiles  by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5479
-- Feat(eos_cli_config_gen): Adding support for port-channel load-balance trident headers by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5493
-- Feat(eos_cli_config_gen): Support enabling PMTUD for hosts by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5462
-- Feat(eos_cli_config_gen): Move access-group keys for management_ssh model by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5554
-- Feat(eos_cli_config_gen): Added support for Sand UDP payload hashing load-balance policies by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5515
+- Feat(eos_cli_config_gen): Added Support for Spanning Tree Port ID Allocation by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5286>
+- Feat(eos_cli_config_gen): Added support for ip virtual router mac-address mlag-peer by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5405>
+- Feat(eos_cli_config_gen): Add support for pim ipv4 neighbor filter by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5433>
+- Feat(eos_cli_config_gen): Add support for software forwarding hardware offload MTU  under router general by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5439>
+- Feat(eos_cli_config_gen): Add support for transceiver dom-thresholds by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5390>
+- Feat(eos_cli_config_gen): Add support to generate 'tunnel source <ip_address>' under Tunnel Interfaces by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5453>
+- Feat(eos_cli_config_gen): Add cli_config_gen support for E-Tree options by @colinmacgiolla in <https://github.com/aristanetworks/avd/pull/5452>
+- Feat(eos_cli_config_gen): Add Diffie-Hellman Group 19 as a valid value for ip security configuration by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5463>
+- Feat(eos_cli_config_gen): Added support for DLB on ECMP groups by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5450>
+- Feat(eos_cli_config_gen): Add support for static mac-address configuration by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5409>
+- Feat(eos_cli_config_gen): add support for signature-verification extension by @KrasenKolev in <https://github.com/aristanetworks/avd/pull/5465>
+- Feat(eos_cli_config_gen): Add support for queue-monitor length mirror by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5451>
+- Feat(eos_cli_config_gen): Add support for VRRP peer_authentication under ethernet_interfaces by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5460>
+- Feat(eos_cli_config_gen): Adding support for platform trident mmu headroom-pool limit by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5459>
+- Feat(eos_cli_config_gen): Added Support for Management Active interface HA in modular devices by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5486>
+- Feat(eos_cli_config_gen): Add support for platform fap buffering command by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5468>
+- Feat(eos_cli_config_gen): Added support for Mirror on drop export to sflow collector by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5466>
+- Feat(eos_cli_config_gen): SVI support for IGMP Querier Virtual Address by @ctyrider in <https://github.com/aristanetworks/avd/pull/5523>
+- Feat(eos_cli_config_gen): Adding support for ingress for platform MMU profiles  by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5479>
+- Feat(eos_cli_config_gen): Adding support for port-channel load-balance trident headers by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5493>
+- Feat(eos_cli_config_gen): Support enabling PMTUD for hosts by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5462>
+- Feat(eos_cli_config_gen): Move access-group keys for management_ssh model by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5554>
+- Feat(eos_cli_config_gen): Added support for Sand UDP payload hashing load-balance policies by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5515>
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs): Changes to eos_designs schema to support path outlier elimination for one or more avt profiles by @ashenoy-arista in https://github.com/aristanetworks/avd/pull/5355
-- Feat(eos_designs): Enable evpn_gateway for pathfinder deployment using next-hop-self by @ayushmittal-arista in https://github.com/aristanetworks/avd/pull/5082
-- Feat(eos_designs): Add structured_config and raw_eos_cli keys to p2p service subinterfaces by @emilarista in https://github.com/aristanetworks/avd/pull/5350
-- Feat(eos_designs): Add static_routes data model under svis in network services by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5240
-- Feat(eos_designs): Add support to set static_routes under l3_interfaces and l3_portchannel_interfaces in network_services by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5402
-- Feat(eos_designs): Added bfd timer support for a peer inside vrfs by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5423
-- Feat(eos_designs): Move generate_cv_tags out of preview by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5421
-- Feat(eos_designs): Added support of Spanning Tree Port ID Allocation by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5444
-- Feat(eos_designs): Adding custom_connected_endpoints_keys by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5255
-- Feat(eos_designs): Add `endpoint_port_channel` access for j2 descriptions for connected_endpoints_port_channel_interfaces by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5489
-- Feat(eos_designs): Add dns_settings to replace name_servers by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3283
-- Feat(eos_designs): Added support for logging_settings by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5498
-- Feat(eos_designs): Add a platform setting to allow/disallow mtu on sub-interfaces by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5456
-- Feat(eos_designs): VRF assignment improvements for snmp_settings by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5531
-- Feat(eos_designs): Add support for IPv6 only underlay and overlay by @Xatrekak in https://github.com/aristanetworks/avd/pull/4393
-- Feat(eos_designs): Add pvlan support for l2vlans by @bjmeuer in https://github.com/aristanetworks/avd/pull/5535
-- Feat(eos_designs): Add possibility to pass cleartext IPsec keys for wan_ipsec_profiles by @gmuloc in https://github.com/aristanetworks/avd/pull/5551
-- Feat(eos_designs): Add support for cleartext_password for BGP peer groups and neighbors in eos_designs by @gmuloc in https://github.com/aristanetworks/avd/pull/5541
-- Feat(eos_designs): Add VRF level OSPF authentication knobs for network services by @gmuloc in https://github.com/aristanetworks/avd/pull/5481
-- Feat(eos_designs): Configure SSH settings via eos_designs by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5543
-- Feat(eos_designs): Add cv_settings to replace cvp_* and terminattr_* by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3301
-- Feat(eos_designs): Add more feature support toggles for platform_settings by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/5338
-- Feat(eos_designs): Preview: Digital Twin for ACT by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/5436
-- Feat(eos_designs): Add support for cleartext_key for ntp_settings.authentication_keys by @gmuloc in https://github.com/aristanetworks/avd/pull/5575
+- Feat(eos_designs): Changes to eos_designs schema to support path outlier elimination for one or more avt profiles by @ashenoy-arista in <https://github.com/aristanetworks/avd/pull/5355>
+- Feat(eos_designs): Enable evpn_gateway for pathfinder deployment using next-hop-self by @ayushmittal-arista in <https://github.com/aristanetworks/avd/pull/5082>
+- Feat(eos_designs): Add structured_config and raw_eos_cli keys to p2p service subinterfaces by @emilarista in <https://github.com/aristanetworks/avd/pull/5350>
+- Feat(eos_designs): Add static_routes data model under svis in network services by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5240>
+- Feat(eos_designs): Add support to set static_routes under l3_interfaces and l3_portchannel_interfaces in network_services by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5402>
+- Feat(eos_designs): Added bfd timer support for a peer inside vrfs by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5423>
+- Feat(eos_designs): Move generate_cv_tags out of preview by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5421>
+- Feat(eos_designs): Added support of Spanning Tree Port ID Allocation by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5444>
+- Feat(eos_designs): Adding custom_connected_endpoints_keys by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5255>
+- Feat(eos_designs): Add `endpoint_port_channel` access for j2 descriptions for connected_endpoints_port_channel_interfaces by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5489>
+- Feat(eos_designs): Add dns_settings to replace name_servers by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/3283>
+- Feat(eos_designs): Added support for logging_settings by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5498>
+- Feat(eos_designs): Add a platform setting to allow/disallow mtu on sub-interfaces by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5456>
+- Feat(eos_designs): VRF assignment improvements for snmp_settings by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5531>
+- Feat(eos_designs): Add support for IPv6 only underlay and overlay by @Xatrekak in <https://github.com/aristanetworks/avd/pull/4393>
+- Feat(eos_designs): Add pvlan support for l2vlans by @bjmeuer in <https://github.com/aristanetworks/avd/pull/5535>
+- Feat(eos_designs): Add possibility to pass cleartext IPsec keys for wan_ipsec_profiles by @gmuloc in <https://github.com/aristanetworks/avd/pull/5551>
+- Feat(eos_designs): Add support for cleartext_password for BGP peer groups and neighbors in eos_designs by @gmuloc in <https://github.com/aristanetworks/avd/pull/5541>
+- Feat(eos_designs): Add VRF level OSPF authentication knobs for network services by @gmuloc in <https://github.com/aristanetworks/avd/pull/5481>
+- Feat(eos_designs): Configure SSH settings via eos_designs by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5543>
+- Feat(eos_designs): Add cv_settings to replace cvp_*and terminattr_* by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/3301>
+- Feat(eos_designs): Add more feature support toggles for platform_settings by @alexeygorbunov in <https://github.com/aristanetworks/avd/pull/5338>
+- Feat(eos_designs): Preview: Digital Twin for ACT by @alexeygorbunov in <https://github.com/aristanetworks/avd/pull/5436>
+- Feat(eos_designs): Add support for cleartext_key for ntp_settings.authentication_keys by @gmuloc in <https://github.com/aristanetworks/avd/pull/5575>
 
 ### New features and enhancement in both eos_designs and eos_cli_config_gen
 
-- Feat(eos_cli_config_gen, eos_designs): Flooded Traffic using Multicast Underlay by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5219
+- Feat(eos_cli_config_gen, eos_designs): Flooded Traffic using Multicast Underlay by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5219>
 
 ### Other new features and enhancements
 
-- Feat(anta_runner): Add new hardware tests by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5430
-- Feat(anta_runner): Add ANTA DNS test by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5278
-- Feat(plugins): Add support for encryption and decryption of tacacs keys by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5434
-- Feat(cv_deploy): New decorator class to handle various gRPC errors for CVClient by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/5326
-- Feat(anta_runner): Honor validate_state for port-channel interfaces test by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5504
-- Feat(anta_runner): Added new specific AVT path and router path tests by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5437
-- Feat(cv_deploy): Allow Campus hybrid workflow (AVD and Access Interface Studio) by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/5141
+- Feat(anta_runner): Add new hardware tests by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5430>
+- Feat(anta_runner): Add ANTA DNS test by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5278>
+- Feat(plugins): Add support for encryption and decryption of tacacs keys by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5434>
+- Feat(cv_deploy): New decorator class to handle various gRPC errors for CVClient by @alexeygorbunov in <https://github.com/aristanetworks/avd/pull/5326>
+- Feat(anta_runner): Honor validate_state for port-channel interfaces test by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5504>
+- Feat(anta_runner): Added new specific AVT path and router path tests by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5437>
+- Feat(cv_deploy): Allow Campus hybrid workflow (AVD and Access Interface Studio) by @alexeygorbunov in <https://github.com/aristanetworks/avd/pull/5141>
 
 ### PyAVD Changes
 
-- Bump(pyavd): Add PyYAML to PyAVD dependencies by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5447
-- Refactor(pyavd): Improve typing and add pyright to CI by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5458
-- Refactor(pyavd): Improve Python typing and type checking by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5506
+- Bump(pyavd): Add PyYAML to PyAVD dependencies by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5447>
+- Refactor(pyavd): Improve typing and add pyright to CI by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5458>
+- Refactor(pyavd): Improve Python typing and type checking by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5506>
 
 ### Other Changes
 
-- Refactor(eos_designs): Rename keys `destination_address_prefix` and `gateway` under ipv4/6 `static_routes` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5327
-- Refactor(eos_designs): Improve pytest coverage for shared_utils/node_type_keys.py by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5336
-- Refactor(plugins): Improve generation of schema classes by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5359
-- Refactor(eos_designs): Update error messages and improve pytest coverage for shared_utils/mlag.py by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5299
-- Refactor(eos_designs): Improve pytest coverage for network_services/route_maps.py by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5317
-- Bump: ANTA requirements to v1.4.0 by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5399
-- Refactor(eos_designs): Improve /metadata/cv_pathfinder.py and improve pytest coverage by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5310
-- Refactor(eos_designs): Improve coverage for shared_utils/inband_management.py by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5330
-- Refactor(eos_designs): Improve pytest coverage for eos_designs_facts/vlans.py by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5384
-- Refactor(eos_designs): Relax control for MLAG subnets when using same subnet by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5375
-- Feat(eos_cli_config_gen): Adding support for vxlan qos dscp ecn rewrite bridged enabled by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5432
-- Refactor(eos_designs): Improve pytest coverage for network_services/vxlan_interfaces.py by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5397
-- Refactor(eos_cli_config_gen, eos_designs): Renamed `ipv4/ipv6_segment_size key` to `ipv4/ipv6` under tcp_mss_ceiling by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5457
-- Refactor(eos_designs): Improved test coverage for shared_utils/wan.py by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5385
-- Refactor(eos_designs): Add pytest coverage for network_services/port_channel_interfaces.py by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5443
-- Refactor(eos_designs): Improve pytest coverage for shared_utils/overlay.py by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5480
-- Refactor(eos_designs): Modify data format for node id pool manager by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5362
-- Refactor(eos_designs): Improve pytest coverage for network_services/vlan_interfaces.py by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5520
-- Refactor(eos_designs): Improve pytest coverage for base/snmp_server.py  by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5534
-- Refactor(eos_designs): Use new eos_cli_config_gen model for SSH ACLs by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5574
+- Refactor(eos_designs): Rename keys `destination_address_prefix` and `gateway` under ipv4/6 `static_routes` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5327>
+- Refactor(eos_designs): Improve pytest coverage for shared_utils/node_type_keys.py by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5336>
+- Refactor(plugins): Improve generation of schema classes by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5359>
+- Refactor(eos_designs): Update error messages and improve pytest coverage for shared_utils/mlag.py by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5299>
+- Refactor(eos_designs): Improve pytest coverage for network_services/route_maps.py by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5317>
+- Bump: ANTA requirements to v1.4.0 by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5399>
+- Refactor(eos_designs): Improve /metadata/cv_pathfinder.py and improve pytest coverage by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5310>
+- Refactor(eos_designs): Improve coverage for shared_utils/inband_management.py by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5330>
+- Refactor(eos_designs): Improve pytest coverage for eos_designs_facts/vlans.py by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5384>
+- Refactor(eos_designs): Relax control for MLAG subnets when using same subnet by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5375>
+- Feat(eos_cli_config_gen): Adding support for vxlan qos dscp ecn rewrite bridged enabled by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5432>
+- Refactor(eos_designs): Improve pytest coverage for network_services/vxlan_interfaces.py by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5397>
+- Refactor(eos_cli_config_gen, eos_designs): Renamed `ipv4/ipv6_segment_size key` to `ipv4/ipv6` under tcp_mss_ceiling by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5457>
+- Refactor(eos_designs): Improved test coverage for shared_utils/wan.py by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5385>
+- Refactor(eos_designs): Add pytest coverage for network_services/port_channel_interfaces.py by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5443>
+- Refactor(eos_designs): Improve pytest coverage for shared_utils/overlay.py by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5480>
+- Refactor(eos_designs): Modify data format for node id pool manager by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5362>
+- Refactor(eos_designs): Improve pytest coverage for network_services/vlan_interfaces.py by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5520>
+- Refactor(eos_designs): Improve pytest coverage for base/snmp_server.py  by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5534>
+- Refactor(eos_designs): Use new eos_cli_config_gen model for SSH ACLs by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5574>
 
 ## Release 5.4.0
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Fix reordering of name-server group between vrf host and root in monitor connectivity by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5134
+- Fix(eos_cli_config_gen): Fix reordering of name-server group between vrf host and root in monitor connectivity by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5134>
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs): Fix descriptions not taking precedence for l3_edge and core_interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/5305
-- Fix(eos_designs): queue monitor length with missing notifying by @ankudinov in https://github.com/aristanetworks/avd/pull/5343
+- Fix(eos_designs): Fix descriptions not taking precedence for l3_edge and core_interfaces by @gmuloc in <https://github.com/aristanetworks/avd/pull/5305>
+- Fix(eos_designs): queue monitor length with missing notifying by @ankudinov in <https://github.com/aristanetworks/avd/pull/5343>
 
 ### Documentation
 
-- Doc: update contribution guide by @emmanuel-ferdman in https://github.com/aristanetworks/avd/pull/5292
-- Doc: underlay ethernet interfaces context update for custom templates by @philippebureau in https://github.com/aristanetworks/avd/pull/5291
-- Doc: Update the contribution guide `authoring_eos_cli_config_gen.md` by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5294
-- Doc: Set platform in CV Pathfinder example by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5228
-- Doc: Update AAP doc page to reflect AAP as not TAC supported by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5342
-- Doc(eos_designs): Add table for fabric numbering by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5353
-- Doc: Arista AVD re-branding by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5361
+- Doc: update contribution guide by @emmanuel-ferdman in <https://github.com/aristanetworks/avd/pull/5292>
+- Doc: underlay ethernet interfaces context update for custom templates by @philippebureau in <https://github.com/aristanetworks/avd/pull/5291>
+- Doc: Update the contribution guide `authoring_eos_cli_config_gen.md` by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5294>
+- Doc: Set platform in CV Pathfinder example by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5228>
+- Doc: Update AAP doc page to reflect AAP as not TAC supported by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5342>
+- Doc(eos_designs): Add table for fabric numbering by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5353>
+- Doc: Arista AVD re-branding by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5361>
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen): Add support for set-nexthop-peer under BGP by @thompsno in https://github.com/aristanetworks/avd/pull/5165
-- Feat(eos_cli_config_gen): Added the support for list of ip domain in ip name server groups by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5282
+- Feat(eos_cli_config_gen): Add support for set-nexthop-peer under BGP by @thompsno in <https://github.com/aristanetworks/avd/pull/5165>
+- Feat(eos_cli_config_gen): Added the support for list of ip domain in ip name server groups by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5282>
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs): Add CloudEOS platform type by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5259
-- Feat(eos_designs): all_active_multihoming_evpn_gateway by @ernestoherrerab in https://github.com/aristanetworks/avd/pull/5056
-- Feat(eos_designs): Allow knob for kernel software forwarding of ecmp routes with or without agent restart. by @ashenoy-arista in https://github.com/aristanetworks/avd/pull/5270
-- Feat(eos_designs): Add core/l3 edge channel id generation options by @emilarista in https://github.com/aristanetworks/avd/pull/5197
+- Feat(eos_designs): Add CloudEOS platform type by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5259>
+- Feat(eos_designs): all_active_multihoming_evpn_gateway by @ernestoherrerab in <https://github.com/aristanetworks/avd/pull/5056>
+- Feat(eos_designs): Allow knob for kernel software forwarding of ecmp routes with or without agent restart. by @ashenoy-arista in <https://github.com/aristanetworks/avd/pull/5270>
+- Feat(eos_designs): Add core/l3 edge channel id generation options by @emilarista in <https://github.com/aristanetworks/avd/pull/5197>
 
 ### Other new features and enhancements
 
-- Feat(anta_runner): Add strict mode to fail the Ansible task if a test failed or errored by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5303
-- Feat(cv_deploy): Handle WorkspaceStreamResponse with ResponseStatus.UNSPECIFIED by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/5333
-- Feat(cv_deploy): Add verification of the duplicated devices by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/4889
+- Feat(anta_runner): Add strict mode to fail the Ansible task if a test failed or errored by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5303>
+- Feat(cv_deploy): Handle WorkspaceStreamResponse with ResponseStatus.UNSPECIFIED by @alexeygorbunov in <https://github.com/aristanetworks/avd/pull/5333>
+- Feat(cv_deploy): Add verification of the duplicated devices by @alexeygorbunov in <https://github.com/aristanetworks/avd/pull/4889>
 
 ### Other Changes
 
-- Refactor: Address ansible-sanity failure from ansible devel by @gmuloc in https://github.com/aristanetworks/avd/pull/5298
-- Refactor(eos_designs): Improve network_services/router_adaptive_virtual_topology.py and improve pytest coverage by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5272
-- Refactor(eos_cli_config_gen, eos_designs): Rename keys `destination_address_prefix` and `gateway` under `static_routes` and `ipv6_static_routes` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5283
-- Refactor(eos_designs): Improve pytest coverage for overlay/ip_security  by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5312
-- Refactor(eos_designs): Improve connected_endpoints/monitor_sessions by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5311
-- Refactor(eos_designs): Improved pytest coverage for metadata/cv_tags.py by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5332
+- Refactor: Address ansible-sanity failure from ansible devel by @gmuloc in <https://github.com/aristanetworks/avd/pull/5298>
+- Refactor(eos_designs): Improve network_services/router_adaptive_virtual_topology.py and improve pytest coverage by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5272>
+- Refactor(eos_cli_config_gen, eos_designs): Rename keys `destination_address_prefix` and `gateway` under `static_routes` and `ipv6_static_routes` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5283>
+- Refactor(eos_designs): Improve pytest coverage for overlay/ip_security  by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5312>
+- Refactor(eos_designs): Improve connected_endpoints/monitor_sessions by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5311>
+- Refactor(eos_designs): Improved pytest coverage for metadata/cv_tags.py by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5332>
 
 ## Release 5.3.0
 
 ### Changes to requirements
 
 - The file `ansible_collections/arista/avd/collections.yml` has been renamed `ansible_collections/arista/avd/requirements.yml` to work well with ansible-lint. A symlink has been kept and will be removed in AVD 6.0.0.
-- `distlib` has been added to the pyavd extras `ansible-collection` to enable installing the collection from source after adding manifest directives to galaxy.yml https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html#manifest-directives
+- `distlib` has been added to the pyavd extras `ansible-collection` to enable installing the collection from source after adding manifest directives to galaxy.yml <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html#manifest-directives>
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Ethernet interface documentation template to change double ** into single * by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5199
+- Fix(eos_cli_config_gen): Ethernet interface documentation template to change double ** into single * by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5199>
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs): ptp_settings.domain by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5007
-- Fix(eos_designs): Avoid returning objects in facts by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5016
-- Fix(eos_designs): Wrong duplicate detection between SVIs and L2VLANs by @gmuloc in https://github.com/aristanetworks/avd/pull/5025
-- Fix(eos_designs): Invalid class returned from snmp_settings.vrfs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5035
-- Fix(eos_designs): Wrong structured config for overlapping network ports by @gmuloc in https://github.com/aristanetworks/avd/pull/5033
-- Fix(eos_designs): Better error message when no ip address configured on a l3_interface on wan_router by @gmuloc in https://github.com/aristanetworks/avd/pull/5068
-- Fix(eos_designs): Raise again on conflicting ethernet interfaces under point-to-point services by @gmuloc in https://github.com/aristanetworks/avd/pull/5058
-- Fix(eos_designs): Do not fail documentation task when missing structured configuration by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5072
-- Fix(eos_designs): Revert changed behavior for management_eapi by @gmuloc in https://github.com/aristanetworks/avd/pull/5112
-- Fix(eos_designs): Fix performance regression in port-profile caching by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5150
-- Fix(eos_designs): Avoid setting cv_tag "lan" for port-channel members by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5230
-- Fix(eos_designs): Bring back connected endpoints short_esi support on EPVN-MPLS LERs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5229
+- Fix(eos_designs): ptp_settings.domain by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5007>
+- Fix(eos_designs): Avoid returning objects in facts by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5016>
+- Fix(eos_designs): Wrong duplicate detection between SVIs and L2VLANs by @gmuloc in <https://github.com/aristanetworks/avd/pull/5025>
+- Fix(eos_designs): Invalid class returned from snmp_settings.vrfs by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5035>
+- Fix(eos_designs): Wrong structured config for overlapping network ports by @gmuloc in <https://github.com/aristanetworks/avd/pull/5033>
+- Fix(eos_designs): Better error message when no ip address configured on a l3_interface on wan_router by @gmuloc in <https://github.com/aristanetworks/avd/pull/5068>
+- Fix(eos_designs): Raise again on conflicting ethernet interfaces under point-to-point services by @gmuloc in <https://github.com/aristanetworks/avd/pull/5058>
+- Fix(eos_designs): Do not fail documentation task when missing structured configuration by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5072>
+- Fix(eos_designs): Revert changed behavior for management_eapi by @gmuloc in <https://github.com/aristanetworks/avd/pull/5112>
+- Fix(eos_designs): Fix performance regression in port-profile caching by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5150>
+- Fix(eos_designs): Avoid setting cv_tag "lan" for port-channel members by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5230>
+- Fix(eos_designs): Bring back connected endpoints short_esi support on EPVN-MPLS LERs by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5229>
 
 ### Fixed issues in both eos_designs and eos_cli_config_gen
 
-- Fix(eos_cli_config_gen, eos_designs): Refactor eos_designs structured_config code for monitor_sessions and fix schema for monitor_sessions in eos_cli_config_gen by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4937
+- Fix(eos_cli_config_gen, eos_designs): Refactor eos_designs structured_config code for monitor_sessions and fix schema for monitor_sessions in eos_cli_config_gen by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4937>
 
 ### Other Fixed issues
 
-- Fix(containers): fix docker/setup-qemu-action@v3 by setting image to tonistiigi/binfmt:qemu-v7.0.0-28 by @ankudinov in https://github.com/aristanetworks/avd/pull/5032
-- Fix(cv_deploy): Abandon Workspaces that failed at Build phase if their requested_state was `abandoned` by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/5030
-- Fix(anta_runner): Improve logging and exception handling by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5213
-- Fix: Properly load Ansible connection vars into ANTA runner by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5195
-- Fix(cv_deploy): Improve handling of invalid metadata studio inputs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5239
+- Fix(containers): fix docker/setup-qemu-action@v3 by setting image to tonistiigi/binfmt:qemu-v7.0.0-28 by @ankudinov in <https://github.com/aristanetworks/avd/pull/5032>
+- Fix(cv_deploy): Abandon Workspaces that failed at Build phase if their requested_state was `abandoned` by @alexeygorbunov in <https://github.com/aristanetworks/avd/pull/5030>
+- Fix(anta_runner): Improve logging and exception handling by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5213>
+- Fix: Properly load Ansible connection vars into ANTA runner by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5195>
+- Fix(cv_deploy): Improve handling of invalid metadata studio inputs by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5239>
 
 ### Documentation
 
-- Doc: Release-notes for release 5.2.1 by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5024
-- Doc: Release-notes for release 5.2.2 by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5043
-- Doc: Release notes 5.2.3 by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5163
-- Doc: Add static route for site1-wan1 to SITE1.yml by @joelbreton2 in https://github.com/aristanetworks/avd/pull/5203
-- Doc(eos_designs): Fix typos in node type table and keys by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5216
-- Doc(eos_designs): Add documentation for `underlay_ospf_graceful_restart` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5221
-- Doc: Update single dc l3ls example  by @joelbreton2 in https://github.com/aristanetworks/avd/pull/4829
-- Doc: Move node type keys mgmt_gateway, ipv6_mgmt_gateway, and flow_tracker_type to the common configuration table by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5242
-- Doc(eos_designs): Add network-services l3_port_channels to input variables by @gmuloc in https://github.com/aristanetworks/avd/pull/5276
-- Doc: Arista AVD A-Care TAC Support Overview by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5136
+- Doc: Release-notes for release 5.2.1 by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5024>
+- Doc: Release-notes for release 5.2.2 by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5043>
+- Doc: Release notes 5.2.3 by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5163>
+- Doc: Add static route for site1-wan1 to SITE1.yml by @joelbreton2 in <https://github.com/aristanetworks/avd/pull/5203>
+- Doc(eos_designs): Fix typos in node type table and keys by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5216>
+- Doc(eos_designs): Add documentation for `underlay_ospf_graceful_restart` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5221>
+- Doc: Update single dc l3ls example  by @joelbreton2 in <https://github.com/aristanetworks/avd/pull/4829>
+- Doc: Move node type keys mgmt_gateway, ipv6_mgmt_gateway, and flow_tracker_type to the common configuration table by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5242>
+- Doc(eos_designs): Add network-services l3_port_channels to input variables by @gmuloc in <https://github.com/aristanetworks/avd/pull/5276>
+- Doc: Arista AVD A-Care TAC Support Overview by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5136>
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen): Add support for Receive Side Scaling (RSS) interface profile by @ashenoy-arista in https://github.com/aristanetworks/avd/pull/4954
-- Feat(eos_cli_config_gen): Add support to set vlan and vni ranges in vxlan interface by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4749
-- Feat(eos_cli_config_gen): Add TWAMP-light data model and router-TE knob by @emilarista in https://github.com/aristanetworks/avd/pull/5020
-- Feat(eos_cli_config_gen): Add Router-TE Flexalgo Support by @emilarista in https://github.com/aristanetworks/avd/pull/5021
-- Feat(eos_cli_config_gen): Add TWAMP sender profile knob under router TE by @emilarista in https://github.com/aristanetworks/avd/pull/5128
-- Feat(eos_cli_config_gen): Support "authorization requests" for GNMI transport GRPC by @bjmeuer in https://github.com/aristanetworks/avd/pull/5139
-- Feat(eos_cli_config_gen): Added support for 802.1x phone ACL bypass by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5149
-- Feat(eos_cli_config_gen): Support microsecond unit for qos_profiles threshold by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5176
-- Feat(eos_cli_config_gen): Add 'replay protection' support in MacSec profiles by @ctyrider in https://github.com/aristanetworks/avd/pull/5180
-- Feat(eos_cli_config_gen): Hardware forwarding id knob for loopbacks by @emilarista in https://github.com/aristanetworks/avd/pull/5167
-- Feat(eos_cli_config_gen): Add support for authentication login command-api by @ccsnw in https://github.com/aristanetworks/avd/pull/5148
-- Feat(eos_cli_config_gen): Support for configuring dhcp server ipv4 and ipv6 for Vlan interfaces by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5168
-- Feat(eos_cli_config_gen): Add support for spanning_tree_bpduguard `rate-limit count` under ethernet_interfaces by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5183
-- Feat(eos_cli_config_gen): Add support for Graceful Restart under VRF in BGP by @ccsnw in https://github.com/aristanetworks/avd/pull/5198
-- Feat(eos_cli_config_gen): Add support for ntp serve all by @davidhayes9 in https://github.com/aristanetworks/avd/pull/5214
-- Feat(eos_cli_config_gen): Added support for ipv6 router OSPFv3 by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5144
-- Feat(eos_cli_config_gen): Add support for dot1x statistics, vlan assignment group and radius av-pair filter_id by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5147
-- Feat(eos_cli_config_gen): Add support for kernel software forwarding ecmp by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5234
-- Feat(eos_cli_config_gen): Add support for agent shutdown option by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5200
-- Feat(eos_cli_config_gen): Add support for command hardware access-list update default-result permit by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5271
+- Feat(eos_cli_config_gen): Add support for Receive Side Scaling (RSS) interface profile by @ashenoy-arista in <https://github.com/aristanetworks/avd/pull/4954>
+- Feat(eos_cli_config_gen): Add support to set vlan and vni ranges in vxlan interface by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4749>
+- Feat(eos_cli_config_gen): Add TWAMP-light data model and router-TE knob by @emilarista in <https://github.com/aristanetworks/avd/pull/5020>
+- Feat(eos_cli_config_gen): Add Router-TE Flexalgo Support by @emilarista in <https://github.com/aristanetworks/avd/pull/5021>
+- Feat(eos_cli_config_gen): Add TWAMP sender profile knob under router TE by @emilarista in <https://github.com/aristanetworks/avd/pull/5128>
+- Feat(eos_cli_config_gen): Support "authorization requests" for GNMI transport GRPC by @bjmeuer in <https://github.com/aristanetworks/avd/pull/5139>
+- Feat(eos_cli_config_gen): Added support for 802.1x phone ACL bypass by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5149>
+- Feat(eos_cli_config_gen): Support microsecond unit for qos_profiles threshold by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5176>
+- Feat(eos_cli_config_gen): Add 'replay protection' support in MacSec profiles by @ctyrider in <https://github.com/aristanetworks/avd/pull/5180>
+- Feat(eos_cli_config_gen): Hardware forwarding id knob for loopbacks by @emilarista in <https://github.com/aristanetworks/avd/pull/5167>
+- Feat(eos_cli_config_gen): Add support for authentication login command-api by @ccsnw in <https://github.com/aristanetworks/avd/pull/5148>
+- Feat(eos_cli_config_gen): Support for configuring dhcp server ipv4 and ipv6 for Vlan interfaces by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5168>
+- Feat(eos_cli_config_gen): Add support for spanning_tree_bpduguard `rate-limit count` under ethernet_interfaces by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5183>
+- Feat(eos_cli_config_gen): Add support for Graceful Restart under VRF in BGP by @ccsnw in <https://github.com/aristanetworks/avd/pull/5198>
+- Feat(eos_cli_config_gen): Add support for ntp serve all by @davidhayes9 in <https://github.com/aristanetworks/avd/pull/5214>
+- Feat(eos_cli_config_gen): Added support for ipv6 router OSPFv3 by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5144>
+- Feat(eos_cli_config_gen): Add support for dot1x statistics, vlan assignment group and radius av-pair filter_id by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5147>
+- Feat(eos_cli_config_gen): Add support for kernel software forwarding ecmp by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5234>
+- Feat(eos_cli_config_gen): Add support for agent shutdown option by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5200>
+- Feat(eos_cli_config_gen): Add support for command hardware access-list update default-result permit by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5271>
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs): Accept auto as argument for rd_override by @rrajpuro-anet in https://github.com/aristanetworks/avd/pull/4858
-- Feat(eos_designs): Add support for using VRF router-id as RD admin subfield by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5061
-- Feat(eos_designs): Automatic assignment of Node IDs using pool manager by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3162
-- Feat(eos_designs): Add metric bandwidth support for l3_interfaces by @ayushmittal-arista in https://github.com/aristanetworks/avd/pull/5017
-- Feat(eos_designs): Add l3_port_channel support in network services by @bjmeuer in https://github.com/aristanetworks/avd/pull/5019
-- Feat(eos_designs): Add support for RSS interface profile for select platforms by @ashenoy-arista in https://github.com/aristanetworks/avd/pull/5009
-- Feat(eos_designs): Enable graceful-restart for underlay OSPF by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5191
-- Feat(eos_designs): Support MST PVST border under node_config by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5218
-- Feat(eos_designs): Add support to bind IPsec connection to source int… by @ashenoy-arista in https://github.com/aristanetworks/avd/pull/5190
-- Feat(eos_designs): Add support to disable management api http-commands in eos_designs by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5243
-- Feat(eos_designs): Hardware forwarding knob for diagnostic loopbacks by @emilarista in https://github.com/aristanetworks/avd/pull/5237
-- Feat(eos_designs): Add support for `structured_config` inside `<network_services_keys.name>[].vrfs[].ospf` by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5241
-- Feat(eos_designs): Added the support of notification_host_flap in mac address table by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5266
-- Feat(eos_designs): Add raw_eos_cli and structured_config to endpoint port-channel subinterfaces by @emilarista in https://github.com/aristanetworks/avd/pull/5244
+- Feat(eos_designs): Accept auto as argument for rd_override by @rrajpuro-anet in <https://github.com/aristanetworks/avd/pull/4858>
+- Feat(eos_designs): Add support for using VRF router-id as RD admin subfield by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5061>
+- Feat(eos_designs): Automatic assignment of Node IDs using pool manager by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/3162>
+- Feat(eos_designs): Add metric bandwidth support for l3_interfaces by @ayushmittal-arista in <https://github.com/aristanetworks/avd/pull/5017>
+- Feat(eos_designs): Add l3_port_channel support in network services by @bjmeuer in <https://github.com/aristanetworks/avd/pull/5019>
+- Feat(eos_designs): Add support for RSS interface profile for select platforms by @ashenoy-arista in <https://github.com/aristanetworks/avd/pull/5009>
+- Feat(eos_designs): Enable graceful-restart for underlay OSPF by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5191>
+- Feat(eos_designs): Support MST PVST border under node_config by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5218>
+- Feat(eos_designs): Add support to bind IPsec connection to source int… by @ashenoy-arista in <https://github.com/aristanetworks/avd/pull/5190>
+- Feat(eos_designs): Add support to disable management api http-commands in eos_designs by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5243>
+- Feat(eos_designs): Hardware forwarding knob for diagnostic loopbacks by @emilarista in <https://github.com/aristanetworks/avd/pull/5237>
+- Feat(eos_designs): Add support for `structured_config` inside `<network_services_keys.name>[].vrfs[].ospf` by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5241>
+- Feat(eos_designs): Added the support of notification_host_flap in mac address table by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5266>
+- Feat(eos_designs): Add raw_eos_cli and structured_config to endpoint port-channel subinterfaces by @emilarista in <https://github.com/aristanetworks/avd/pull/5244>
 
 ### Other new features and enhancements
 
-- Feat(containers): add labels to AVD container images and fork test workflows by @ankudinov in https://github.com/aristanetworks/avd/pull/5081
-- Feat: New anta_workflow plugin using PyAVD by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/4196
-- Feat(anta_runner): Add ANTA interfaces related tests by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5172
-- Feat(anta_runner): Add ANTA MLAG related tests by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5184
-- Feat(anta_runner): Add ANTA BGP neighbors reachability tests by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5188
-- Feat(anta_runner): Add ANTA system tests by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5238
-- Feat(anta_runner): Add various ANTA tests, including BFD, WAN by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/5222
+- Feat(containers): add labels to AVD container images and fork test workflows by @ankudinov in <https://github.com/aristanetworks/avd/pull/5081>
+- Feat: New anta_workflow plugin using PyAVD by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/4196>
+- Feat(anta_runner): Add ANTA interfaces related tests by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5172>
+- Feat(anta_runner): Add ANTA MLAG related tests by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5184>
+- Feat(anta_runner): Add ANTA BGP neighbors reachability tests by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5188>
+- Feat(anta_runner): Add ANTA system tests by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5238>
+- Feat(anta_runner): Add various ANTA tests, including BFD, WAN by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/5222>
 
 ### PyAVD Changes
 
-- Bump(pyavd): Add distlib to pyavd ansible-collection extra to support manifest directives by @gmuloc in https://github.com/aristanetworks/avd/pull/5108
+- Bump(pyavd): Add distlib to pyavd ansible-collection extra to support manifest directives by @gmuloc in <https://github.com/aristanetworks/avd/pull/5108>
 
 ### Other Changes
 
-- Refactor(eos_designs): Refactor eos_designs structured_config code for overlay/router_traffic_engineering by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4992
-- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_virtual_router_mac_address by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4991
-- Refactor(eos_designs): Refactor eos_designs structured_config code for underlay/router_msdp by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4967
-- Bump(requirements): Bump the prod group across 2 directories with 1 update by @dependabot in https://github.com/aristanetworks/avd/pull/5008
-- Refactor(eos_designs): structured_config for overlay route_maps by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4994
-- Refactor(eos_designs): structured_config for ipv6_static_routes by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4986
-- Refactor(eos_designs): structured_config for network_services router_ospf by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4981
-- Refactor(eos_designs): Network Services ethernet interfaces refactoring to classes by @gmuloc in https://github.com/aristanetworks/avd/pull/4976
-- Refactor(eos_designs): Refactor eos_designs structured_config code for static_routes by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4943
-- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_extcommunity_lists by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5045
-- Refactor(eos_designs): Refactor eos_designs structured_config code for management_security by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5038
-- Refactor(eos_designs): structured_config for underlay route_maps by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5047
-- Refactor(eos_designs): structured_config for loopback by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5018
-- Refactor(eos_designs): Remove dependency on overlay_routing_protocol and evpn_role for WAN routers by @gmuloc in https://github.com/aristanetworks/avd/pull/4865
-- Refactor(eos_designs): Structured config classes for underlay ethernet_interfaces by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5054
-- Refactor(eos_designs): Network Services port-channel refactoring to classes by @gmuloc in https://github.com/aristanetworks/avd/pull/4995
-- Refactor(eos_designs): Structured config classes for underlay port-channels by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5055
-- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_security(overlay) by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5046
-- Refactor(eos_cli_config_gen): Enhance aaa to support multiple groups where available in EOS by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4666
-- Refactor(eos_designs): Refactor eos_designs structured_config code for router_isis by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5090
-- Refactor(eos_designs): Refactor eos_designs structured_config code for router_ospf(underlay) by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5097
-- Refactor(eos_designs): Fix type issues and other small improvements by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5099
-- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_igmp_snooping.py by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5012
-- Refactor(eos_designs): Refactor eos_designs structured_config code for metadata by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4993
-- Refactor(eos_designs): structured_config for underlay/mlag/inband_management Vlans  by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5051
-- Refactor(eos_designs): Refactor eos_designs structured_config code for stun(underlay) by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5103
-- Refactor(eos_designs): structured_config for underlay router_pim_sparse_mode by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5114
-- Refactor(eos_designs): Refactor eos_designs structured_config code for router_internet_exit by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5105
-- Refactor(eos_designs): Refactor eos_designs structured_config code ip_access_list by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4972
-- Refactor(eos_designs): Refactor structured_config code for cvx.py(overlay) by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5102
-- Refactor(eos_designs): Refactor structure_config code for management-cvx by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5121
-- Refactor: Stop check for extra requirements when running from source by @gmuloc in https://github.com/aristanetworks/avd/pull/5095
-- Refactor(eos_designs): Refactor eos_designs structured_config code for spanning_tree by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5119
-- Refactor(eos_designs): structured_config for prefix_lists by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5109
-- Refactor(eos_designs): structured_config for network_services route_maps by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5037
-- Refactor(eos_designs): Refactor eos_designs structured_config code for models eos_cli by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5138
-- Refactor(eos_designs): structured_config for inband_management **init** by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5135
-- Refactor(eos_designs): Refactor structured_config code for dhcp_servers.py by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5084
-- Refactor(eos_designs): Refactor eos_designs structured_config code for mlag init by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5131
-- Refactor(eos_designs): Refactor eos_designs structured_config code for flows init by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5123
-- Refactor(eos_designs): Refactor eos_designs structured_config code for router_path_selection by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5002
-- Refactor(eos_designs): Refactor eos_designs structured_config code for router_adaptive_virtual_topology by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5106
-- Refactor(eos_designs): Refactor eos_designs structured_config code for network_services struct_cfgs by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5175
-- Refactor(eos_designs): Refactor structured_config code for application_traffic_recognition by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5111
-- Refactor(eos_designs): Refactor eos_designs structured_config code for core_interfaces_and_l3_edge ethernet/port-channel interfaces, router-bgp and utils by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5087
-- Refactor(eos_designs): Refactor eos_designs structured_config code for router_bgp(overlay) by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/5117
-- Refactor(eos_designs): Refactor code for underlay/overlay/connected_endpoints/network_services utils by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/5182
-- Refactor(eos_designs): Refactor eos_designs structured_config code for models in base/init.py and utils.py by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/5127
-- Refactor(eos_designs): Use schema classes for facts by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5185
-- Refactor: Remove shared_utils unused code post refactoring by @gmuloc in https://github.com/aristanetworks/avd/pull/5245
-- Refactor(eos_designs): Refactor network_services wan_utils and zscaler_utils by @gmuloc in https://github.com/aristanetworks/avd/pull/5211
-- Refactor(eos_designs): Better handling of index error p2p_links nodes and other fields in core_interface by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/5215
-- Refactor(eos_designs): Clean legacy render method for structured config by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5262
+- Refactor(eos_designs): Refactor eos_designs structured_config code for overlay/router_traffic_engineering by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4992>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_virtual_router_mac_address by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4991>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for underlay/router_msdp by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4967>
+- Bump(requirements): Bump the prod group across 2 directories with 1 update by @dependabot in <https://github.com/aristanetworks/avd/pull/5008>
+- Refactor(eos_designs): structured_config for overlay route_maps by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4994>
+- Refactor(eos_designs): structured_config for ipv6_static_routes by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4986>
+- Refactor(eos_designs): structured_config for network_services router_ospf by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4981>
+- Refactor(eos_designs): Network Services ethernet interfaces refactoring to classes by @gmuloc in <https://github.com/aristanetworks/avd/pull/4976>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for static_routes by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4943>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_extcommunity_lists by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5045>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for management_security by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5038>
+- Refactor(eos_designs): structured_config for underlay route_maps by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5047>
+- Refactor(eos_designs): structured_config for loopback by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5018>
+- Refactor(eos_designs): Remove dependency on overlay_routing_protocol and evpn_role for WAN routers by @gmuloc in <https://github.com/aristanetworks/avd/pull/4865>
+- Refactor(eos_designs): Structured config classes for underlay ethernet_interfaces by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5054>
+- Refactor(eos_designs): Network Services port-channel refactoring to classes by @gmuloc in <https://github.com/aristanetworks/avd/pull/4995>
+- Refactor(eos_designs): Structured config classes for underlay port-channels by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5055>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_security(overlay) by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5046>
+- Refactor(eos_cli_config_gen): Enhance aaa to support multiple groups where available in EOS by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4666>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for router_isis by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5090>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for router_ospf(underlay) by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5097>
+- Refactor(eos_designs): Fix type issues and other small improvements by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5099>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_igmp_snooping.py by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5012>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for metadata by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4993>
+- Refactor(eos_designs): structured_config for underlay/mlag/inband_management Vlans  by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5051>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for stun(underlay) by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5103>
+- Refactor(eos_designs): structured_config for underlay router_pim_sparse_mode by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5114>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for router_internet_exit by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5105>
+- Refactor(eos_designs): Refactor eos_designs structured_config code ip_access_list by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4972>
+- Refactor(eos_designs): Refactor structured_config code for cvx.py(overlay) by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5102>
+- Refactor(eos_designs): Refactor structure_config code for management-cvx by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5121>
+- Refactor: Stop check for extra requirements when running from source by @gmuloc in <https://github.com/aristanetworks/avd/pull/5095>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for spanning_tree by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5119>
+- Refactor(eos_designs): structured_config for prefix_lists by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5109>
+- Refactor(eos_designs): structured_config for network_services route_maps by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5037>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for models eos_cli by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5138>
+- Refactor(eos_designs): structured_config for inband_management **init** by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5135>
+- Refactor(eos_designs): Refactor structured_config code for dhcp_servers.py by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5084>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for mlag init by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5131>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for flows init by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5123>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for router_path_selection by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5002>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for router_adaptive_virtual_topology by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5106>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for network_services struct_cfgs by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5175>
+- Refactor(eos_designs): Refactor structured_config code for application_traffic_recognition by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5111>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for core_interfaces_and_l3_edge ethernet/port-channel interfaces, router-bgp and utils by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5087>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for router_bgp(overlay) by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/5117>
+- Refactor(eos_designs): Refactor code for underlay/overlay/connected_endpoints/network_services utils by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/5182>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for models in base/init.py and utils.py by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/5127>
+- Refactor(eos_designs): Use schema classes for facts by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5185>
+- Refactor: Remove shared_utils unused code post refactoring by @gmuloc in <https://github.com/aristanetworks/avd/pull/5245>
+- Refactor(eos_designs): Refactor network_services wan_utils and zscaler_utils by @gmuloc in <https://github.com/aristanetworks/avd/pull/5211>
+- Refactor(eos_designs): Better handling of index error p2p_links nodes and other fields in core_interface by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/5215>
+- Refactor(eos_designs): Clean legacy render method for structured config by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5262>
 
 ## Release 5.2.3
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs): Revert changed behavior for management_eapi (#5112) by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5158
-- Fix(eos_designs): Fix performance regression in port-profile caching (#5150) by @carlbuchmann in https://github.com/aristanetworks/avd/pull/5159
+- Fix(eos_designs): Revert changed behavior for management_eapi (#5112) by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5158>
+- Fix(eos_designs): Fix performance regression in port-profile caching (#5150) by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/5159>
 
 ## Release 5.2.2
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs): Invalid class returned from snmp_settings.vrfs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5035
-- Fix(eos_designs): Wrong structured config for overlapping network ports by @gmuloc in https://github.com/aristanetworks/avd/pull/5033
+- Fix(eos_designs): Invalid class returned from snmp_settings.vrfs by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5035>
+- Fix(eos_designs): Wrong structured config for overlapping network ports by @gmuloc in <https://github.com/aristanetworks/avd/pull/5033>
 
 ### Other Fixed issues
 
-- Fix(containers): fix docker/setup-qemu-action@v3 by setting image to tonistiigi/binfmt:qemu-v7.0.0-28 by @ankudinov in https://github.com/aristanetworks/avd/pull/5033
+- Fix(containers): fix docker/setup-qemu-action@v3 by setting image to tonistiigi/binfmt:qemu-v7.0.0-28 by @ankudinov in <https://github.com/aristanetworks/avd/pull/5033>
 
 ## Release 5.2.1
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs): ptp_settings.domain by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5007
-- Fix(eos_designs): Avoid returning objects in facts by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/5016
-- Fix(eos_designs): Wrong duplicate detection between SVIs and L2VLANs by @gmuloc in https://github.com/aristanetworks/avd/pull/5025
+- Fix(eos_designs): ptp_settings.domain by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5007>
+- Fix(eos_designs): Avoid returning objects in facts by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/5016>
+- Fix(eos_designs): Wrong duplicate detection between SVIs and L2VLANs by @gmuloc in <https://github.com/aristanetworks/avd/pull/5025>
 
 ## Release 5.2.0
 
@@ -463,124 +468,124 @@ This may lead to updates in the generated configurations, but it will not affect
 
 ### Breaking Changes
 
-- Fix(eos_designs)!: Correct Loopback prefixes in PL-LOOPBACKS-EVPN-OVERLAY prefix-list by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4915
+- Fix(eos_designs)!: Correct Loopback prefixes in PL-LOOPBACKS-EVPN-OVERLAY prefix-list by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4915>
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Fix the invalid configuration of vpn-route in export direction for router bgp vrf by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4765
-- Fix(eos_cli_config_gen): Fix wrong variable used in `eos\stun.j2` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4814
-- Fix(eos_cli_config_gen): Fix the invalid command `no neighbor PATH-SELECTION-PG-1 send` for BGP address-family path-selection by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4861
-- Fix(eos_cli_config_gen): Change `lldp.receive_packet_tagged_drop` from `str` to `bool` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4878
-- Fix(eos_cli_config_gen): Fix the errdisable documentation J2 expects recovery.interval to be always set by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4979
+- Fix(eos_cli_config_gen): Fix the invalid configuration of vpn-route in export direction for router bgp vrf by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4765>
+- Fix(eos_cli_config_gen): Fix wrong variable used in `eos\stun.j2` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4814>
+- Fix(eos_cli_config_gen): Fix the invalid command `no neighbor PATH-SELECTION-PG-1 send` for BGP address-family path-selection by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4861>
+- Fix(eos_cli_config_gen): Change `lldp.receive_packet_tagged_drop` from `str` to `bool` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4878>
+- Fix(eos_cli_config_gen): Fix the errdisable documentation J2 expects recovery.interval to be always set by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4979>
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs): Support of validate_lldp key in structured config by @bjmeuer in https://github.com/aristanetworks/avd/pull/4777
-- Fix(eos_designs): Align bgp_maximum_paths range(1 to 600) between eos_designs and eos_cli_config_gen role by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4912
+- Fix(eos_designs): Support of validate_lldp key in structured config by @bjmeuer in <https://github.com/aristanetworks/avd/pull/4777>
+- Fix(eos_designs): Align bgp_maximum_paths range(1 to 600) between eos_designs and eos_cli_config_gen role by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4912>
 
 ### Other Fixed issues
 
-- Fix(eos_validate_state): Fix the DHCP not recognized error for STUN and Connectivity tests by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4764
-- Fix(cv_deploy): Ignore missing structured config files by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4836
-- Fix(cv_deploy): Ensure lossrate for cv_pathfinder metadata is a float by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4852
+- Fix(eos_validate_state): Fix the DHCP not recognized error for STUN and Connectivity tests by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4764>
+- Fix(cv_deploy): Ignore missing structured config files by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4836>
+- Fix(cv_deploy): Ensure lossrate for cv_pathfinder metadata is a float by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4852>
 
 ### Documentation
 
-- Doc(eos_cli_config_gen): Improve snmp server documentation by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4806
-- Doc: Fix wrong command in cv-pathinder example by @gmuloc in https://github.com/aristanetworks/avd/pull/4837
-- Doc: Adding contribution guide for eos_cli_config_gen by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4730
-- Doc: Added support for skip the TOC on fabric and device documentation by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4796
-- Doc: Move docs folder to root of repo by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4923
-- Doc: Change location for docs/requirements.txt by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4932
-- Doc(eos_designs): Add missing node type L3 port-channels configuration table by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4989
+- Doc(eos_cli_config_gen): Improve snmp server documentation by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4806>
+- Doc: Fix wrong command in cv-pathinder example by @gmuloc in <https://github.com/aristanetworks/avd/pull/4837>
+- Doc: Adding contribution guide for eos_cli_config_gen by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4730>
+- Doc: Added support for skip the TOC on fabric and device documentation by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4796>
+- Doc: Move docs folder to root of repo by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4923>
+- Doc: Change location for docs/requirements.txt by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4932>
+- Doc(eos_designs): Add missing node type L3 port-channels configuration table by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4989>
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen): Add is_hostname knob to router_isis by @ccsnw in https://github.com/aristanetworks/avd/pull/4755
-- Feat(eos_cli_config_gen): Added support for DHCP client accept default route feature in port-channel interfaces by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4767
-- Feat(eos_cli_config_gen): Add support for 'cipher v1.0' and 'cipher v1.3' under management_security.ssl_profiles by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4782
-- Feat(eos_cli_config_gen): Add min-links in port-channel-interfaces by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4790
-- Feat(eos_cli_config_gen): Add support for global MPLS RSVP by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4634
-- Feat(eos_cli_config_gen): Added outlier elimination feature support for AVT profile by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4762
-- Feat(eos_cli_config_gen): Add switchport 'tap' and 'tool' mode config to the ethernet and port-channel interfaces by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4174
-- Feat(eos_cli_config_gen): Add interface traffic engineering and TE admin group for ethernet/port-channel by @emilarista in https://github.com/aristanetworks/avd/pull/4754
-- Feat(eos_cli_config_gen): Added support for IP locking enforcement disabled and address family IPv4/IPv6 by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4803
-- Feat(eos_cli_config_gen): Add support for `connection tx-interface match source-ip` for `ip security` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4844
-- Feat(eos_cli_config_gen): Added login/motd banner in device documentation by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4855
-- Feat(eos_cli_config_gen): Add ICMP echo size for Monitor Connectivity hosts by @ctyrider in https://github.com/aristanetworks/avd/pull/4853
-- Feat(eos_cli_config_gen): Added support for metric bandwidth per interface under router path-selection by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4830
-- Feat(eos_cli_config_gen): Added support for fips_restrictions under management security by @KrasenKolev in https://github.com/aristanetworks/avd/pull/4845
-- Feat(eos_cli_config_gen): Additional interface TE options by @emilarista in https://github.com/aristanetworks/avd/pull/4823
-- Feat(eos_cli_config_gen): Add support for configuring  `dhcp server ipv4` and `dhcp server ipv6` for Port-Channel interfaces by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4885
-- Feat(eos_cli_config_gen): Added support for Virtual Router MAC Address Advertisement Interval by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4891
-- Feat(eos_cli_config_gen): Add support for Next Hop Self Source Interface to EVPN Peer Groups by @ccsnw in https://github.com/aristanetworks/avd/pull/4903
-- Feat(eos_cli_config_gen): Add tls option for logging protocol by @emilarista in https://github.com/aristanetworks/avd/pull/4914
-- Feat(eos_cli_config_gen): Add support for unix-socket protocol by @KrasenKolev in https://github.com/aristanetworks/avd/pull/4898
-- Feat(eos_cli_config_gen): Add match dscp and ecn support to class map type qos by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4863
-- Feat(eos_cli_config_gen): Add support for for NAT service_profile under L3 port_channel interface by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4934
-- Feat(eos_cli_config_gen): Add interface TE twamp-light with fallback knobs by @emilarista in https://github.com/aristanetworks/avd/pull/4935
-- Feat(eos_cli_config_gen): Add support for mpls tunnel termination settings by @ccsnw in https://github.com/aristanetworks/avd/pull/4888
+- Feat(eos_cli_config_gen): Add is_hostname knob to router_isis by @ccsnw in <https://github.com/aristanetworks/avd/pull/4755>
+- Feat(eos_cli_config_gen): Added support for DHCP client accept default route feature in port-channel interfaces by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4767>
+- Feat(eos_cli_config_gen): Add support for 'cipher v1.0' and 'cipher v1.3' under management_security.ssl_profiles by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4782>
+- Feat(eos_cli_config_gen): Add min-links in port-channel-interfaces by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4790>
+- Feat(eos_cli_config_gen): Add support for global MPLS RSVP by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4634>
+- Feat(eos_cli_config_gen): Added outlier elimination feature support for AVT profile by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4762>
+- Feat(eos_cli_config_gen): Add switchport 'tap' and 'tool' mode config to the ethernet and port-channel interfaces by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4174>
+- Feat(eos_cli_config_gen): Add interface traffic engineering and TE admin group for ethernet/port-channel by @emilarista in <https://github.com/aristanetworks/avd/pull/4754>
+- Feat(eos_cli_config_gen): Added support for IP locking enforcement disabled and address family IPv4/IPv6 by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4803>
+- Feat(eos_cli_config_gen): Add support for `connection tx-interface match source-ip` for `ip security` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4844>
+- Feat(eos_cli_config_gen): Added login/motd banner in device documentation by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4855>
+- Feat(eos_cli_config_gen): Add ICMP echo size for Monitor Connectivity hosts by @ctyrider in <https://github.com/aristanetworks/avd/pull/4853>
+- Feat(eos_cli_config_gen): Added support for metric bandwidth per interface under router path-selection by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4830>
+- Feat(eos_cli_config_gen): Added support for fips_restrictions under management security by @KrasenKolev in <https://github.com/aristanetworks/avd/pull/4845>
+- Feat(eos_cli_config_gen): Additional interface TE options by @emilarista in <https://github.com/aristanetworks/avd/pull/4823>
+- Feat(eos_cli_config_gen): Add support for configuring  `dhcp server ipv4` and `dhcp server ipv6` for Port-Channel interfaces by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4885>
+- Feat(eos_cli_config_gen): Added support for Virtual Router MAC Address Advertisement Interval by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4891>
+- Feat(eos_cli_config_gen): Add support for Next Hop Self Source Interface to EVPN Peer Groups by @ccsnw in <https://github.com/aristanetworks/avd/pull/4903>
+- Feat(eos_cli_config_gen): Add tls option for logging protocol by @emilarista in <https://github.com/aristanetworks/avd/pull/4914>
+- Feat(eos_cli_config_gen): Add support for unix-socket protocol by @KrasenKolev in <https://github.com/aristanetworks/avd/pull/4898>
+- Feat(eos_cli_config_gen): Add match dscp and ecn support to class map type qos by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4863>
+- Feat(eos_cli_config_gen): Add support for for NAT service_profile under L3 port_channel interface by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4934>
+- Feat(eos_cli_config_gen): Add interface TE twamp-light with fallback knobs by @emilarista in <https://github.com/aristanetworks/avd/pull/4935>
+- Feat(eos_cli_config_gen): Add support for mpls tunnel termination settings by @ccsnw in <https://github.com/aristanetworks/avd/pull/4888>
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs): Relax mode in structured config by @gmuloc in https://github.com/aristanetworks/avd/pull/4784
-- Feat(eos_designs): Improve `ptp` settings for `p2p_links` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4612
-- Feat(eos_designs): Added support to set RCF for peer group in router bgp address family IPv4/IPv6 by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4804
-- Feat(eos_designs): sflow_polling_interval by @ernestoherrerab in https://github.com/aristanetworks/avd/pull/4820
-- Feat(eos_designs): Add `uplink_interface_speed` option for `default_interfaces` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4828
-- Feat(eos_designs): Added rack, pod, dc, fabric information in the structured_config metadata by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4827
-- Feat(eos_designs): Add missing schemas for eos_designs by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4840
-- Feat(eos_designs): Added support for use different router IDs per VRF defined in network services by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4775
-- Feat(eos_designs): Add platform match criteria for network_ports by @kpbush30 in https://github.com/aristanetworks/avd/pull/4798
-- Feat(eos_designs): Support multiple IP pools and/or IP ranges for all pools by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4883
-- Feat(eos_designs): Only enable PTP on certain uplinks by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4819
-- Feat(eos_designs): Optional dedicated MLAG peer group for VRFs by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4881
-- Feat(eos_designs): Add support for l3_port_channel_interfaces for WAN by @ashenoy-arista in https://github.com/aristanetworks/avd/pull/4752
+- Feat(eos_designs): Relax mode in structured config by @gmuloc in <https://github.com/aristanetworks/avd/pull/4784>
+- Feat(eos_designs): Improve `ptp` settings for `p2p_links` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4612>
+- Feat(eos_designs): Added support to set RCF for peer group in router bgp address family IPv4/IPv6 by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4804>
+- Feat(eos_designs): sflow_polling_interval by @ernestoherrerab in <https://github.com/aristanetworks/avd/pull/4820>
+- Feat(eos_designs): Add `uplink_interface_speed` option for `default_interfaces` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4828>
+- Feat(eos_designs): Added rack, pod, dc, fabric information in the structured_config metadata by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4827>
+- Feat(eos_designs): Add missing schemas for eos_designs by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4840>
+- Feat(eos_designs): Added support for use different router IDs per VRF defined in network services by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4775>
+- Feat(eos_designs): Add platform match criteria for network_ports by @kpbush30 in <https://github.com/aristanetworks/avd/pull/4798>
+- Feat(eos_designs): Support multiple IP pools and/or IP ranges for all pools by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4883>
+- Feat(eos_designs): Only enable PTP on certain uplinks by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4819>
+- Feat(eos_designs): Optional dedicated MLAG peer group for VRFs by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4881>
+- Feat(eos_designs): Add support for l3_port_channel_interfaces for WAN by @ashenoy-arista in <https://github.com/aristanetworks/avd/pull/4752>
 
 ### Other Changes
 
-- Refactor(plugins): Optimize schema validation by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4757
-- Feat(eos_cli_config_gen): Adding support to disable make_before_break for PIM sparse-mode by @davidhayes9 in https://github.com/aristanetworks/avd/pull/4745
-- Refactor(eos_designs): Use python classes built from schemas for inputs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4603
-- Refactor(eos_cli_config_gen): Improve the aaa accounting j2 template by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4636
-- Bump: Pre-release 5.2.0-dev1 by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4792
-- Refactor(eos_cli_config_gen): Update eos template to validate  `type` key defined in `aaa_server_group` model by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4748
-- Refactor(plugins): Improve schema models by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4795
-- Refactor(eos_designs): Structured config output by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4700
-- Bump: Pre-release 5.2.0-dev2 by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4839
-- Bump: New minimum requirement for ansible-core 2.16 by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4871
-- Feat(eos_cli_config_gen): Add comment to ethernet and port-channel interfaces by @joelbreton2 in https://github.com/aristanetworks/avd/pull/4890
-- Refactor(plugins): Add support for default_value to natural_sort by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4901
-- Refactor(eos_cli_config_gen): Updated `hash_algorithm` and `authentication key` as required key in ntp schema by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4876
-- Refactor(eos_cli_config_gen): Optimize Jinja2 logic for DHCP servers documentation by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4913
-- Feat(eos_cli_config_gen): Add support for ip name server groups by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4763
-- Refactor(eos_designs): Improve structured_config object duplication checks with opt-in by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4897
-- Refactor(eos_designs): Refactor eos_designs structured_config code for dps_interfaces by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4941
-- Refactor: Change mixin classes to use `Protocol` by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4938
-- Refactor: Fix type check on structured_config_contributor by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4956
-- Refactor(eos_designs): Refactor eos_designs structured_config code for router-general by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4942
-- Refactor(eos_designs): Refactor eos_designs structured_config code for underlay router_bgp by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4953
-- Refactor(eos_designs): structured_config for network_services vlans by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4955
-- Refactor(eos_designs): Refactor eos_designs structured_config code for vrfs by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4952
-- Refactor(eos_designs): Refactor eos_designs structured_config code for tunnel_interfaces by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4946
-- Refactor(eos_designs): Refactor eos_designs structured_config code for patch_panel by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4949
-- Refactor(eos_designs): structured_config for network_services vlan_interfaces by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4957
-- Refactor(eos_designs): structured_config for standard_access_list under network services and underlay by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4959
-- Refactor(eos_designs): Refactor eos_designs struct_config for structured_configs/base/snmp_server.py by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4951
-- Refactor(eos_designs): Refactor eos_designs structured_config code for monitor_connectivity by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4947
-- Refactor(eos_designs): structured_config for underlay mpls by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4963
-- Refactor(eos_designs): Refactor eos_designs structured_config code for router_multicast.py by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4964
-- Refactor(eos_designs): structured_config for network_services ip_security by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4966
-- Refactor(eos_designs): Refactor eos_designs structured_config code for virtual_source_nat_vrfs by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4974
-- Refactor(eos_designs): structured_config for agents by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4975
-- Refactor(eos_designs): Refactor eos_designs structured_config code router_bfd by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4968
-- Refactor(eos_designs): Refactor structured_config for network_services router_service_insertion by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4982
-- Refactor(eos_designs): Refactor eos_designs structured_config code for `router_pim_sparse_mode.py` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4973
-- Refactor(eos_designs): structured_config for core_interfaces_and_l3_edge/router_ospf.py by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4977
-- Refactor(eos_designs): Refactor structured_config code for `underlay/as.py` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4978
-- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_nat by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4944
-- Refactor(eos_designs): Refactor network_service vxlan_interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/4962
-- Refactor(eos_designs): structured_config for network_services router_bgp by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4961
+- Refactor(plugins): Optimize schema validation by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4757>
+- Feat(eos_cli_config_gen): Adding support to disable make_before_break for PIM sparse-mode by @davidhayes9 in <https://github.com/aristanetworks/avd/pull/4745>
+- Refactor(eos_designs): Use python classes built from schemas for inputs by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4603>
+- Refactor(eos_cli_config_gen): Improve the aaa accounting j2 template by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4636>
+- Bump: Pre-release 5.2.0-dev1 by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4792>
+- Refactor(eos_cli_config_gen): Update eos template to validate  `type` key defined in `aaa_server_group` model by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4748>
+- Refactor(plugins): Improve schema models by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4795>
+- Refactor(eos_designs): Structured config output by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4700>
+- Bump: Pre-release 5.2.0-dev2 by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4839>
+- Bump: New minimum requirement for ansible-core 2.16 by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4871>
+- Feat(eos_cli_config_gen): Add comment to ethernet and port-channel interfaces by @joelbreton2 in <https://github.com/aristanetworks/avd/pull/4890>
+- Refactor(plugins): Add support for default_value to natural_sort by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4901>
+- Refactor(eos_cli_config_gen): Updated `hash_algorithm` and `authentication key` as required key in ntp schema by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4876>
+- Refactor(eos_cli_config_gen): Optimize Jinja2 logic for DHCP servers documentation by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4913>
+- Feat(eos_cli_config_gen): Add support for ip name server groups by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4763>
+- Refactor(eos_designs): Improve structured_config object duplication checks with opt-in by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4897>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for dps_interfaces by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4941>
+- Refactor: Change mixin classes to use `Protocol` by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4938>
+- Refactor: Fix type check on structured_config_contributor by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4956>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for router-general by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4942>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for underlay router_bgp by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4953>
+- Refactor(eos_designs): structured_config for network_services vlans by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4955>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for vrfs by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4952>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for tunnel_interfaces by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4946>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for patch_panel by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4949>
+- Refactor(eos_designs): structured_config for network_services vlan_interfaces by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4957>
+- Refactor(eos_designs): structured_config for standard_access_list under network services and underlay by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4959>
+- Refactor(eos_designs): Refactor eos_designs struct_config for structured_configs/base/snmp_server.py by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4951>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for monitor_connectivity by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4947>
+- Refactor(eos_designs): structured_config for underlay mpls by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4963>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for router_multicast.py by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4964>
+- Refactor(eos_designs): structured_config for network_services ip_security by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4966>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for virtual_source_nat_vrfs by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4974>
+- Refactor(eos_designs): structured_config for agents by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4975>
+- Refactor(eos_designs): Refactor eos_designs structured_config code router_bfd by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4968>
+- Refactor(eos_designs): Refactor structured_config for network_services router_service_insertion by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4982>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for `router_pim_sparse_mode.py` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4973>
+- Refactor(eos_designs): structured_config for core_interfaces_and_l3_edge/router_ospf.py by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4977>
+- Refactor(eos_designs): Refactor structured_config code for `underlay/as.py` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4978>
+- Refactor(eos_designs): Refactor eos_designs structured_config code for ip_nat by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4944>
+- Refactor(eos_designs): Refactor network_service vxlan_interfaces by @gmuloc in <https://github.com/aristanetworks/avd/pull/4962>
+- Refactor(eos_designs): structured_config for network_services router_bgp by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4961>
 
 ## Release 5.1.0
 
@@ -593,77 +598,77 @@ This may lead to updates in the generated configurations, but it will not affect
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Prevent empty source and dest ports list for ip access lists by @gmuloc in https://github.com/aristanetworks/avd/pull/4660
+- Fix(eos_cli_config_gen): Prevent empty source and dest ports list for ip access lists by @gmuloc in <https://github.com/aristanetworks/avd/pull/4660>
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs): Add redistribution of attached-host to BGP for inband management by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4696
-- Fix(eos_designs): Always output interface access_vlan as int in structured_config by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4738
-- Fix(eos_designs): Explicitly extend SVI or L2VLAN to remote EVPN domains by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4736
+- Fix(eos_designs): Add redistribution of attached-host to BGP for inband management by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4696>
+- Fix(eos_designs): Always output interface access_vlan as int in structured_config by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4738>
+- Fix(eos_designs): Explicitly extend SVI or L2VLAN to remote EVPN domains by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4736>
 
 ### Other Fixed issues
 
-- Fix(eos_validate_state): Fix the VerifyLLDPNeighbors test to skip in case validate_state is set to False by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4679
+- Fix(eos_validate_state): Fix the VerifyLLDPNeighbors test to skip in case validate_state is set to False by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4679>
 
 ### Documentation
 
-- Doc(eos_designs,eos_cli_config_gen): Fix incorrect schemas by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4691
-- Doc: Fix invalid deprecation links by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4703
-- Doc(eos_designs): Add note in network services redistribute connected regarding VRF default by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4704
-- Doc(eos_designs): Fix MPLS node types documentation in node_types table by @gmuloc in https://github.com/aristanetworks/avd/pull/4733
-- Doc(eos_cli_config_gen): Make the Radius Server documentation visible by @gmuloc in https://github.com/aristanetworks/avd/pull/4741
+- Doc(eos_designs,eos_cli_config_gen): Fix incorrect schemas by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4691>
+- Doc: Fix invalid deprecation links by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4703>
+- Doc(eos_designs): Add note in network services redistribute connected regarding VRF default by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4704>
+- Doc(eos_designs): Fix MPLS node types documentation in node_types table by @gmuloc in <https://github.com/aristanetworks/avd/pull/4733>
+- Doc(eos_cli_config_gen): Make the Radius Server documentation visible by @gmuloc in <https://github.com/aristanetworks/avd/pull/4741>
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen): Add support for OSPF graceful restart by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4591
-- Feat(eos_cli_config_gen): Added dot1x radius av-pair `lldp` and `dhcp` command support by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4618
-- Feat(eos_cli_config_gen): Add maximum_paths  to router_bgp.vrfs by @juanjtomasg in https://github.com/aristanetworks/avd/pull/4655
-- Feat(eos_cli_config_gen): Added support for `neighbor x.x.x.x encapsulation mpls next-hop-self source-intf <source-interface>` by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4608
-- Feat(eos_cli_config_gen): Add vrf support for vmtracer_sessions by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4601
-- Feat(eos_cli_config_gen): Add `route_map_in/out` for `router_bgp.address_family_evpn.neighbors[]` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4625
-- Feat(eos_cli_config_gen): Expand CLI to support DualEncap MH EVPN GW requirements by @colinmacgiolla in https://github.com/aristanetworks/avd/pull/4613
-- Feat(eos_cli_config_gen): Add support for deadtime configuration to radius_server by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4614
-- Feat(eos_cli_config_gen): Add integrity key under ike policy by @sugetha24 in https://github.com/aristanetworks/avd/pull/4606
-- Feat(eos_cli_config_gen): Support for Interface Profiles on Port-channel interfaces by @JaakkoRautanen in https://github.com/aristanetworks/avd/pull/4661
-- Feat(eos_cli_config_gen): Add support for LSP and CSNP timers under router_isis by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4619
-- Feat(eos_cli_config_gen): Add support for `mac timestamp header` command by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4635
-- Feat(eos_cli_config_gen): Adding improved model for interface link tracking groups by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4610
-- Feat(eos_cli_config_gen): Add support for ipv4/ipv6 access group ingress default in system.control_plane by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4710
-- Feat(eos_cli_config_gen): Add BFD Slow-Timer Knob by @ccsnw in https://github.com/aristanetworks/avd/pull/4718
-- Feat(eos_cli_config_gen): Add support for `monitor server radius` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4595
-- Feat(eos_cli_config_gen): Add support for additional isis authentication commands in `ethernet-interfaces` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4326
-- Feat(eos_cli_config_gen): Add support for BGP default timers and send-community commands by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4607
-- Feat(eos_cli_config_gen): Add support for additional modes and feature in isis authentication under `port-channel-interfaces` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4353
+- Feat(eos_cli_config_gen): Add support for OSPF graceful restart by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4591>
+- Feat(eos_cli_config_gen): Added dot1x radius av-pair `lldp` and `dhcp` command support by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4618>
+- Feat(eos_cli_config_gen): Add maximum_paths  to router_bgp.vrfs by @juanjtomasg in <https://github.com/aristanetworks/avd/pull/4655>
+- Feat(eos_cli_config_gen): Added support for `neighbor x.x.x.x encapsulation mpls next-hop-self source-intf <source-interface>` by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4608>
+- Feat(eos_cli_config_gen): Add vrf support for vmtracer_sessions by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4601>
+- Feat(eos_cli_config_gen): Add `route_map_in/out` for `router_bgp.address_family_evpn.neighbors[]` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4625>
+- Feat(eos_cli_config_gen): Expand CLI to support DualEncap MH EVPN GW requirements by @colinmacgiolla in <https://github.com/aristanetworks/avd/pull/4613>
+- Feat(eos_cli_config_gen): Add support for deadtime configuration to radius_server by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4614>
+- Feat(eos_cli_config_gen): Add integrity key under ike policy by @sugetha24 in <https://github.com/aristanetworks/avd/pull/4606>
+- Feat(eos_cli_config_gen): Support for Interface Profiles on Port-channel interfaces by @JaakkoRautanen in <https://github.com/aristanetworks/avd/pull/4661>
+- Feat(eos_cli_config_gen): Add support for LSP and CSNP timers under router_isis by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4619>
+- Feat(eos_cli_config_gen): Add support for `mac timestamp header` command by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4635>
+- Feat(eos_cli_config_gen): Adding improved model for interface link tracking groups by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4610>
+- Feat(eos_cli_config_gen): Add support for ipv4/ipv6 access group ingress default in system.control_plane by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4710>
+- Feat(eos_cli_config_gen): Add BFD Slow-Timer Knob by @ccsnw in <https://github.com/aristanetworks/avd/pull/4718>
+- Feat(eos_cli_config_gen): Add support for `monitor server radius` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4595>
+- Feat(eos_cli_config_gen): Add support for additional isis authentication commands in `ethernet-interfaces` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4326>
+- Feat(eos_cli_config_gen): Add support for BGP default timers and send-community commands by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4607>
+- Feat(eos_cli_config_gen): Add support for additional modes and feature in isis authentication under `port-channel-interfaces` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4353>
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs): Add support the all dot1x features under adapters/port-profiles/network-ports by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4648
-- Feat(eos_designs): Add option to disable default 'redistribute connected' in VRF. by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4220
-- Feat(eos_designs): Adding port_channel_id as option for endpoint ethernet description by @bjmeuer in https://github.com/aristanetworks/avd/pull/4667
-- Feat(eos_designs): Add support to use router general for router id by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4687
-- Feat(eos_designs): Add support to enable ISIS authentication at global level by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4102
-- Feat(eos_designs): Support for L3 Inband ZTP by @jrecchia1029 in https://github.com/aristanetworks/avd/pull/4304
+- Feat(eos_designs): Add support the all dot1x features under adapters/port-profiles/network-ports by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4648>
+- Feat(eos_designs): Add option to disable default 'redistribute connected' in VRF. by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4220>
+- Feat(eos_designs): Adding port_channel_id as option for endpoint ethernet description by @bjmeuer in <https://github.com/aristanetworks/avd/pull/4667>
+- Feat(eos_designs): Add support to use router general for router id by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4687>
+- Feat(eos_designs): Add support to enable ISIS authentication at global level by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4102>
+- Feat(eos_designs): Support for L3 Inband ZTP by @jrecchia1029 in <https://github.com/aristanetworks/avd/pull/4304>
 
 ### New features and enhancement in both eos_designs and eos_cli_config_gen
 
-- Feat(eos_designs,eos_cli_config_gen): Support for IPv6 on network services VRF diagnostic loopback by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4222
+- Feat(eos_designs,eos_cli_config_gen): Support for IPv6 on network services VRF diagnostic loopback by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4222>
 
 ### Other new features and enhancements
 
-- Feat(eos_validate_state): Added the support of `validate_lldp` key to skip the VerifyLLDPNeighbors tests by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4684
-- Feat(plugins): Set changed=true and print yellow updates when recompiling schemas/templates by @gmuloc in https://github.com/aristanetworks/avd/pull/4715
-- Feat(plugins): Verify pyavd extras again in verify_requirements by @gmuloc in https://github.com/aristanetworks/avd/pull/4720
+- Feat(eos_validate_state): Added the support of `validate_lldp` key to skip the VerifyLLDPNeighbors tests by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4684>
+- Feat(plugins): Set changed=true and print yellow updates when recompiling schemas/templates by @gmuloc in <https://github.com/aristanetworks/avd/pull/4715>
+- Feat(plugins): Verify pyavd extras again in verify_requirements by @gmuloc in <https://github.com/aristanetworks/avd/pull/4720>
 
 ### PyAVD Changes
 
-- Refactor(pyavd): Adding `path` attribute to the validation error for removed keys by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4688
+- Refactor(pyavd): Adding `path` attribute to the validation error for removed keys by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4688>
 
 ### Other Changes
 
-- Refactor(cv_deploy): Improve metadata for zscaler by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4631
-- Refactor(eos_cli_config_gen): Adding check for hosts key in TACACS server j2 file by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4701
-- Bump(requirements): Update ansible-core requirement from <2.18.0,>=2.15.0 to >=2.15.0,<2.19.0 in /ansible_collections/arista/avd by @dependabot in https://github.com/aristanetworks/avd/pull/4713
-- Refactor(eos_designs): Use new isis_authentication data models by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4734
+- Refactor(cv_deploy): Improve metadata for zscaler by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4631>
+- Refactor(eos_cli_config_gen): Adding check for hosts key in TACACS server j2 file by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4701>
+- Bump(requirements): Update ansible-core requirement from <2.18.0,>=2.15.0 to >=2.15.0,<2.19.0 in /ansible_collections/arista/avd by @dependabot in <https://github.com/aristanetworks/avd/pull/4713>
+- Refactor(eos_designs): Use new isis_authentication data models by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4734>
 
 ## Release 5.0.0
 
@@ -839,214 +844,214 @@ Instead use the `skip_tests` mechanism. See the [porting guide](../porting-guide
 
 #### Breaking Changes
 
-- Fix(eos_designs)!: VARPv6 config is not generated even when "ipv6_enable: true" is specified by @bjmeuer in https://github.com/aristanetworks/avd/pull/4208
-- Refactor(eos_cli_config_gen)!: Removing default type: switched from ethernet and port-channel interfaces by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4355
-- Refactor(eos_designs)!: Change the default value of `mlag_on_orphan_port_channel_downlink` to `false` by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4371
-- Fix(eos_designs)!: Add missing BGP peer description for MLAG peerings in VRFs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4394
-- Refactor(eos_designs)!: Change the default value of `isis_system_id_format` to `underlay_loopback` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4373
-- Refactor(eos_designs)!: Change merge strategy for SVI structured_config from SVI profiles by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4383
-- Fix(eos_designs)!: Do not render EVPN address-family on MPLS devices unless `overlay_address_families` includes `evpn` by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4390
-- Refactor(eos_cli_config_gen)!: Make router_traffic_engineering.enabled required by @gmuloc in https://github.com/aristanetworks/avd/pull/4403
-- Feat(eos_designs)!: Update the default platform settings for R3-series to have TCAM profile "vxlan-routing" by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4387
-- Fix(eos_cli_config_gen)!: Make `router_isis.address_family_ipv4/6.enabled` Required by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4401
-- Feat(eos_designs)!: Improve logic for BGP configuration of network services VRFs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4358
-- Refactor(eos_designs)!: Raise AVD error if sFlow is enabled but `sflow_settings.destinations` is not configured by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4402
-- Refactor(eos_cli_config_gen,eos_designs)!: Update router_ospf.redistribute.bgp/connected/static with enabled keys by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4417
-- Feat(eos_designs)!: Shutdown interfaces and bgp towards undeployed peers by default by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4424
-- Refactor(eos_designs)!: Import AvdIpAddressing class from PyAVD by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4422
-- Fix(eos_designs)!: BGP vlan config should not have redistribute igmp when belonging to a VRF with evpn multicast by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4210
-- Refactor(eos_designs)!: Change loopback0 description and terminology to router_id_loopback by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4448
-- Refactor(eos_designs)!: WAN default MTU set to 9194 for Dps and WAN HA interfaces and for LAN uplink interfaces added `p2p_uplinks_mtu` support in platform settings by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4415
-- Refactor(eos_designs)!: Change the default Loopback1 description by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4451
-- Refactor(eos_designs)!: Change the default mgmt_interface_description to upper case by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4452
-- Refactor(eos_designs)!: Only render IGMP snooping querier version and address when enabled by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4478
-- Feat(eos_designs)!: Update eos_designs code to generate new switchport model in structured_configs by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4454
-- Refactor(eos_designs)!: Combine the VLAN trunk groups used for MLAG by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4494
-- Refactor(eos_designs)!: Change default descriptions for connected endpoints and network ports by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4457
-- Fix(eos_cli_config_gen)!: update logic in monitor_sessions to not require both source and destination by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3823
-- Refactor(eos_designs)!: Change default mlag interface descriptions by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4464
-- Fix(eos_cli_config_gen)!: Avoid generating invalid configuration for traffic policies by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4266
-- Feat(eos_designs,eos_cli_config_gen)!: Change default encapsulation to path-selection for WAN iBGP EVPN peerings by @gmuloc in https://github.com/aristanetworks/avd/pull/4496
-- Fix(eos_designs)!: Make evpn_gateway.remote_peers override work as documented by @gmuloc in https://github.com/aristanetworks/avd/pull/4510
-- Refactor(eos_designs)!: Change MLAG VLAN names and SVI descriptions by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4479
-- Refactor(eos_designs)!: Change MLAG L3 VRF VLAN names and SVI descriptions by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4514
-- Refactor(eos_designs)!: Raise when a referenced profile name is not defined by @gmuloc in https://github.com/aristanetworks/avd/pull/4516
-- Refactor(eos_designs)!: Change default BGP peer descriptions by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4517
-- Refactor(eos_designs)!: Change L3 P2P descriptions for uplinks and p2p_links by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4520
-- Refactor(eos_designs)!: Change L2 uplink description by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4532
-- Refactor(eos_designs)!: Change default VRF Diagnostic Loopback descriptions by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4534
-- Refactor(eos_cli_config_gen)!: Reorder hardware and hardware-counter commands by @gmuloc in https://github.com/aristanetworks/avd/pull/4580
-- Fix(eos_designs)!: Endpoints PoE and 802.1x configuration for port-channel members by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4627
+- Fix(eos_designs)!: VARPv6 config is not generated even when "ipv6_enable: true" is specified by @bjmeuer in <https://github.com/aristanetworks/avd/pull/4208>
+- Refactor(eos_cli_config_gen)!: Removing default type: switched from ethernet and port-channel interfaces by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4355>
+- Refactor(eos_designs)!: Change the default value of `mlag_on_orphan_port_channel_downlink` to `false` by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4371>
+- Fix(eos_designs)!: Add missing BGP peer description for MLAG peerings in VRFs by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4394>
+- Refactor(eos_designs)!: Change the default value of `isis_system_id_format` to `underlay_loopback` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4373>
+- Refactor(eos_designs)!: Change merge strategy for SVI structured_config from SVI profiles by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4383>
+- Fix(eos_designs)!: Do not render EVPN address-family on MPLS devices unless `overlay_address_families` includes `evpn` by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4390>
+- Refactor(eos_cli_config_gen)!: Make router_traffic_engineering.enabled required by @gmuloc in <https://github.com/aristanetworks/avd/pull/4403>
+- Feat(eos_designs)!: Update the default platform settings for R3-series to have TCAM profile "vxlan-routing" by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4387>
+- Fix(eos_cli_config_gen)!: Make `router_isis.address_family_ipv4/6.enabled` Required by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4401>
+- Feat(eos_designs)!: Improve logic for BGP configuration of network services VRFs by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4358>
+- Refactor(eos_designs)!: Raise AVD error if sFlow is enabled but `sflow_settings.destinations` is not configured by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4402>
+- Refactor(eos_cli_config_gen,eos_designs)!: Update router_ospf.redistribute.bgp/connected/static with enabled keys by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4417>
+- Feat(eos_designs)!: Shutdown interfaces and bgp towards undeployed peers by default by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4424>
+- Refactor(eos_designs)!: Import AvdIpAddressing class from PyAVD by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4422>
+- Fix(eos_designs)!: BGP vlan config should not have redistribute igmp when belonging to a VRF with evpn multicast by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4210>
+- Refactor(eos_designs)!: Change loopback0 description and terminology to router_id_loopback by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4448>
+- Refactor(eos_designs)!: WAN default MTU set to 9194 for Dps and WAN HA interfaces and for LAN uplink interfaces added `p2p_uplinks_mtu` support in platform settings by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4415>
+- Refactor(eos_designs)!: Change the default Loopback1 description by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4451>
+- Refactor(eos_designs)!: Change the default mgmt_interface_description to upper case by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4452>
+- Refactor(eos_designs)!: Only render IGMP snooping querier version and address when enabled by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4478>
+- Feat(eos_designs)!: Update eos_designs code to generate new switchport model in structured_configs by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4454>
+- Refactor(eos_designs)!: Combine the VLAN trunk groups used for MLAG by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4494>
+- Refactor(eos_designs)!: Change default descriptions for connected endpoints and network ports by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4457>
+- Fix(eos_cli_config_gen)!: update logic in monitor_sessions to not require both source and destination by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/3823>
+- Refactor(eos_designs)!: Change default mlag interface descriptions by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4464>
+- Fix(eos_cli_config_gen)!: Avoid generating invalid configuration for traffic policies by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4266>
+- Feat(eos_designs,eos_cli_config_gen)!: Change default encapsulation to path-selection for WAN iBGP EVPN peerings by @gmuloc in <https://github.com/aristanetworks/avd/pull/4496>
+- Fix(eos_designs)!: Make evpn_gateway.remote_peers override work as documented by @gmuloc in <https://github.com/aristanetworks/avd/pull/4510>
+- Refactor(eos_designs)!: Change MLAG VLAN names and SVI descriptions by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4479>
+- Refactor(eos_designs)!: Change MLAG L3 VRF VLAN names and SVI descriptions by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4514>
+- Refactor(eos_designs)!: Raise when a referenced profile name is not defined by @gmuloc in <https://github.com/aristanetworks/avd/pull/4516>
+- Refactor(eos_designs)!: Change default BGP peer descriptions by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4517>
+- Refactor(eos_designs)!: Change L3 P2P descriptions for uplinks and p2p_links by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4520>
+- Refactor(eos_designs)!: Change L2 uplink description by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4532>
+- Refactor(eos_designs)!: Change default VRF Diagnostic Loopback descriptions by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4534>
+- Refactor(eos_cli_config_gen)!: Reorder hardware and hardware-counter commands by @gmuloc in <https://github.com/aristanetworks/avd/pull/4580>
+- Fix(eos_designs)!: Endpoints PoE and 802.1x configuration for port-channel members by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4627>
 
 #### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Fix router_isis rx_disabled and mode: shared-secret by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4267
-- Fix(eos_cli_config_gen): Sort IPsec SA, IKE policies and profiles by @gmuloc in https://github.com/aristanetworks/avd/pull/4227
-- Fix(eos_cli_config_gen): Use the correct VRF name for ip nat profile by @gmuloc in https://github.com/aristanetworks/avd/pull/4398
-- Fix(eos_cli_config_gen): Remove primary key of system.control_plane.ipv4/6_access_group and make vrf key unique by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4465
-- Fix(eos_cli_config_gen): Fix the command for next-hop mpls resolution in address-family evpn by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4490
-- Fix(eos_cli_config_gen): Do not render entries with only sequence number from ip_access_list by @gmuloc in https://github.com/aristanetworks/avd/pull/4492
-- Fix(eos_cli_config_gen): Fix wrong indentation of config for redistribute routes in `router_bgp.vrfs[].address_family_ipv6` by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4552
-- Fix(eos_cli_config_gen): Fixing poe link down power-off action command in j2 template by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4576
-- Fix(eos_cli_config_gen): Fix the maximum-routes, next-hop resolution v4-mapped-v6 translation commands in `router_bgp.address_family_ipv4_labeled_unicast` by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4567
+- Fix(eos_cli_config_gen): Fix router_isis rx_disabled and mode: shared-secret by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4267>
+- Fix(eos_cli_config_gen): Sort IPsec SA, IKE policies and profiles by @gmuloc in <https://github.com/aristanetworks/avd/pull/4227>
+- Fix(eos_cli_config_gen): Use the correct VRF name for ip nat profile by @gmuloc in <https://github.com/aristanetworks/avd/pull/4398>
+- Fix(eos_cli_config_gen): Remove primary key of system.control_plane.ipv4/6_access_group and make vrf key unique by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4465>
+- Fix(eos_cli_config_gen): Fix the command for next-hop mpls resolution in address-family evpn by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4490>
+- Fix(eos_cli_config_gen): Do not render entries with only sequence number from ip_access_list by @gmuloc in <https://github.com/aristanetworks/avd/pull/4492>
+- Fix(eos_cli_config_gen): Fix wrong indentation of config for redistribute routes in `router_bgp.vrfs[].address_family_ipv6` by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4552>
+- Fix(eos_cli_config_gen): Fixing poe link down power-off action command in j2 template by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4576>
+- Fix(eos_cli_config_gen): Fix the maximum-routes, next-hop resolution v4-mapped-v6 translation commands in `router_bgp.address_family_ipv4_labeled_unicast` by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4567>
 
 #### Fixed issues in eos_designs
 
-- Fix(eos_designs): Move schema for ipv4_prefix_list_catalog to pyavd for proper enforcement by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4322
-- Fix(eos_designs): Do not render vrf default under router ospf by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4334
-- Fix(eos_designs): Provide the proper kwarg to Ansible Display.warning() in schema tools by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/4345
-- Fix(eos_designs): Better error message when missing 'evpn_multicast' for PIM l3 interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/4391
-- Fix(eos_designs): Fix context vars for custom interface description templates by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4429
-- Fix(eos_designs): Do not filter AVT on HA device if one path-group is present on peer by @gmuloc in https://github.com/aristanetworks/avd/pull/4463
-- Fix(eos_designs): Fix schema validation of dynamic keys by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4474
-- Fix(eos_designs): Use CP-Profile for WAN HA when DP-Profile is not configured by @gmuloc in https://github.com/aristanetworks/avd/pull/4309
-- Fix(eos_designs): Add redistribute connected under BGP for VRF default if no underlay by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4522
-- Fix(eos_designs): Make it possible to add custom PTP profiles by @gmuloc in https://github.com/aristanetworks/avd/pull/4523
-- Fix(eos_designs): Fix the Invalid command of `vxlan vxlan vlan <vlan_id> flood vtep` by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4592
+- Fix(eos_designs): Move schema for ipv4_prefix_list_catalog to pyavd for proper enforcement by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4322>
+- Fix(eos_designs): Do not render vrf default under router ospf by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4334>
+- Fix(eos_designs): Provide the proper kwarg to Ansible Display.warning() in schema tools by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/4345>
+- Fix(eos_designs): Better error message when missing 'evpn_multicast' for PIM l3 interfaces by @gmuloc in <https://github.com/aristanetworks/avd/pull/4391>
+- Fix(eos_designs): Fix context vars for custom interface description templates by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4429>
+- Fix(eos_designs): Do not filter AVT on HA device if one path-group is present on peer by @gmuloc in <https://github.com/aristanetworks/avd/pull/4463>
+- Fix(eos_designs): Fix schema validation of dynamic keys by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4474>
+- Fix(eos_designs): Use CP-Profile for WAN HA when DP-Profile is not configured by @gmuloc in <https://github.com/aristanetworks/avd/pull/4309>
+- Fix(eos_designs): Add redistribute connected under BGP for VRF default if no underlay by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4522>
+- Fix(eos_designs): Make it possible to add custom PTP profiles by @gmuloc in <https://github.com/aristanetworks/avd/pull/4523>
+- Fix(eos_designs): Fix the Invalid command of `vxlan vxlan vlan <vlan_id> flood vtep` by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4592>
 
 #### Fixed issues in both eos_designs and eos_cli_config_gen
 
-- Fix(eos_cli_config_gen,eos_designs): Dont configure access group on interface when access group is defined on session level by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4565
+- Fix(eos_cli_config_gen,eos_designs): Dont configure access group on interface when access group is defined on session level by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4565>
 
 #### Other Fixed issues
 
-- Fix(cv_deploy): Fix async comprehensions in get_tags by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/4332
-- Fix(eos_validate_state): Update documentation by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/4350
-- Fix(cv_deploy): Ensure 'AVD Configurations' container is inserted first by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4356
-- Fix(cv_deploy): Fix Ansible Logging and increase API timeouts by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4357
-- Fix(eos_validate_state): Ensure graceful handling of command errors from ANTA by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4385
-- Fix(plugins): Support zeroes in interface numbers for range_expand by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4420
+- Fix(cv_deploy): Fix async comprehensions in get_tags by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/4332>
+- Fix(eos_validate_state): Update documentation by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/4350>
+- Fix(cv_deploy): Ensure 'AVD Configurations' container is inserted first by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4356>
+- Fix(cv_deploy): Fix Ansible Logging and increase API timeouts by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4357>
+- Fix(eos_validate_state): Ensure graceful handling of command errors from ANTA by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4385>
+- Fix(plugins): Support zeroes in interface numbers for range_expand by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4420>
 
 #### Documentation
 
-- Doc(eos_cli_config_gen): Removing deprecation info from description as it was already removed by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4426
-- Doc(eos_cli_config_gen): Add missing tables to input-variables by @gmuloc in https://github.com/aristanetworks/avd/pull/4469
-- Doc(eos_designs): How-to guide and porting guide updates for description templates by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4558
-- Doc(eos_cli_config_gen): Fix new_key paths for router_bgp to raise errors in case of a key conflict by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/4597
-- Doc(eos_designs): Remove adapter native_vlan_tag unused default value by @gmuloc in https://github.com/aristanetworks/avd/pull/4602
-- Doc(eos_designs): Update custom_structured_config doc following merge changes in 4.0.0 by @alexeygorbunov in https://github.com/aristanetworks/avd/pull/4611
-- Doc: Add CV Pathfinder AVD example by @gmuloc in https://github.com/aristanetworks/avd/pull/4453
-- Doc(eos_designs): correct dc_name docs by @pvinci-arista in https://github.com/aristanetworks/avd/pull/4646
-- Doc(eos_validate_state): Update diagram and documentation to include custom ANTA test catalogs by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/4653
+- Doc(eos_cli_config_gen): Removing deprecation info from description as it was already removed by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4426>
+- Doc(eos_cli_config_gen): Add missing tables to input-variables by @gmuloc in <https://github.com/aristanetworks/avd/pull/4469>
+- Doc(eos_designs): How-to guide and porting guide updates for description templates by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4558>
+- Doc(eos_cli_config_gen): Fix new_key paths for router_bgp to raise errors in case of a key conflict by @alexeygorbunov in <https://github.com/aristanetworks/avd/pull/4597>
+- Doc(eos_designs): Remove adapter native_vlan_tag unused default value by @gmuloc in <https://github.com/aristanetworks/avd/pull/4602>
+- Doc(eos_designs): Update custom_structured_config doc following merge changes in 4.0.0 by @alexeygorbunov in <https://github.com/aristanetworks/avd/pull/4611>
+- Doc: Add CV Pathfinder AVD example by @gmuloc in <https://github.com/aristanetworks/avd/pull/4453>
+- Doc(eos_designs): correct dc_name docs by @pvinci-arista in <https://github.com/aristanetworks/avd/pull/4646>
+- Doc(eos_validate_state): Update diagram and documentation to include custom ANTA test catalogs by @carl-baillargeon in <https://github.com/aristanetworks/avd/pull/4653>
 
 #### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen): Add support for isis authentication on vlan interfaces by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4254
-- Feat(eos_cli_config_gen): Extend GRE span with payload support by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4190
-- Feat(eos_cli_config_gen): Add support for snmp-server ipmib ifspeed shape-rate by @gusmb in https://github.com/aristanetworks/avd/pull/4382
-- Feat(eos_cli_config_gen): Add switchport data model by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4158
-- Feat(eos_cli_config_gen): Enhance encapsulation schema/template for ethernet and port-channel interfaces by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4388
-- Feat(eos_cli_config_gen): Set ssh authentication protocols and empty password by @jmussmann in https://github.com/aristanetworks/avd/pull/4436
-- Feat(eos_cli_config_gen): Add support for additional dot1x commands. by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4191
-- Feat(eos_cli_config_gen): Add support for port-channel local interfaces for router-path-selection by @gmuloc in https://github.com/aristanetworks/avd/pull/4475
-- Feat(eos_cli_config_gen): add_hardware_port_group_knob by @ccsnw in https://github.com/aristanetworks/avd/pull/4500
-- Feat(eos_cli_config_gen): Global logging keys for congestion-drops, link-status, and repeat-messages by @nathanmusser in https://github.com/aristanetworks/avd/pull/4493
-- Feat(eos_cli_config_gen): Add support for IPv4 BGP Labeled-Unicast (BGP-LU) by @colinmacgiolla in https://github.com/aristanetworks/avd/pull/4412
-- Feat(eos_cli_config_gen): Add support additional-paths to root context of BGP using new DM by @ccsnw in https://github.com/aristanetworks/avd/pull/4519
-- Feat(eos_cli_config_gen): Redo the model for additional-paths in BGP by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/3730
-- Feat(eos_cli_config_gen): Add permit_response_traffic nat to ip-access-lists by @gmuloc in https://github.com/aristanetworks/avd/pull/4545
-- Feat(eos_cli_config_gen): Add trident l3 routing mac per vlan option  by @ccsnw in https://github.com/aristanetworks/avd/pull/4548
+- Feat(eos_cli_config_gen): Add support for isis authentication on vlan interfaces by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4254>
+- Feat(eos_cli_config_gen): Extend GRE span with payload support by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4190>
+- Feat(eos_cli_config_gen): Add support for snmp-server ipmib ifspeed shape-rate by @gusmb in <https://github.com/aristanetworks/avd/pull/4382>
+- Feat(eos_cli_config_gen): Add switchport data model by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4158>
+- Feat(eos_cli_config_gen): Enhance encapsulation schema/template for ethernet and port-channel interfaces by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4388>
+- Feat(eos_cli_config_gen): Set ssh authentication protocols and empty password by @jmussmann in <https://github.com/aristanetworks/avd/pull/4436>
+- Feat(eos_cli_config_gen): Add support for additional dot1x commands. by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4191>
+- Feat(eos_cli_config_gen): Add support for port-channel local interfaces for router-path-selection by @gmuloc in <https://github.com/aristanetworks/avd/pull/4475>
+- Feat(eos_cli_config_gen): add_hardware_port_group_knob by @ccsnw in <https://github.com/aristanetworks/avd/pull/4500>
+- Feat(eos_cli_config_gen): Global logging keys for congestion-drops, link-status, and repeat-messages by @nathanmusser in <https://github.com/aristanetworks/avd/pull/4493>
+- Feat(eos_cli_config_gen): Add support for IPv4 BGP Labeled-Unicast (BGP-LU) by @colinmacgiolla in <https://github.com/aristanetworks/avd/pull/4412>
+- Feat(eos_cli_config_gen): Add support additional-paths to root context of BGP using new DM by @ccsnw in <https://github.com/aristanetworks/avd/pull/4519>
+- Feat(eos_cli_config_gen): Redo the model for additional-paths in BGP by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/3730>
+- Feat(eos_cli_config_gen): Add permit_response_traffic nat to ip-access-lists by @gmuloc in <https://github.com/aristanetworks/avd/pull/4545>
+- Feat(eos_cli_config_gen): Add trident l3 routing mac per vlan option  by @ccsnw in <https://github.com/aristanetworks/avd/pull/4548>
 
 #### New features and enhancements in eos_designs
 
-- Feat(eos_designs): Custom platform_settings and node_type_keys by @jonxstill in https://github.com/aristanetworks/avd/pull/3300
-- Feat(eos_designs): Add support to enable sflow on l3 interfaces by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4444
-- Feat(eos_designs): Update eos_designs code to generate new interface-encapsulation model in structured_configs by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4504
-- Feat(eos_designs): Add possibility to change network mask for direct WAN HA link by @gmuloc in https://github.com/aristanetworks/avd/pull/4497
-- Feat(eos_designs): Add support for Port-Channel for Direct HA by @gmuloc in https://github.com/aristanetworks/avd/pull/4482
-- Feat(eos_designs): Configure l3 interfaces BGP peers even when underlay_bgp is False by @gmuloc in https://github.com/aristanetworks/avd/pull/4543
+- Feat(eos_designs): Custom platform_settings and node_type_keys by @jonxstill in <https://github.com/aristanetworks/avd/pull/3300>
+- Feat(eos_designs): Add support to enable sflow on l3 interfaces by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4444>
+- Feat(eos_designs): Update eos_designs code to generate new interface-encapsulation model in structured_configs by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4504>
+- Feat(eos_designs): Add possibility to change network mask for direct WAN HA link by @gmuloc in <https://github.com/aristanetworks/avd/pull/4497>
+- Feat(eos_designs): Add support for Port-Channel for Direct HA by @gmuloc in <https://github.com/aristanetworks/avd/pull/4482>
+- Feat(eos_designs): Configure l3 interfaces BGP peers even when underlay_bgp is False by @gmuloc in <https://github.com/aristanetworks/avd/pull/4543>
 
 #### Other new features and enhancements
 
-- Feat(plugins): Add strict mode and ignore_case flags to natural_sort filter by @gmuloc in https://github.com/aristanetworks/avd/pull/4298
-- Feat(eos_validate_state): Added the validation for DPS interface reachability by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4154
-- Feat(plugins): Add AVD String Formatter for later use in custom descriptions by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4432
-- Feat(eos_validate_state): Added the validation for AVT path for static peers and role of device by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4200
+- Feat(plugins): Add strict mode and ignore_case flags to natural_sort filter by @gmuloc in <https://github.com/aristanetworks/avd/pull/4298>
+- Feat(eos_validate_state): Added the validation for DPS interface reachability by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4154>
+- Feat(plugins): Add AVD String Formatter for later use in custom descriptions by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4432>
+- Feat(eos_validate_state): Added the validation for AVT path for static peers and role of device by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4200>
 
 #### PyAVD Changes
 
-- Doc(pyavd): Update pyavd docs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4632
+- Doc(pyavd): Update pyavd docs by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4632>
 
 #### Other Changes
 
-- Bump: Minimum Python version 3.10 by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4276
-- Cut(eos_cli_config_gen): Remove the deprecated keys for event-handlers by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4279
-- Cut(eos_cli_config_gen): Remove deprecated key entropy_source from management_security data model by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4277
-- Cut(eos_cli_config_gen): Remove the deprecated key local_interface from stun server data model by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4274
-- Cut(eos_cli_config_gen): Remove deprecated key cvcompression from daemon_terminattr data model by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4288
-- Cut(eos_cli_config_gen): Remove the deprecated keys for flow-trackings by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4294
-- Cut(eos_cli_config_gen): Remove deprecated key MIB_family_name from snmp_server data model  by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4289
-- Cut(eos_cli_config_gen,eos_designs): Remove deprecated jsonschema files by @gmuloc in https://github.com/aristanetworks/avd/pull/4299
-- Refactor(eos_cli_config_gen): Remove error handling for missing name in hardware-counters by @gmuloc in https://github.com/aristanetworks/avd/pull/4302
-- Cut(eos_designs): Remove deprecated keys marked `removed: true` in version 4.0.0 by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4312
-- Cut(eos_designs): Remove deprecated keys from bgp_peer_groups by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4307
-- Cut(eos_cli_config_gen): Remove the deprecated keys for vlan_interfaces  by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4305
-- Cut: Remove deprecated Ansible plugins by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4291
-- Refactor(eos_validate_state): Keep only ANTA mode in eos_validate_state by @gmuloc in https://github.com/aristanetworks/avd/pull/4286
-- Cut(eos_cli_config_gen): Remove deprecated keys from router_bgp data model by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4311
-- Cut(eos_cli_config_gen): Remove the deprecated keys for name-server by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4290
-- Cut(eos_cli_config_gen): Remove deprecated keys enable_vrfs and octa  from management_api_gnmi data model by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4296
-- Cut(eos_cli_config_gen): Remove deprecated data model radius_servers by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4295
-- Cut(eos_cli_config_gen): Remove the deprecated keys for port-channel-interfaces by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4297
-- Cut(eos_cli_config_gen): Remove deprecated keys `address_family` and `isis_af_defaults` from router-isis data model by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4278
-- Cut(eos_designs): Remove deprecated key cvp_instance_ip by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4317
-- Cut(eos_designs): Remove deprecated key short_esi by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4319
-- Cut(eos_designs): Remove the deprecated ipv6_address_virtual key from SVI settings by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4314
-- Cut(eos_designs): Remove deprecated ptp data model by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4316
-- Cut(eos_cli_config_gen): Remove automatic conversion of dict-of-dicts to lists by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4320
-- Cut(eos_designs): Remove automatic conversion of dict-of-dicts to lists by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4321
-- Cut(eos_designs): Remove deprecated inband_management_subnet and inband_management_vlan keys by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4318
-- Refactor(eos_designs): Add helper to retrieve ip from ip prefix by @gmuloc in https://github.com/aristanetworks/avd/pull/4306
-- Cut(plugins): Remove convert_dicts filter plugin and integrations into schema tooling by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4323
-- Refactor(eos_cli_config_gen): Deprecate Upper case letter Vxlan1 to vxlan1 for vxlan_interface schema by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4250
-- Cut(eos_cli_config_gen): Removing 'null' as valid value of esp integrity and encryption from ip-security module by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4336
-- Refactor(eos_designs): Remove legacy interface_descriptions function by @gmuloc in https://github.com/aristanetworks/avd/pull/4300
-- Refactor(eos_designs,eos_cli_config_gen): Default validation_mode to error and remove conversion_mode by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4327
-- Feat(eos_designs, eos_validate_state): Updated the upper case letter Vxlan1 to vxlan1 for vxlan_interfaces structure config by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4347
-- Refactor(eos_designs): Deprecate `design.type`  and combine default `node_type_keys` by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4340
-- Refactor(eos_designs): Optimize eos_designs_structured_config file write by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4283
-- Refactor(eos_cli_config_gen): Remove type column from the documentation of ethernet-interfaces and port-channel-interfaces by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4363
-- Refactor(eos_cli_config_gen): Remove EOS default configuration by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4361
-- Bump: Python library cvprac>=1.4.0 by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4369
-- Refactor(eos_designs): Optimize handling of WAN internet exits by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4372
-- Refactor(eos_cli_config_gen): Allow duplicate value of `address` in `router_pim_sparse_mode.rp_addresses` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4366
-- Refactor(eos_cli_config_gen): Deprecate `community_lists` data model by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4396
-- Refactor(eos_cli_config_gen): Remove hack for ansible 2.12 for arp by @gmuloc in https://github.com/aristanetworks/avd/pull/4404
-- Refactor(eos_designs): Move documentation to Python by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4364
-- Refactor(eos_designs): Move default platform_settings. network_services_keys and connected_endpoints_keys to schema by @gmuloc in https://github.com/aristanetworks/avd/pull/4395
-- Refactor(eos_cli_config_gen): Deprecation of `type` key from ethernet and port-channel interfaces by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4416
-- Refactor(cv_deploy): Optimize push of configlets with version aware API calls by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4419
-- Refactor(eos_cli_config_gen): Rearrange eos-intended-config based on eos cli by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4411
-- Refactor(eos_designs): Remove "preview" from flow_tracking_settings by @gmuloc in https://github.com/aristanetworks/avd/pull/4472
-- Refactor(eos_designs): Use VRF ID instead of VRF VNI as offset for evpn underlay l3 multicast group by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4450
-- Cut: Remove Ansible tags from AVD roles by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4427
-- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4381
-- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order part 2 by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4449
-- Refactor(eos_cli_config_gen): Change the 'protocol' key to 'encapsulation' in interfaces-encapsulation model by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4509
-- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order part-3 by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4462
-- Refactor(eos_cli_config_gen): Rearrange `eos_cli_config_gen` output to match with EOS - Part 4 by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4487
-- Refactor(eos_designs): Change default of redistribute_mlag_ibgp_peering_vrfs to false by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4499
-- Refactor(eos_cli_config_gen): Rearrange the order of `management api http` in eos-intended-config based on eos cli by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4535
-- Refactor(eos_cli_config_gen): Improve schema for redistributes_routes under address_family_ipv4_multicast, address_family_ipv6 and vrfs for router_bgp by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4359
-- Refactor(eos_designs): Move debug vars dump to action plugin instead of it's own task by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4540
-- Refactor(eos_cli_config_gen): Rearrange the eos-cli config for `vlan-interfaces` to match with EOS by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4488
-- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order - Part 6 by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4546
-- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order for router-isis by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4555
-- Refactor(eos_designs): Setting ospf.area default values to 0.0.0.0 by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4536
-- Refactor(eos_designs): Better error messages for missing keys by @gmuloc in https://github.com/aristanetworks/avd/pull/4541
-- Refactor(eos_cli_config_gen): Improve schemas with `primary_key/required` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4563
-- Refactor(plugins): Emit errors when both deprecated and new keys are set by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4562
-- Refactor(eos_cli_config_gen): Improved redistribute data models under router_bgp by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4550
-- Refactor(eos_cli_config_gen): Rearrange generated CLI for qos queues under interfaces and qos_profiles by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4579
-- Refactor(eos_cli_config_gen): Rearrange the CLI for platform by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4578
-- Refactor(eos_cli_config_gen): Rearrange the eos-cli config for router-bgp to match with EOS by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4566
-- Refactor(eos_cli_config_gen): Rearrange eos_cli_config_gen commands to match with EOS sequence - Part 5 by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4549
-- Refactor(eos_designs): Changed the redistribute_routes data model by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4544
-- Refactor(eos_cli_config_gen): Rearrange eos_cli output to match with eos for `port-channel-interfaces` by @laxmikantchintakindi in https://github.com/aristanetworks/avd/pull/4557
-- Bump: anta>=1.1.0 by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4586
-- Refactor(eos_cli_config_gen): Rearrange the eos-cli config for tap-aggregation to match with EOS by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/4585
-- Refactor(eos_cli_config_gen): Rearrange the eos-cli config for ethernet-interfaces to match with EOS by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/4569
-- Refactor(eos_cli_config_gen): Rearrange generated CLI for `traffic-policies`, `system` and `static-routes` by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/4590
-- Cut: Remove deprecated deploy_to_cv role by @gmuloc in https://github.com/aristanetworks/avd/pull/4609
-- Bump: arista.cvp Ansible collection requirement to latest version by @carlbuchmann in https://github.com/aristanetworks/avd/pull/4643
-- Bump: Add support for Python3.13 by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/4651
+- Bump: Minimum Python version 3.10 by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4276>
+- Cut(eos_cli_config_gen): Remove the deprecated keys for event-handlers by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4279>
+- Cut(eos_cli_config_gen): Remove deprecated key entropy_source from management_security data model by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4277>
+- Cut(eos_cli_config_gen): Remove the deprecated key local_interface from stun server data model by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4274>
+- Cut(eos_cli_config_gen): Remove deprecated key cvcompression from daemon_terminattr data model by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4288>
+- Cut(eos_cli_config_gen): Remove the deprecated keys for flow-trackings by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4294>
+- Cut(eos_cli_config_gen): Remove deprecated key MIB_family_name from snmp_server data model  by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4289>
+- Cut(eos_cli_config_gen,eos_designs): Remove deprecated jsonschema files by @gmuloc in <https://github.com/aristanetworks/avd/pull/4299>
+- Refactor(eos_cli_config_gen): Remove error handling for missing name in hardware-counters by @gmuloc in <https://github.com/aristanetworks/avd/pull/4302>
+- Cut(eos_designs): Remove deprecated keys marked `removed: true` in version 4.0.0 by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4312>
+- Cut(eos_designs): Remove deprecated keys from bgp_peer_groups by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4307>
+- Cut(eos_cli_config_gen): Remove the deprecated keys for vlan_interfaces  by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4305>
+- Cut: Remove deprecated Ansible plugins by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4291>
+- Refactor(eos_validate_state): Keep only ANTA mode in eos_validate_state by @gmuloc in <https://github.com/aristanetworks/avd/pull/4286>
+- Cut(eos_cli_config_gen): Remove deprecated keys from router_bgp data model by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4311>
+- Cut(eos_cli_config_gen): Remove the deprecated keys for name-server by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4290>
+- Cut(eos_cli_config_gen): Remove deprecated keys enable_vrfs and octa  from management_api_gnmi data model by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4296>
+- Cut(eos_cli_config_gen): Remove deprecated data model radius_servers by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4295>
+- Cut(eos_cli_config_gen): Remove the deprecated keys for port-channel-interfaces by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4297>
+- Cut(eos_cli_config_gen): Remove deprecated keys `address_family` and `isis_af_defaults` from router-isis data model by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4278>
+- Cut(eos_designs): Remove deprecated key cvp_instance_ip by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4317>
+- Cut(eos_designs): Remove deprecated key short_esi by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4319>
+- Cut(eos_designs): Remove the deprecated ipv6_address_virtual key from SVI settings by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4314>
+- Cut(eos_designs): Remove deprecated ptp data model by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4316>
+- Cut(eos_cli_config_gen): Remove automatic conversion of dict-of-dicts to lists by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4320>
+- Cut(eos_designs): Remove automatic conversion of dict-of-dicts to lists by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4321>
+- Cut(eos_designs): Remove deprecated inband_management_subnet and inband_management_vlan keys by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4318>
+- Refactor(eos_designs): Add helper to retrieve ip from ip prefix by @gmuloc in <https://github.com/aristanetworks/avd/pull/4306>
+- Cut(plugins): Remove convert_dicts filter plugin and integrations into schema tooling by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4323>
+- Refactor(eos_cli_config_gen): Deprecate Upper case letter Vxlan1 to vxlan1 for vxlan_interface schema by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4250>
+- Cut(eos_cli_config_gen): Removing 'null' as valid value of esp integrity and encryption from ip-security module by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4336>
+- Refactor(eos_designs): Remove legacy interface_descriptions function by @gmuloc in <https://github.com/aristanetworks/avd/pull/4300>
+- Refactor(eos_designs,eos_cli_config_gen): Default validation_mode to error and remove conversion_mode by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4327>
+- Feat(eos_designs, eos_validate_state): Updated the upper case letter Vxlan1 to vxlan1 for vxlan_interfaces structure config by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4347>
+- Refactor(eos_designs): Deprecate `design.type`  and combine default `node_type_keys` by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4340>
+- Refactor(eos_designs): Optimize eos_designs_structured_config file write by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4283>
+- Refactor(eos_cli_config_gen): Remove type column from the documentation of ethernet-interfaces and port-channel-interfaces by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4363>
+- Refactor(eos_cli_config_gen): Remove EOS default configuration by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4361>
+- Bump: Python library cvprac>=1.4.0 by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4369>
+- Refactor(eos_designs): Optimize handling of WAN internet exits by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4372>
+- Refactor(eos_cli_config_gen): Allow duplicate value of `address` in `router_pim_sparse_mode.rp_addresses` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4366>
+- Refactor(eos_cli_config_gen): Deprecate `community_lists` data model by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4396>
+- Refactor(eos_cli_config_gen): Remove hack for ansible 2.12 for arp by @gmuloc in <https://github.com/aristanetworks/avd/pull/4404>
+- Refactor(eos_designs): Move documentation to Python by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4364>
+- Refactor(eos_designs): Move default platform_settings. network_services_keys and connected_endpoints_keys to schema by @gmuloc in <https://github.com/aristanetworks/avd/pull/4395>
+- Refactor(eos_cli_config_gen): Deprecation of `type` key from ethernet and port-channel interfaces by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4416>
+- Refactor(cv_deploy): Optimize push of configlets with version aware API calls by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4419>
+- Refactor(eos_cli_config_gen): Rearrange eos-intended-config based on eos cli by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4411>
+- Refactor(eos_designs): Remove "preview" from flow_tracking_settings by @gmuloc in <https://github.com/aristanetworks/avd/pull/4472>
+- Refactor(eos_designs): Use VRF ID instead of VRF VNI as offset for evpn underlay l3 multicast group by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4450>
+- Cut: Remove Ansible tags from AVD roles by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4427>
+- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4381>
+- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order part 2 by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4449>
+- Refactor(eos_cli_config_gen): Change the 'protocol' key to 'encapsulation' in interfaces-encapsulation model by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4509>
+- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order part-3 by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4462>
+- Refactor(eos_cli_config_gen): Rearrange `eos_cli_config_gen` output to match with EOS - Part 4 by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4487>
+- Refactor(eos_designs): Change default of redistribute_mlag_ibgp_peering_vrfs to false by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4499>
+- Refactor(eos_cli_config_gen): Rearrange the order of `management api http` in eos-intended-config based on eos cli by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4535>
+- Refactor(eos_cli_config_gen): Improve schema for redistributes_routes under address_family_ipv4_multicast, address_family_ipv6 and vrfs for router_bgp by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4359>
+- Refactor(eos_designs): Move debug vars dump to action plugin instead of it's own task by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4540>
+- Refactor(eos_cli_config_gen): Rearrange the eos-cli config for `vlan-interfaces` to match with EOS by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4488>
+- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order - Part 6 by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4546>
+- Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order for router-isis by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4555>
+- Refactor(eos_designs): Setting ospf.area default values to 0.0.0.0 by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4536>
+- Refactor(eos_designs): Better error messages for missing keys by @gmuloc in <https://github.com/aristanetworks/avd/pull/4541>
+- Refactor(eos_cli_config_gen): Improve schemas with `primary_key/required` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4563>
+- Refactor(plugins): Emit errors when both deprecated and new keys are set by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4562>
+- Refactor(eos_cli_config_gen): Improved redistribute data models under router_bgp by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4550>
+- Refactor(eos_cli_config_gen): Rearrange generated CLI for qos queues under interfaces and qos_profiles by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4579>
+- Refactor(eos_cli_config_gen): Rearrange the CLI for platform by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4578>
+- Refactor(eos_cli_config_gen): Rearrange the eos-cli config for router-bgp to match with EOS by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4566>
+- Refactor(eos_cli_config_gen): Rearrange eos_cli_config_gen commands to match with EOS sequence - Part 5 by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4549>
+- Refactor(eos_designs): Changed the redistribute_routes data model by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4544>
+- Refactor(eos_cli_config_gen): Rearrange eos_cli output to match with eos for `port-channel-interfaces` by @laxmikantchintakindi in <https://github.com/aristanetworks/avd/pull/4557>
+- Bump: anta>=1.1.0 by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4586>
+- Refactor(eos_cli_config_gen): Rearrange the eos-cli config for tap-aggregation to match with EOS by @Shivani-gslab in <https://github.com/aristanetworks/avd/pull/4585>
+- Refactor(eos_cli_config_gen): Rearrange the eos-cli config for ethernet-interfaces to match with EOS by @Vibhu-gslab in <https://github.com/aristanetworks/avd/pull/4569>
+- Refactor(eos_cli_config_gen): Rearrange generated CLI for `traffic-policies`, `system` and `static-routes` by @MaheshGSLAB in <https://github.com/aristanetworks/avd/pull/4590>
+- Cut: Remove deprecated deploy_to_cv role by @gmuloc in <https://github.com/aristanetworks/avd/pull/4609>
+- Bump: arista.cvp Ansible collection requirement to latest version by @carlbuchmann in <https://github.com/aristanetworks/avd/pull/4643>
+- Bump: Add support for Python3.13 by @ClausHolbechArista in <https://github.com/aristanetworks/avd/pull/4651>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,17 +96,23 @@ plugins:
         - development/*
         - galaxy-importer/*
         - python-avd/*
+        - python/*
+        - rust/*
       regex:
         # Exclude examples common md snippets
         - 'ansible_collections\/arista\/avd\/examples\/common/.*'
         # Exclude all examples but single-dc-l3ls which is referenced in getting getting-started
         - 'ansible_collections\/arista\/avd\/examples\/((?!single-dc-l3ls).*)\/documentation\/.*'
+        # Previous regex matches the ipv6 scenario
+        - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls-ipv6/documentation\/.*'
+        # TODO: Not sure why this example is not present in our doc - discuss with other maintainers.
+        - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls-ipv6/README.md'
         # Exclude all single-dc-l3ls files not referenced in getting getting-started
         - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls\/documentation\/fabric\/((?!FABRIC-documentation.md).*)'
         - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls\/documentation\/devices\/((?!dc1-leaf1a.md).*)'
-        - '.*.py$'
-        - '.*.pyc$'
-        - '.*.j2$'
+        - ".*.py$"
+        - ".*.pyc$"
+        - ".*.j2$"
   - include_dir_to_nav
   - git-revision-date-localized:
       type: date
@@ -139,7 +145,7 @@ markdown_extensions:
       fractions: false
   - pymdownx.snippets:
       base_path:
-        - './'
+        - "./"
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
@@ -216,3 +222,7 @@ nav:
   - AVD Dev Containers:
       - Overview: docs/containers/overview.md
   - Support: docs/support/support_overview.md
+# Indicates which files should be added to the build site but not present in nav.
+not_in_nav: |
+  /ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/*
+  /docs/contribution/eos_designs_facts_internal/tables/eos_designs_facts.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,7 +105,6 @@ plugins:
         - 'ansible_collections\/arista\/avd\/examples\/((?!single-dc-l3ls).*)\/documentation\/.*'
         # Previous regex matches the ipv6 scenario
         - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls-ipv6/documentation\/.*'
-        # TODO: Not sure why this example is not present in our doc - discuss with other maintainers.
         - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls-ipv6/README.md'
         # Exclude all single-dc-l3ls files not referenced in getting getting-started
         - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls\/documentation\/fabric\/((?!FABRIC-documentation.md).*)'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,3 +226,4 @@ nav:
 not_in_nav: |
   /ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/*
   /docs/contribution/eos_designs_facts_internal/tables/eos_designs_facts.md
+  /docs/warn-eos-cli-config-keys-usage-in-eos-designs.md


### PR DESCRIPTION
## Change Summary

Our mkdocs site was building up a couple of INFO / WARNING

this PR addresses some of them

## Related Issue(s)

-
## Component(s) name

`documentation`

## Proposed changes

* add `not_in_nav` option + update `excluded` files
* cleanup some mkdocstring python option for pyavd documentation that was triggering a deprecation warning and was not in used anywhere it seems.

## How to test

From AVD repo root:

run `mkdocs serve` in devel vs in this PR and notice the reduced noise when starting the documentation.

the following should be left (and we need to look in to tables generation for this so later PR):

```
INFO    -  Doc file 'ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md' contains a
           link '##', but there is no such anchor on this page.
INFO    -  Doc file 'ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/role-configuration.md' contains
           a link '##', but there is no such anchor on this page.
INFO    -  Doc file 'ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md' contains a link
           '##', but there is no such anchor on this page.
INFO    -  Doc file 'ansible_collections/arista/avd/roles/eos_designs/docs/role-configuration.md' contains a link
           '##', but there is no such anchor on this page.
INFO    -  Doc file 'ansible_collections/arista/avd/roles/eos_designs/docs/how-to/cloudvision-tags.md' contains a
           link '##', but there is no such anchor on this page.
INFO    -  Doc file
           'ansible_collections/arista/avd/roles/eos_designs/docs/how-to/custom-structured-configuration.md'
           contains a link '##', but there is no such anchor on this page.
INFO    -  Doc file 'ansible_collections/arista/avd/roles/eos_designs/docs/how-to/ptp.md' contains a link '##',
           but there is no such anchor on this page.
INFO    -  Doc file 'docs/contribution/eos_designs_facts_internal/tables/eos_designs_facts.md' contains a link
           '##', but there is no such anchor on this page.

```

## Checklist

### User Checklist

- [x] Need to discuss the fact that l3ls-single-dc README.md is not part of our nav. is it on purpose? (I can't recall :) )
    * yes is the answer

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
