### PR TITLE
CI: Run additional tasks when we change requirements

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -54,10 +54,7 @@ jobs:
       eos_design: ${{ steps.filter.outputs.eos_design }}
       config_gen: ${{ steps.filter.outputs.config_gen }}
       pyavd: ${{ steps.filter.outputs.pyavd }}
-      cloudvision: ${{ steps.filter.outputs.cloudvision }}
-      plugins: ${{ steps.filter.outputs.plugins }}
       requirements: ${{ steps.filter.outputs.requirements }}
-      docs: ${{ steps.filter.outputs.docs }}
       anta_runner: ${{ steps.filter.outputs.anta_runner }}
       rust_src_or_ci_changed: ${{ steps.filter.outputs.rust_src_or_ci_changed }}
     steps:
@@ -91,14 +88,6 @@ jobs:
               - 'ansible_collections/arista/avd/meta/runtime.yml'
               - '.github/requirements-ci-dev.txt'
               - '.github/workflows/pull-request-management.yml'
-            docs:
-              - '.github/workflows/pull-request-management.yml'
-              - 'mkdocs.yml'
-              - 'ansible_collections/arista/avd/docs/**'
-              - 'ansible_collections/arista/avd/roles/**/*.md'
-              - 'ansible_collections/arista/avd/**/*.md'
-              - 'ansible_collections/arista/avd/README.md'
-              - 'ansible_collections/arista/avd/**/*.schema.yml'
             pyavd:
               - 'python-avd/*'
               - 'python-avd/**/*'
@@ -193,6 +182,7 @@ jobs:
     name: Validate eos_cli_config_gen
     runs-on: ubuntu-latest
     needs: [build_pyavd, file-changes]
+    if: needs.file-changes.outputs.config_gen == 'true' || needs.file-changes.outputs.requirements == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -206,7 +196,6 @@ jobs:
         include:
           - avd_scenario: "eos_cli_config_gen"
             ansible_version: "ansible-core==2.16.0"
-    if: needs.file-changes.outputs.config_gen == 'true'
     steps:
       - uses: actions/checkout@v5
       - name: Download pyavd Artifact
@@ -235,6 +224,8 @@ jobs:
   molecule_eos_designs:
     name: Validate eos_designs
     runs-on: ubuntu-latest
+    needs: [build_pyavd, file-changes]
+    if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true' || needs.file-changes.outputs.requirements == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -266,8 +257,6 @@ jobs:
             ansible_version: "ansible-core<2.18.0"
           - avd_scenario: "eos_designs_unit_tests"
             ansible_version: "ansible-core<2.19.0"
-    needs: [build_pyavd, file-changes]
-    if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true'
     steps:
       - uses: actions/checkout@v5
       - name: Download pyavd Artifact
@@ -290,7 +279,7 @@ jobs:
     name: Validate eos_designs with minimum requirements
     runs-on: ubuntu-latest
     needs: [build_pyavd, file-changes]
-    if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true'
+    if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true' || needs.file-changes.outputs.requirements == 'true'
     steps:
       - uses: actions/checkout@v5
       - name: Download pyavd Artifact
@@ -327,6 +316,8 @@ jobs:
   molecule_anta_runner:
     name: Validate anta_runner
     runs-on: ubuntu-latest
+    needs: [build_pyavd, file-changes]
+    if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.anta_runner == 'true' || needs.file-changes.outputs.requirements == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -337,8 +328,6 @@ jobs:
         include:
           - avd_scenario: "anta_runner"
             ansible_version: "ansible-core==2.16.0"
-    needs: [build_pyavd, file-changes]
-    if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.anta_runner == 'true'
     steps:
       - uses: actions/checkout@v5
       - name: Download pyavd Artifact
@@ -565,7 +554,8 @@ jobs:
     if: |
       needs.file-changes.outputs.eos_design == 'true' ||
       needs.file-changes.outputs.config_gen == 'true' ||
-      needs.file-changes.outputs.pyavd == 'true'
+      needs.file-changes.outputs.pyavd == 'true' ||
+      needs.file-changes.outputs.requirements == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -675,13 +665,11 @@ jobs:
         # https://github.com/actions/runner-images/issues/13046
         # the next update will be macos-15-intel
         os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            windows-latest,
-            macos-14,
-            macos-latest,
-          ]
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - windows-latest
+          - macos-14
+          - macos-latest
     steps:
       - uses: actions/checkout@v5
         # This is needed for arm machines since they don't ship with 2024 edition.
@@ -736,13 +724,11 @@ jobs:
         # https://github.com/actions/runner-images/issues/13046
         # the next update will be macos-15-intel
         os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            windows-latest,
-            macos-14,
-            macos-latest,
-          ]
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - windows-latest
+          - macos-14
+          - macos-latest
         python: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Change Summary

CI is sad, because Sonar is sad, because Jobs are skipped, because some PR don't trigger said job. So coverage file is missing and so Sonar is sad. Especially in merge-queue

## Related Issue(s)

Sad CI

## Component(s) name

`ci`

## Proposed changes

- [ ] Make CI happy again by running pyavd and its coverage and other stuff EVEN when we ONLY change the requirements
- [ ] clean up some old stuff in files-change we were not using anymore (sometimes for months or maybe years)

## How to test

Hopefully CI is 🟢 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
