### PR TITLE
CI: Capping pydantic<2.12 for CI

### DIFF
--- a/.github/requirements-ci-molecule.txt
+++ b/.github/requirements-ci-molecule.txt
@@ -2,4 +2,4 @@
 molecule>=6.0
 molecule-plugins[docker]>=23.4.0
 # temporarily capping pydantic for CI
-pydantic<2.21
+pydantic<2.12

--- a/.github/requirements-ci-molecule.txt
+++ b/.github/requirements-ci-molecule.txt
@@ -1,3 +1,5 @@
 # Waiting for pip 25.1 release to move these dependencies to dependency-group in pyproject.toml
 molecule>=6.0
 molecule-plugins[docker]>=23.4.0
+# temporarily capping pydantic for CI
+pydantic<2.21

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -5,7 +5,7 @@ anta==1.5.0
 cryptography>=43.0.0
 netaddr>=0.7.19
 PyYAML>=6.0.0
-# temporarilty capping pydantic for CI
+# temporarily capping pydantic for CI
 pydantic<2.12
 # dev requirements
 ansible-core>=2.16.0,<2.19.0

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -5,6 +5,8 @@ anta==1.5.0
 cryptography>=43.0.0
 netaddr>=0.7.19
 PyYAML>=6.0.0
+# temporarilty capping pydantic for CI
+pydantic<2.12
 # dev requirements
 ansible-core>=2.16.0,<2.19.0
 ansible-doc-extractor>=0.1.10

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -41,7 +41,7 @@ pytest = [
     "anta>=1.5.0",
     "pytest",
     "pytest-asyncio",
-    "pydantic>=2.3.0<2.12",
+    "pydantic>=2.3.0,<2.12",
     "referencing>=0.35.0",
 ]
 coverage = [

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -41,7 +41,7 @@ pytest = [
     "anta>=1.5.0",
     "pytest",
     "pytest-asyncio",
-    "pydantic>=2.3.0",
+    "pydantic>=2.3.0<2.12",
     "referencing>=0.35.0",
 ]
 coverage = [


### PR DESCRIPTION
## Change Summary

ANTA is failing currently with pydantic 2.12 released last night.
cf https://github.com/pydantic/pydantic/issues/12348

for now unblocking CI for the rest