### PR TITLE
Refactor: Clean-up forgotten is_deployed usage

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/cv_workflow.py
+++ b/ansible_collections/arista/avd/plugins/action/cv_workflow.py
@@ -34,7 +34,7 @@ try:
         CVWorkspace,
         DeployToCvResult,
     )
-    from pyavd._utils import default, get, strip_empties_from_dict
+    from pyavd._utils import get, strip_empties_from_dict
 
     HAS_PYAVD = True
 except ImportError:
@@ -348,7 +348,7 @@ class ActionModule(ActionBase):
             # No structured config file.
             structured_config = {}
 
-        if not default(get(structured_config, "metadata.is_deployed"), get(structured_config, "is_deployed", default=True)):
+        if not get(structured_config, "metadata.is_deployed", default=True):
             del structured_config
             return ([], [], [], [])
 

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -23,9 +23,8 @@ For additional information, please see [versioning](../versioning/semantic-versi
 ### Changes to requirements
 
 - Python requirements:
-  - PyAVD no longer requires the `cvprac`,  treelib` and `jsonschema` libraries.
-  - PyAVD now requires the `cryptography` Python library to be version 43.0.0 or higher.<br>
-    The latest version can be installed with `pip install "cryptography>=43.0.0" --upgrade`.
+  - PyAVD no longer requires the `cvprac`,  `treelib` and `jsonschema` libraries.
+  - PyAVD now requires the `cryptography` Python library to be version 43.0.0 or higher. It will be installed automatically when upgrading pyavd.
   - PyAVD now requires the `python-socks[asyncio]` Python library to be version 2.7.2 or higher. It will be installed automatically when upgrading pyavd.
 - Ansible collection requirements:
   - `arista.avd` Ansible collection no longer requires the `arista.cvp` and `ansible.utils` collections.

--- a/python-avd/pyavd/api/_anta/minimal_structured_config.py
+++ b/python-avd/pyavd/api/_anta/minimal_structured_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pyavd._utils import default, get
+from pyavd._utils import get
 
 
 @dataclass(frozen=True)
@@ -59,7 +59,7 @@ def get_minimal_structured_configs(structured_configs: dict[str, dict]) -> dict[
         # Create the minimal structured configuration
         minimal_structured_configs[device] = MinimalStructuredConfig(
             hostname=structured_config["hostname"],
-            is_deployed=default(get(structured_config, "metadata.is_deployed"), get(structured_config, "is_deployed", default=False)),
+            is_deployed=get(structured_config, "metadata.is_deployed", default=False),
             dns_domain=get(structured_config, "dns_domain"),
             ethernet_interfaces=minimal_ethernet_interfaces,
         )

--- a/python-avd/pyavd/get_device_test_catalog.py
+++ b/python-avd/pyavd/get_device_test_catalog.py
@@ -7,7 +7,7 @@ from logging import getLogger
 from time import perf_counter
 from typing import TYPE_CHECKING
 
-from pyavd._utils import default, get
+from pyavd._utils import get
 
 if TYPE_CHECKING:
     from ._anta.lib import AntaCatalog
@@ -67,7 +67,7 @@ def get_device_test_catalog(
     start_time = perf_counter()
     LOGGER.debug("<%s> Generating ANTA catalog with settings: %s", hostname, settings.model_dump(mode="json"))
 
-    if settings.ignore_is_deployed is False and not default(get(structured_config, "metadata.is_deployed", get(structured_config, "is_deployed", False))):
+    if settings.ignore_is_deployed is False and not get(structured_config, "metadata.is_deployed", default=False):
         LOGGER.info("<%s> Device is not deployed, returning an empty catalog", hostname)
         return AntaCatalog()
 


### PR DESCRIPTION
## Change Summary

cf title

## Component(s) name

`arista.avd.anta_runner`

## Proposed changes

* clean up usage of removed key
* adjust release-notes for other pending little stuff

## How to test

nothing should happen

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
