### PR TITLE
Fix(eos_designs): Escape asdot in as-path access-list for WAN HA (#6016)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-leaf11.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-leaf11.cfg
@@ -1,0 +1,88 @@
+!
+no enable password
+no aaa root
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname asdot-for-wan-ha-leaf11
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_asdot-for-wan-ha-transit1A1_Ethernet52
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.17.0.0/31
+!
+interface Ethernet2
+   description P2P_asdot-for-wan-ha-transit1B1_Ethernet52
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.17.0.2/31
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 192.168.45.1/32
+!
+interface Loopback1
+   description VXLAN_TUNNEL_SOURCE
+   no shutdown
+   ip address 192.168.255.1/32
+!
+interface Vxlan1
+   description asdot-for-wan-ha-leaf11_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:1c:73:00:00:01
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.45.0/24 eq 32
+   seq 20 permit 192.168.255.0/24 eq 32
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65199
+   router-id 192.168.45.1
+   update wait-install
+   no bgp default ipv4-unicast
+   maximum-paths 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.17.0.1 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.17.0.1 remote-as 65000.1
+   neighbor 172.17.0.1 description asdot-for-wan-ha-transit1A1_Ethernet52
+   neighbor 172.17.0.3 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.17.0.3 remote-as 65000.1
+   neighbor 172.17.0.3 description asdot-for-wan-ha-transit1B1_Ethernet52
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-leaf11.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-leaf11.cfg
@@ -12,6 +12,13 @@ hostname asdot-for-wan-ha-leaf11
 !
 vrf instance MGMT
 !
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
 interface Ethernet1
    description P2P_asdot-for-wan-ha-transit1A1_Ethernet52
    no shutdown
@@ -60,7 +67,7 @@ router bgp 65199
    router-id 192.168.45.1
    update wait-install
    no bgp default ipv4-unicast
-   maximum-paths 4
+   maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1A1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1A1.cfg
@@ -1,0 +1,313 @@
+!
+no enable password
+no aaa root
+!
+flow tracking hardware
+   tracker FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 300000
+      exporter CV-TELEMETRY
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 3600000
+   no shutdown
+!
+service routing protocols model multi-agent
+!
+kernel software forwarding ecmp
+!
+hostname asdot-for-wan-ha-transit1A1
+!
+router adaptive-virtual-topology
+   topology role transit region
+   region AVD_Land_West id 42
+   zone AVD_Land_West-ZONE id 1
+   site Site422 id 422
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-POLICY-CONTROL-PLANE
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-CONTROL-PLANE id 254
+!
+router path-selection
+   tcp mss ceiling ipv4 ingress
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1.42
+      !
+      peer dynamic
+   !
+   path-group LAN_HA id 65535
+      flow assignment lan
+      !
+      local interface Ethernet52
+      !
+      peer static router-ip 192.168.142.2
+         name asdot-for-wan-ha-transit1B1
+         ipv4 address 172.17.0.3
+   !
+   path-group MPLS id 100
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet2.42
+      !
+      peer dynamic
+   !
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
+!
+spanning-tree mode none
+!
+vrf instance MGMT
+!
+management security
+   !
+   ssl profile STUN-DTLS
+      tls versions 1.2
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate STUN-DTLS.crt key STUN-DTLS.key
+!
+ip security
+   ike policy CP-IKE-POLICY
+      local-id 192.168.142.1
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
+      dpd 10 50 clear
+      mode transport
+   !
+   key controller
+      profile DP-PROFILE
+!
+interface Dps1
+   description DPS Interface
+   mtu 9194
+   flow tracker hardware FLOW-TRACKER
+   ip address 192.168.142.1/32
+!
+interface Ethernet1
+   no shutdown
+   no switchport
+!
+interface Ethernet1.42
+   description Comcast
+   no shutdown
+   encapsulation dot1q vlan 42
+   ip address dhcp
+   dhcp client accept default-route
+!
+interface Ethernet2
+   no shutdown
+   no switchport
+!
+interface Ethernet2.42
+   description Colt_10666
+   no shutdown
+   encapsulation dot1q vlan 666
+   ip address 172.16.6.6/31
+!
+interface Ethernet52
+   description P2P_asdot-for-wan-ha-leaf11_Ethernet1
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.17.0.1/31
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 192.168.42.1/32
+!
+interface Vxlan1
+   description asdot-for-wan-ha-transit1A1_VTEP
+   vxlan source-interface Dps1
+   vxlan udp-port 4789
+   vxlan vrf default vni 1
+!
+application traffic recognition
+   !
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
+   !
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip as-path access-list ASPATH-WAN permit 65000\.1 any
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.1:422
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.42.0/24 eq 32
+!
+ip prefix-list PL-WAN-HA-PEER-PREFIXES
+   seq 10 permit 172.17.0.2/31
+!
+ip prefix-list PL-WAN-HA-PREFIXES
+   seq 10 permit 172.17.0.0/31
+!
+route-map RM-BGP-UNDERLAY-PEERS-IN permit 10
+   description Allow WAN HA peer interface prefixes
+   match ip address prefix-list PL-WAN-HA-PEER-PREFIXES
+!
+route-map RM-BGP-UNDERLAY-PEERS-IN deny 20
+   description Deny other routes from the HA peer
+   match as-path ASPATH-WAN
+!
+route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
+   description Mark prefixes originated from the LAN
+   set extcommunity soo 192.168.42.1:422 additive
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
+   description Make routes learned from WAN HA peer less preferred on LAN routers
+   match route-type internal
+   match tag 50
+   set metric 50
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   set extcommunity soo 192.168.42.1:422 additive
+!
+route-map RM-CONN-2-BGP permit 50
+   match ip address prefix-list PL-WAN-HA-PREFIXES
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 192.168.42.1:422 additive
+!
+route-map RM-WAN-HA-PEER-IN permit 10
+   description Set tag 50 on routes received from HA peer over EVPN
+   set tag 50
+!
+route-map RM-WAN-HA-PEER-OUT permit 10
+   description Make EVPN routes learned from WAN less preferred on HA peer
+   match route-type internal
+   set local-preference 50
+!
+route-map RM-WAN-HA-PEER-OUT permit 20
+   description Make locally injected routes less preferred on HA peer
+   set local-preference 75
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000.1
+   router-id 192.168.42.1
+   update wait-install
+   no bgp default ipv4-unicast
+   maximum-paths 16
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS allowas-in 1
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000.1
+   neighbor WAN-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.17.0.0 remote-as 65199
+   neighbor 172.17.0.0 description asdot-for-wan-ha-leaf11_Ethernet1
+   neighbor 192.168.142.2 remote-as 65000.1
+   neighbor 192.168.142.2 update-source Dps1
+   neighbor 192.168.142.2 description asdot-for-wan-ha-transit1B1
+   neighbor 192.168.142.2 route-reflector-client
+   neighbor 192.168.142.2 route-map RM-WAN-HA-PEER-IN in
+   neighbor 192.168.142.2 route-map RM-WAN-HA-PEER-OUT out
+   neighbor 192.168.142.2 send-community
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor WAN-OVERLAY-PEERS encapsulation path-selection
+      neighbor 192.168.142.2 activate
+      neighbor 192.168.142.2 encapsulation path-selection
+      neighbor default next-hop-self received-evpn-routes route-type ip-prefix
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      no neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      path-selection
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   vrf default
+      rd 192.168.42.1:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+!
+router traffic-engineering
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1A1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1A1.cfg
@@ -2,6 +2,8 @@
 no enable password
 no aaa root
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -13,8 +15,6 @@ flow tracking hardware
    no shutdown
 !
 service routing protocols model multi-agent
-!
-kernel software forwarding ecmp
 !
 hostname asdot-for-wan-ha-transit1A1
 !
@@ -82,6 +82,13 @@ router path-selection
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1B1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1B1.cfg
@@ -1,0 +1,313 @@
+!
+no enable password
+no aaa root
+!
+flow tracking hardware
+   tracker FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 300000
+      exporter CV-TELEMETRY
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 3600000
+   no shutdown
+!
+service routing protocols model multi-agent
+!
+kernel software forwarding ecmp
+!
+hostname asdot-for-wan-ha-transit1B1
+!
+router adaptive-virtual-topology
+   topology role transit region
+   region AVD_Land_West id 42
+   zone AVD_Land_West-ZONE id 1
+   site Site422 id 422
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-POLICY-CONTROL-PLANE
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-CONTROL-PLANE id 254
+!
+router path-selection
+   tcp mss ceiling ipv4 ingress
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1.42
+      !
+      peer dynamic
+   !
+   path-group LAN_HA id 65535
+      flow assignment lan
+      !
+      local interface Ethernet52
+      !
+      peer static router-ip 192.168.142.1
+         name asdot-for-wan-ha-transit1A1
+         ipv4 address 172.17.0.1
+   !
+   path-group MPLS id 100
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet2.42
+      !
+      peer dynamic
+   !
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
+!
+spanning-tree mode none
+!
+vrf instance MGMT
+!
+management security
+   !
+   ssl profile STUN-DTLS
+      tls versions 1.2
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate STUN-DTLS.crt key STUN-DTLS.key
+!
+ip security
+   ike policy CP-IKE-POLICY
+      local-id 192.168.142.2
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
+      dpd 10 50 clear
+      mode transport
+   !
+   key controller
+      profile DP-PROFILE
+!
+interface Dps1
+   description DPS Interface
+   mtu 9194
+   flow tracker hardware FLOW-TRACKER
+   ip address 192.168.142.2/32
+!
+interface Ethernet1
+   no shutdown
+   no switchport
+!
+interface Ethernet1.42
+   description Comcast
+   no shutdown
+   encapsulation dot1q vlan 42
+   ip address dhcp
+   dhcp client accept default-route
+!
+interface Ethernet2
+   no shutdown
+   no switchport
+!
+interface Ethernet2.42
+   description Colt
+   no shutdown
+   encapsulation dot1q vlan 666
+   ip address 172.16.7.6/31
+!
+interface Ethernet52
+   description P2P_asdot-for-wan-ha-leaf11_Ethernet2
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.17.0.3/31
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 192.168.42.2/32
+!
+interface Vxlan1
+   description asdot-for-wan-ha-transit1B1_VTEP
+   vxlan source-interface Dps1
+   vxlan udp-port 4789
+   vxlan vrf default vni 1
+!
+application traffic recognition
+   !
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
+   !
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip as-path access-list ASPATH-WAN permit 65000\.1 any
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.1:422
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.42.0/24 eq 32
+!
+ip prefix-list PL-WAN-HA-PEER-PREFIXES
+   seq 10 permit 172.17.0.0/31
+!
+ip prefix-list PL-WAN-HA-PREFIXES
+   seq 10 permit 172.17.0.2/31
+!
+route-map RM-BGP-UNDERLAY-PEERS-IN permit 10
+   description Allow WAN HA peer interface prefixes
+   match ip address prefix-list PL-WAN-HA-PEER-PREFIXES
+!
+route-map RM-BGP-UNDERLAY-PEERS-IN deny 20
+   description Deny other routes from the HA peer
+   match as-path ASPATH-WAN
+!
+route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
+   description Mark prefixes originated from the LAN
+   set extcommunity soo 192.168.42.1:422 additive
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
+   description Make routes learned from WAN HA peer less preferred on LAN routers
+   match route-type internal
+   match tag 50
+   set metric 50
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   set extcommunity soo 192.168.42.1:422 additive
+!
+route-map RM-CONN-2-BGP permit 50
+   match ip address prefix-list PL-WAN-HA-PREFIXES
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 192.168.42.1:422 additive
+!
+route-map RM-WAN-HA-PEER-IN permit 10
+   description Set tag 50 on routes received from HA peer over EVPN
+   set tag 50
+!
+route-map RM-WAN-HA-PEER-OUT permit 10
+   description Make EVPN routes learned from WAN less preferred on HA peer
+   match route-type internal
+   set local-preference 50
+!
+route-map RM-WAN-HA-PEER-OUT permit 20
+   description Make locally injected routes less preferred on HA peer
+   set local-preference 75
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000.1
+   router-id 192.168.42.2
+   update wait-install
+   no bgp default ipv4-unicast
+   maximum-paths 16
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS allowas-in 1
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000.1
+   neighbor WAN-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.17.0.2 remote-as 65199
+   neighbor 172.17.0.2 description asdot-for-wan-ha-leaf11_Ethernet2
+   neighbor 192.168.142.1 remote-as 65000.1
+   neighbor 192.168.142.1 update-source Dps1
+   neighbor 192.168.142.1 description asdot-for-wan-ha-transit1A1
+   neighbor 192.168.142.1 route-reflector-client
+   neighbor 192.168.142.1 route-map RM-WAN-HA-PEER-IN in
+   neighbor 192.168.142.1 route-map RM-WAN-HA-PEER-OUT out
+   neighbor 192.168.142.1 send-community
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor WAN-OVERLAY-PEERS encapsulation path-selection
+      neighbor 192.168.142.1 activate
+      neighbor 192.168.142.1 encapsulation path-selection
+      neighbor default next-hop-self received-evpn-routes route-type ip-prefix
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      no neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      path-selection
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   vrf default
+      rd 192.168.42.2:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+!
+router traffic-engineering
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1B1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1B1.cfg
@@ -2,6 +2,8 @@
 no enable password
 no aaa root
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -13,8 +15,6 @@ flow tracking hardware
    no shutdown
 !
 service routing protocols model multi-agent
-!
-kernel software forwarding ecmp
 !
 hostname asdot-for-wan-ha-transit1B1
 !
@@ -82,6 +82,13 @@ router path-selection
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-leaf11.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-leaf11.yml
@@ -1,0 +1,125 @@
+aaa_root:
+  disabled: true
+config_end: true
+enable_password:
+  disabled: true
+ethernet_interfaces:
+- name: Ethernet1
+  description: P2P_asdot-for-wan-ha-transit1A1_Ethernet52
+  shutdown: false
+  mtu: 9214
+  ip_address: 172.17.0.0/31
+  peer: asdot-for-wan-ha-transit1A1
+  peer_interface: Ethernet52
+  peer_type: wan_router
+  switchport:
+    enabled: false
+- name: Ethernet2
+  description: P2P_asdot-for-wan-ha-transit1B1_Ethernet52
+  shutdown: false
+  mtu: 9214
+  ip_address: 172.17.0.2/31
+  peer: asdot-for-wan-ha-transit1B1
+  peer_interface: Ethernet52
+  peer_type: wan_router
+  switchport:
+    enabled: false
+hostname: asdot-for-wan-ha-leaf11
+ip_igmp_snooping:
+  globally_enabled: true
+ip_routing: true
+ip_virtual_router_mac_address: 00:1c:73:00:00:01
+loopback_interfaces:
+- name: Loopback0
+  description: ROUTER_ID
+  shutdown: false
+  ip_address: 192.168.45.1/32
+- name: Loopback1
+  description: VXLAN_TUNNEL_SOURCE
+  shutdown: false
+  ip_address: 192.168.255.1/32
+metadata:
+  is_deployed: true
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.45.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.255.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_bgp:
+  as: '65199'
+  router_id: 192.168.45.1
+  maximum_paths:
+    paths: 4
+  updates:
+    wait_install: true
+  bgp:
+    default:
+      ipv4_unicast: false
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    send_community: all
+    maximum_routes: 12000
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    ebgp_multihop: 3
+    send_community: all
+    maximum_routes: 0
+  neighbors:
+  - ip_address: 172.17.0.1
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65000.1'
+    peer: asdot-for-wan-ha-transit1A1
+    description: asdot-for-wan-ha-transit1A1_Ethernet52
+  - ip_address: 172.17.0.3
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65000.1'
+    peer: asdot-for-wan-ha-transit1B1
+    description: asdot-for-wan-ha-transit1B1_Ethernet52
+  redistribute:
+    connected:
+      enabled: true
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+service_routing_protocols_model: multi-agent
+transceiver_qsfp_default_mode_4x10: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+vxlan_interface:
+  vxlan1:
+    description: asdot-for-wan-ha-leaf11_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-leaf11.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-leaf11.yml
@@ -38,6 +38,10 @@ loopback_interfaces:
   description: VXLAN_TUNNEL_SOURCE
   shutdown: false
   ip_address: 192.168.255.1/32
+management_api_http:
+  enable_https: true
+  enable_vrfs:
+  - name: MGMT
 metadata:
   is_deployed: true
   fabric_name: EOS_DESIGNS_UNIT_TESTS
@@ -65,6 +69,7 @@ router_bgp:
   router_id: 192.168.45.1
   maximum_paths:
     paths: 4
+    ecmp: 4
   updates:
     wait_install: true
   bgp:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1A1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1A1.yml
@@ -1,0 +1,487 @@
+aaa_root:
+  disabled: true
+application_traffic_recognition:
+  field_sets:
+    ipv4_prefixes:
+    - name: PFX-PATHFINDERS
+  applications:
+    ipv4_applications:
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
+  application_profiles:
+  - name: APP-PROFILE-CONTROL-PLANE
+    applications:
+    - name: APP-CONTROL-PLANE
+as_path:
+  access_lists:
+  - name: ASPATH-WAN
+    entries:
+    - type: permit
+      match: 65000\.1
+config_end: true
+dps_interfaces:
+- name: Dps1
+  description: DPS Interface
+  mtu: 9194
+  ip_address: 192.168.142.1/32
+  flow_tracker:
+    hardware: FLOW-TRACKER
+enable_password:
+  disabled: true
+ethernet_interfaces:
+- name: Ethernet52
+  description: P2P_asdot-for-wan-ha-leaf11_Ethernet1
+  shutdown: false
+  mtu: 9214
+  ip_address: 172.17.0.1/31
+  peer: asdot-for-wan-ha-leaf11
+  peer_interface: Ethernet1
+  peer_type: l3leaf
+  switchport:
+    enabled: false
+- name: Ethernet1.42
+  description: Comcast
+  shutdown: false
+  encapsulation_dot1q:
+    vlan: 42
+  ip_address: dhcp
+  dhcp_client_accept_default_route: true
+  peer_type: l3_interface
+- name: Ethernet2.42
+  description: Colt_10666
+  shutdown: false
+  encapsulation_dot1q:
+    vlan: 666
+  ip_address: 172.16.6.6/31
+  peer_type: l3_interface
+- name: Ethernet1
+  shutdown: false
+  peer_type: l3_interface
+  switchport:
+    enabled: false
+- name: Ethernet2
+  shutdown: false
+  peer_type: l3_interface
+  switchport:
+    enabled: false
+flow_tracking:
+  hardware:
+    trackers:
+    - name: FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 300000
+      exporters:
+      - name: CV-TELEMETRY
+        collectors:
+        - host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 3600000
+    shutdown: false
+hostname: asdot-for-wan-ha-transit1A1
+ip_extcommunity_lists:
+- name: ECL-EVPN-SOO
+  entries:
+  - type: permit
+    extcommunities: soo 192.168.42.1:422
+ip_routing: true
+ip_security:
+  ike_policies:
+  - name: CP-IKE-POLICY
+    local_id: 192.168.142.1
+  sa_policies:
+  - name: DP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  profiles:
+  - name: DP-PROFILE
+    sa_policy: DP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890666
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  - name: CP-PROFILE
+    ike_policy: CP-IKE-POLICY
+    sa_policy: CP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  key_controller:
+    profile: DP-PROFILE
+kernel:
+  software_forwarding_ecmp: true
+loopback_interfaces:
+- name: Loopback0
+  description: ROUTER_ID
+  shutdown: false
+  ip_address: 192.168.42.1/32
+management_security:
+  ssl_profiles:
+  - name: STUN-DTLS
+    tls_versions: '1.2'
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
+    certificate:
+      file: STUN-DTLS.crt
+      key: STUN-DTLS.key
+metadata:
+  is_deployed: true
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: transit region
+    - name: Region
+      value: AVD_Land_West
+    - name: Zone
+      value: AVD_Land_West-ZONE
+    - name: Site
+      value: Site422
+    interface_tags:
+    - interface: Ethernet52
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet1.42
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Comcast
+    - interface: Ethernet2.42
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Colt
+      - name: Circuit
+        value: '10666'
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet2
+      tags:
+      - name: Type
+        value: lan
+  cv_pathfinder:
+    role: transit region
+    region: AVD_Land_West
+    zone: AVD_Land_West-ZONE
+    site: Site422
+    vtep_ip: 192.168.142.1
+    ssl_profile: STUN-DTLS
+    interfaces:
+    - name: Ethernet1.42
+      carrier: Comcast
+      pathgroup: INET
+    - name: Ethernet2.42
+      carrier: Colt
+      circuit_id: '10666'
+      pathgroup: MPLS
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.42.0/24 eq 32
+- name: PL-WAN-HA-PREFIXES
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.17.0.0/31
+- name: PL-WAN-HA-PEER-PREFIXES
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.17.0.2/31
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    set:
+    - extcommunity soo 192.168.42.1:422 additive
+  - sequence: 50
+    type: permit
+    match:
+    - ip address prefix-list PL-WAN-HA-PREFIXES
+- name: RM-BGP-UNDERLAY-PEERS-IN
+  sequence_numbers:
+  - sequence: 40
+    type: permit
+    description: Mark prefixes originated from the LAN
+    set:
+    - extcommunity soo 192.168.42.1:422 additive
+  - sequence: 10
+    type: permit
+    description: Allow WAN HA peer interface prefixes
+    match:
+    - ip address prefix-list PL-WAN-HA-PEER-PREFIXES
+  - sequence: 20
+    type: deny
+    description: Deny other routes from the HA peer
+    match:
+    - as-path ASPATH-WAN
+- name: RM-BGP-UNDERLAY-PEERS-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    description: Make routes learned from WAN HA peer less preferred on LAN routers
+    match:
+    - tag 50
+    - route-type internal
+    set:
+    - metric 50
+  - sequence: 20
+    type: permit
+- name: RM-EVPN-SOO-IN
+  sequence_numbers:
+  - sequence: 10
+    type: deny
+    match:
+    - extcommunity ECL-EVPN-SOO
+  - sequence: 20
+    type: permit
+- name: RM-EVPN-SOO-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - extcommunity soo 192.168.42.1:422 additive
+- name: RM-WAN-HA-PEER-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    description: Set tag 50 on routes received from HA peer over EVPN
+    set:
+    - tag 50
+- name: RM-WAN-HA-PEER-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    description: Make EVPN routes learned from WAN less preferred on HA peer
+    match:
+    - route-type internal
+    set:
+    - local-preference 50
+  - sequence: 20
+    type: permit
+    description: Make locally injected routes less preferred on HA peer
+    set:
+    - local-preference 75
+- name: RM-EVPN-EXPORT-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - extcommunity ECL-EVPN-SOO
+router_adaptive_virtual_topology:
+  topology_role: transit region
+  region:
+    name: AVD_Land_West
+    id: 42
+  zone:
+    name: AVD_Land_West-ZONE
+    id: 1
+  site:
+    name: Site422
+    id: 422
+  profiles:
+  - name: DEFAULT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-POLICY-CONTROL-PLANE
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  policies:
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-POLICY-CONTROL-PLANE
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: DEFAULT-POLICY-CONTROL-PLANE
+      id: 254
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_bgp:
+  as: '65000.1'
+  router_id: 192.168.42.1
+  maximum_paths:
+    paths: 16
+  updates:
+    wait_install: true
+  bgp:
+    default:
+      ipv4_unicast: false
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    send_community: all
+    maximum_routes: 12000
+    allowas_in:
+      enabled: true
+      times: 1
+    route_map_in: RM-BGP-UNDERLAY-PEERS-IN
+    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
+  - name: WAN-OVERLAY-PEERS
+    type: wan
+    remote_as: '65000.1'
+    update_source: Dps1
+    bfd: true
+    bfd_timers:
+      interval: 1000
+      min_rx: 1000
+      multiplier: 10
+    password: htm4AZe9mIQOO1uiMuGgYQ==
+    send_community: all
+    maximum_routes: 0
+    ttl_maximum_hops: 1
+  neighbors:
+  - ip_address: 172.17.0.0
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65199'
+    peer: asdot-for-wan-ha-leaf11
+    description: asdot-for-wan-ha-leaf11_Ethernet1
+  - ip_address: 192.168.142.2
+    remote_as: '65000.1'
+    peer: asdot-for-wan-ha-transit1B1
+    description: asdot-for-wan-ha-transit1B1
+    route_reflector_client: true
+    update_source: Dps1
+    route_map_in: RM-WAN-HA-PEER-IN
+    route_map_out: RM-WAN-HA-PEER-OUT
+    send_community: all
+  redistribute:
+    connected:
+      enabled: true
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    neighbor_default:
+      next_hop_self_received_evpn_routes:
+        enable: true
+    neighbors:
+    - ip_address: 192.168.142.2
+      activate: true
+      encapsulation: path-selection
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+      route_map_in: RM-EVPN-SOO-IN
+      route_map_out: RM-EVPN-SOO-OUT
+      encapsulation: path-selection
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: WAN-OVERLAY-PEERS
+      activate: false
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    path_selection:
+      roles:
+        producer: true
+  address_family_path_selection:
+    bgp:
+      additional_paths:
+        receive: true
+        send: any
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  vrfs:
+  - name: default
+    rd: 192.168.42.1:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+router_path_selection:
+  path_groups:
+  - name: INET
+    id: 101
+    ipsec_profile: CP-PROFILE
+    local_interfaces:
+    - name: Ethernet1.42
+    dynamic_peers:
+      enabled: true
+  - name: MPLS
+    id: 100
+    ipsec_profile: CP-PROFILE
+    local_interfaces:
+    - name: Ethernet2.42
+    dynamic_peers:
+      enabled: true
+  - name: LAN_HA
+    id: 65535
+    flow_assignment: lan
+    local_interfaces:
+    - name: Ethernet52
+    static_peers:
+    - router_ip: 192.168.142.2
+      name: asdot-for-wan-ha-transit1B1
+      ipv4_addresses:
+      - 172.17.0.3
+  load_balance_policies:
+  - name: LB-DEFAULT-POLICY-CONTROL-PLANE
+    path_groups:
+    - name: INET
+    - name: MPLS
+    - name: LAN_HA
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
+    - name: MPLS
+    - name: LAN_HA
+  tcp_mss_ceiling:
+    ipv4: auto
+router_traffic_engineering:
+  enabled: true
+service_routing_protocols_model: multi-agent
+spanning_tree:
+  mode: none
+transceiver_qsfp_default_mode_4x10: false
+vrfs:
+- name: MGMT
+  ip_routing: false
+vxlan_interface:
+  vxlan1:
+    description: asdot-for-wan-ha-transit1A1_VTEP
+    vxlan:
+      source_interface: Dps1
+      udp_port: 4789
+      vrfs:
+      - name: default
+        vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1A1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1A1.yml
@@ -1,5 +1,10 @@
 aaa_root:
   disabled: true
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 application_traffic_recognition:
   field_sets:
     ipv4_prefixes:
@@ -120,13 +125,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
-kernel:
-  software_forwarding_ecmp: true
 loopback_interfaces:
 - name: Loopback0
   description: ROUTER_ID
   shutdown: false
   ip_address: 192.168.42.1/32
+management_api_http:
+  enable_https: true
+  enable_vrfs:
+  - name: MGMT
 management_security:
   ssl_profiles:
   - name: STUN-DTLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1B1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1B1.yml
@@ -1,0 +1,484 @@
+aaa_root:
+  disabled: true
+application_traffic_recognition:
+  field_sets:
+    ipv4_prefixes:
+    - name: PFX-PATHFINDERS
+  applications:
+    ipv4_applications:
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
+  application_profiles:
+  - name: APP-PROFILE-CONTROL-PLANE
+    applications:
+    - name: APP-CONTROL-PLANE
+as_path:
+  access_lists:
+  - name: ASPATH-WAN
+    entries:
+    - type: permit
+      match: 65000\.1
+config_end: true
+dps_interfaces:
+- name: Dps1
+  description: DPS Interface
+  mtu: 9194
+  ip_address: 192.168.142.2/32
+  flow_tracker:
+    hardware: FLOW-TRACKER
+enable_password:
+  disabled: true
+ethernet_interfaces:
+- name: Ethernet52
+  description: P2P_asdot-for-wan-ha-leaf11_Ethernet2
+  shutdown: false
+  mtu: 9214
+  ip_address: 172.17.0.3/31
+  peer: asdot-for-wan-ha-leaf11
+  peer_interface: Ethernet2
+  peer_type: l3leaf
+  switchport:
+    enabled: false
+- name: Ethernet1.42
+  description: Comcast
+  shutdown: false
+  encapsulation_dot1q:
+    vlan: 42
+  ip_address: dhcp
+  dhcp_client_accept_default_route: true
+  peer_type: l3_interface
+- name: Ethernet2.42
+  description: Colt
+  shutdown: false
+  encapsulation_dot1q:
+    vlan: 666
+  ip_address: 172.16.7.6/31
+  peer_type: l3_interface
+- name: Ethernet1
+  shutdown: false
+  peer_type: l3_interface
+  switchport:
+    enabled: false
+- name: Ethernet2
+  shutdown: false
+  peer_type: l3_interface
+  switchport:
+    enabled: false
+flow_tracking:
+  hardware:
+    trackers:
+    - name: FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 300000
+      exporters:
+      - name: CV-TELEMETRY
+        collectors:
+        - host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 3600000
+    shutdown: false
+hostname: asdot-for-wan-ha-transit1B1
+ip_extcommunity_lists:
+- name: ECL-EVPN-SOO
+  entries:
+  - type: permit
+    extcommunities: soo 192.168.42.1:422
+ip_routing: true
+ip_security:
+  ike_policies:
+  - name: CP-IKE-POLICY
+    local_id: 192.168.142.2
+  sa_policies:
+  - name: DP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  profiles:
+  - name: DP-PROFILE
+    sa_policy: DP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890666
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  - name: CP-PROFILE
+    ike_policy: CP-IKE-POLICY
+    sa_policy: CP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  key_controller:
+    profile: DP-PROFILE
+kernel:
+  software_forwarding_ecmp: true
+loopback_interfaces:
+- name: Loopback0
+  description: ROUTER_ID
+  shutdown: false
+  ip_address: 192.168.42.2/32
+management_security:
+  ssl_profiles:
+  - name: STUN-DTLS
+    tls_versions: '1.2'
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
+    certificate:
+      file: STUN-DTLS.crt
+      key: STUN-DTLS.key
+metadata:
+  is_deployed: true
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: transit region
+    - name: Region
+      value: AVD_Land_West
+    - name: Zone
+      value: AVD_Land_West-ZONE
+    - name: Site
+      value: Site422
+    interface_tags:
+    - interface: Ethernet52
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet1.42
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Comcast
+    - interface: Ethernet2.42
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Colt
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet2
+      tags:
+      - name: Type
+        value: lan
+  cv_pathfinder:
+    role: transit region
+    region: AVD_Land_West
+    zone: AVD_Land_West-ZONE
+    site: Site422
+    vtep_ip: 192.168.142.2
+    ssl_profile: STUN-DTLS
+    interfaces:
+    - name: Ethernet1.42
+      carrier: Comcast
+      pathgroup: INET
+    - name: Ethernet2.42
+      carrier: Colt
+      pathgroup: MPLS
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.42.0/24 eq 32
+- name: PL-WAN-HA-PREFIXES
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.17.0.2/31
+- name: PL-WAN-HA-PEER-PREFIXES
+  sequence_numbers:
+  - sequence: 10
+    action: permit 172.17.0.0/31
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    set:
+    - extcommunity soo 192.168.42.1:422 additive
+  - sequence: 50
+    type: permit
+    match:
+    - ip address prefix-list PL-WAN-HA-PREFIXES
+- name: RM-BGP-UNDERLAY-PEERS-IN
+  sequence_numbers:
+  - sequence: 40
+    type: permit
+    description: Mark prefixes originated from the LAN
+    set:
+    - extcommunity soo 192.168.42.1:422 additive
+  - sequence: 10
+    type: permit
+    description: Allow WAN HA peer interface prefixes
+    match:
+    - ip address prefix-list PL-WAN-HA-PEER-PREFIXES
+  - sequence: 20
+    type: deny
+    description: Deny other routes from the HA peer
+    match:
+    - as-path ASPATH-WAN
+- name: RM-BGP-UNDERLAY-PEERS-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    description: Make routes learned from WAN HA peer less preferred on LAN routers
+    match:
+    - tag 50
+    - route-type internal
+    set:
+    - metric 50
+  - sequence: 20
+    type: permit
+- name: RM-EVPN-SOO-IN
+  sequence_numbers:
+  - sequence: 10
+    type: deny
+    match:
+    - extcommunity ECL-EVPN-SOO
+  - sequence: 20
+    type: permit
+- name: RM-EVPN-SOO-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - extcommunity soo 192.168.42.1:422 additive
+- name: RM-WAN-HA-PEER-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    description: Set tag 50 on routes received from HA peer over EVPN
+    set:
+    - tag 50
+- name: RM-WAN-HA-PEER-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    description: Make EVPN routes learned from WAN less preferred on HA peer
+    match:
+    - route-type internal
+    set:
+    - local-preference 50
+  - sequence: 20
+    type: permit
+    description: Make locally injected routes less preferred on HA peer
+    set:
+    - local-preference 75
+- name: RM-EVPN-EXPORT-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - extcommunity ECL-EVPN-SOO
+router_adaptive_virtual_topology:
+  topology_role: transit region
+  region:
+    name: AVD_Land_West
+    id: 42
+  zone:
+    name: AVD_Land_West-ZONE
+    id: 1
+  site:
+    name: Site422
+    id: 422
+  profiles:
+  - name: DEFAULT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-POLICY-CONTROL-PLANE
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  policies:
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-POLICY-CONTROL-PLANE
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: DEFAULT-POLICY-CONTROL-PLANE
+      id: 254
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_bgp:
+  as: '65000.1'
+  router_id: 192.168.42.2
+  maximum_paths:
+    paths: 16
+  updates:
+    wait_install: true
+  bgp:
+    default:
+      ipv4_unicast: false
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    send_community: all
+    maximum_routes: 12000
+    allowas_in:
+      enabled: true
+      times: 1
+    route_map_in: RM-BGP-UNDERLAY-PEERS-IN
+    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
+  - name: WAN-OVERLAY-PEERS
+    type: wan
+    remote_as: '65000.1'
+    update_source: Dps1
+    bfd: true
+    bfd_timers:
+      interval: 1000
+      min_rx: 1000
+      multiplier: 10
+    password: htm4AZe9mIQOO1uiMuGgYQ==
+    send_community: all
+    maximum_routes: 0
+    ttl_maximum_hops: 1
+  neighbors:
+  - ip_address: 172.17.0.2
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65199'
+    peer: asdot-for-wan-ha-leaf11
+    description: asdot-for-wan-ha-leaf11_Ethernet2
+  - ip_address: 192.168.142.1
+    remote_as: '65000.1'
+    peer: asdot-for-wan-ha-transit1A1
+    description: asdot-for-wan-ha-transit1A1
+    route_reflector_client: true
+    update_source: Dps1
+    route_map_in: RM-WAN-HA-PEER-IN
+    route_map_out: RM-WAN-HA-PEER-OUT
+    send_community: all
+  redistribute:
+    connected:
+      enabled: true
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    neighbor_default:
+      next_hop_self_received_evpn_routes:
+        enable: true
+    neighbors:
+    - ip_address: 192.168.142.1
+      activate: true
+      encapsulation: path-selection
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+      route_map_in: RM-EVPN-SOO-IN
+      route_map_out: RM-EVPN-SOO-OUT
+      encapsulation: path-selection
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: WAN-OVERLAY-PEERS
+      activate: false
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    path_selection:
+      roles:
+        producer: true
+  address_family_path_selection:
+    bgp:
+      additional_paths:
+        receive: true
+        send: any
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  vrfs:
+  - name: default
+    rd: 192.168.42.2:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+router_path_selection:
+  path_groups:
+  - name: INET
+    id: 101
+    ipsec_profile: CP-PROFILE
+    local_interfaces:
+    - name: Ethernet1.42
+    dynamic_peers:
+      enabled: true
+  - name: MPLS
+    id: 100
+    ipsec_profile: CP-PROFILE
+    local_interfaces:
+    - name: Ethernet2.42
+    dynamic_peers:
+      enabled: true
+  - name: LAN_HA
+    id: 65535
+    flow_assignment: lan
+    local_interfaces:
+    - name: Ethernet52
+    static_peers:
+    - router_ip: 192.168.142.1
+      name: asdot-for-wan-ha-transit1A1
+      ipv4_addresses:
+      - 172.17.0.1
+  load_balance_policies:
+  - name: LB-DEFAULT-POLICY-CONTROL-PLANE
+    path_groups:
+    - name: INET
+    - name: MPLS
+    - name: LAN_HA
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
+    - name: MPLS
+    - name: LAN_HA
+  tcp_mss_ceiling:
+    ipv4: auto
+router_traffic_engineering:
+  enabled: true
+service_routing_protocols_model: multi-agent
+spanning_tree:
+  mode: none
+transceiver_qsfp_default_mode_4x10: false
+vrfs:
+- name: MGMT
+  ip_routing: false
+vxlan_interface:
+  vxlan1:
+    description: asdot-for-wan-ha-transit1B1_VTEP
+    vxlan:
+      source_interface: Dps1
+      udp_port: 4789
+      vrfs:
+      - name: default
+        vni: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1B1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1B1.yml
@@ -1,5 +1,10 @@
 aaa_root:
   disabled: true
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 application_traffic_recognition:
   field_sets:
     ipv4_prefixes:
@@ -120,13 +125,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
-kernel:
-  software_forwarding_ecmp: true
 loopback_interfaces:
 - name: Loopback0
   description: ROUTER_ID
   shutdown: false
   ip_address: 192.168.42.2/32
+management_api_http:
+  enable_https: true
+  enable_vrfs:
+  - name: MGMT
 management_security:
   ssl_profiles:
   - name: STUN-DTLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/ASDOT_FOR_WAN_HA.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/ASDOT_FOR_WAN_HA.yml
@@ -1,0 +1,106 @@
+---
+# Testing that the generated as-path access-list will have the dotted ASN escaped correctly.
+wan_mode: cv-pathfinder
+underlay_routing_protocol: ebgp
+cv_pathfinder_regions:
+  - name: AVD_Land_West
+    id: 42
+    description: AVD Region
+    sites:
+      - name: Site422
+        id: 422
+        location: Somewhere
+
+wan_virtual_topologies:
+  vrfs:
+    - name: PROD
+      wan_vni: 42
+
+default_node_types:
+  - node_type: wan_router
+    match_hostnames:
+      - "asdot-for-wan-ha-transit.*"
+  - node_type: l3leaf
+    match_hostnames:
+      - ".*leaf.*"
+
+l3leaf:
+  defaults:
+    bgp_as: 65199
+    loopback_ipv4_pool: 192.168.45.0/24
+    vtep_loopback_ipv4_pool: 192.168.255.0/24
+    virtual_router_mac_address: 00:1c:73:00:00:01
+  nodes:
+    - name: asdot-for-wan-ha-leaf11
+      id: 1
+
+wan_path_groups:
+  - name: MPLS
+    id: 100
+  - name: INET
+    id: 101
+
+wan_ipsec_profiles:
+  control_plane:
+    shared_key: ABCDEF1234567890
+  data_plane:
+    shared_key: ABCDEF1234567890666
+
+bgp_peer_groups:
+  wan_overlay_peers:
+    password: "htm4AZe9mIQOO1uiMuGgYQ=="
+    listen_range_prefixes:
+      - 192.168.142.0/24
+
+wan_carriers:
+  - name: Comcast
+    path_group: INET
+    trusted: true
+  - name: Colt
+    path_group: MPLS
+    trusted: true
+
+wan_router:
+  defaults:
+    loopback_ipv4_pool: 192.168.42.0/24
+    vtep_loopback_ipv4_pool: 192.168.142.0/24
+    uplink_ipv4_pool: 172.17.0.0/16
+    bgp_as: 65000.100
+  node_groups:
+    - group: ASDOT-FOR-WAN-HA-TRANSIT
+      uplink_switches: [asdot-for-wan-ha-leaf11]
+      uplink_type: p2p-vrfs
+      uplink_interfaces: [Ethernet52]
+      cv_pathfinder_transit_mode: region
+      cv_pathfinder_region: AVD_Land_West
+      cv_pathfinder_site: Site422
+      wan_ha:
+        enabled: true
+        ipsec: false
+      nodes:
+        - name: asdot-for-wan-ha-transit1A1
+          id: 1
+          uplink_switch_interfaces: [Ethernet1]
+          l3_interfaces:
+            - name: Ethernet1.42
+              wan_carrier: Comcast
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+            - name: Ethernet2.42
+              peer_ip: 123.12.3.4
+              encapsulation_dot1q_vlan: 666
+              wan_carrier: Colt
+              wan_circuit_id: 10666
+              ip_address: 172.16.6.6/31
+        - name: asdot-for-wan-ha-transit1B1
+          id: 2
+          uplink_switch_interfaces: [Ethernet2]
+          l3_interfaces:
+            - name: Ethernet1.42
+              wan_carrier: Comcast
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+            - name: Ethernet2.42
+              encapsulation_dot1q_vlan: 666
+              wan_carrier: Colt
+              ip_address: 172.16.7.6/31

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -446,6 +446,11 @@ all:
                 autovpn-rr1:
                 autovpn-rr2:
                 autovpn-edge:
+            ASDOT_FOR_WAN_HA:
+              hosts:
+                asdot-for-wan-ha-transit1A1:
+                asdot-for-wan-ha-transit1B1:
+                asdot-for-wan-ha-leaf11:
             CV_PATHFINDER_TESTS:
               children:
                 SITE_HA_ENABLED:

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/as_path.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/as_path.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
+from pyavd._utils import as_path_list_match_from_bgp_asns
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigUnderlayProtocol
@@ -25,7 +26,7 @@ class AsPathMixin(Protocol):
         if self.shared_utils.underlay_routing_protocol != "ebgp":
             return
 
-        if self.shared_utils.wan_ha and self.shared_utils.use_uplinks_for_wan_ha:
+        if self.shared_utils.wan_ha and self.shared_utils.use_uplinks_for_wan_ha and self.shared_utils.bgp_as:
             entries = EosCliConfigGen.AsPath.AccessListsItem.Entries()
-            entries.append_new(type="permit", match=self.shared_utils.bgp_as)
+            entries.append_new(type="permit", match=as_path_list_match_from_bgp_asns((self.shared_utils.bgp_as,)))
             self.structured_config.as_path.access_lists.append_new(name="ASPATH-WAN", entries=entries)

--- a/python-avd/pyavd/_utils/__init__.py
+++ b/python-avd/pyavd/_utils/__init__.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 from .append_if_not_duplicate import append_if_not_duplicate
+from .as_path_list_match_from_bgp_asns import as_path_list_match_from_bgp_asns
 from .batch import batch
 from .compare_dicts import compare_dicts
 from .default import default
@@ -30,6 +31,7 @@ __all__ = [
     "Undefined",
     "UndefinedType",
     "append_if_not_duplicate",
+    "as_path_list_match_from_bgp_asns",
     "batch",
     "compare_dicts",
     "default",

--- a/python-avd/pyavd/_utils/as_path_list_match_from_bgp_asns.py
+++ b/python-avd/pyavd/_utils/as_path_list_match_from_bgp_asns.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from collections.abc import Sequence
+
+
+def as_path_list_match_from_bgp_asns(bgp_asns: Sequence[str]) -> str:
+    """
+    Create a match string for an EOS as-path access-list entry.
+
+    For now this only escapes dots in case of dotted BGP ASN and joins them on underscore.
+    """
+    return "_".join(bgp_asn.replace(".", "\\.") for bgp_asn in bgp_asns)


### PR DESCRIPTION
Cherry-pick #6016

(before #6002 haha YAY 🥳)