### PR TITLE
Refactor(eos_designs): Fix deprecation warnings for `standard_access_lists[].sequence_numbers`

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-disabled.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-disabled.yml
@@ -768,9 +768,10 @@ router_multicast:
 service_routing_protocols_model: multi-agent
 standard_access_lists:
 - name: RPS_ACL_VRF_Tenant_E_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.0.136.0/21
+    action: permit
+    source: 232.0.136.0/21
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf1a.yml
@@ -1007,19 +1007,23 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 standard_access_lists:
 - name: RP_ACL_VRF_OVERRIDE
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.1.0.0/21
+    action: permit
+    source: 232.1.0.0/21
 - name: RPS_ACL_VRF_Tenant_E_1
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.0.120.0/21
+    action: permit
+    source: 232.0.120.0/21
   - sequence: 20
-    action: permit 232.0.128.0/21
+    action: permit
+    source: 232.0.128.0/21
 - name: RPS_ACL_VRF_Tenant_E_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.0.136.0/21
+    action: permit
+    source: 232.0.136.0/21
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf1b.yml
@@ -1007,19 +1007,23 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 standard_access_lists:
 - name: RP_ACL_VRF_OVERRIDE
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.1.0.0/21
+    action: permit
+    source: 232.1.0.0/21
 - name: RPS_ACL_VRF_Tenant_E_1
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.0.120.0/21
+    action: permit
+    source: 232.0.120.0/21
   - sequence: 20
-    action: permit 232.0.128.0/21
+    action: permit
+    source: 232.0.128.0/21
 - name: RPS_ACL_VRF_Tenant_E_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.0.136.0/21
+    action: permit
+    source: 232.0.136.0/21
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf2a.yml
@@ -879,9 +879,10 @@ router_pim_sparse_mode:
 service_routing_protocols_model: multi-agent
 standard_access_lists:
 - name: RPS_ACL_VRF_Tenant_E_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.0.136.0/21
+    action: permit
+    source: 232.0.136.0/21
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf3a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf3a.yml
@@ -947,9 +947,10 @@ sflow:
   run: true
 standard_access_lists:
 - name: RPS_ACL_VRF_Tenant_E_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.0.136.0/21
+    action: permit
+    source: 232.0.136.0/21
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf3b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf3b.yml
@@ -947,9 +947,10 @@ sflow:
   run: true
 standard_access_lists:
 - name: RPS_ACL_VRF_Tenant_E_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 232.0.136.0/21
+    action: permit
+    source: 232.0.136.0/21
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-l3leaf1a.yml
@@ -262,17 +262,20 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 standard_access_lists:
 - name: RP_ACL_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.2.0/24
+    action: permit
+    source: 239.255.2.0/24
 - name: RP_ACL_4
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.4.0/24
+    action: permit
+    source: 239.255.4.0/24
 - name: RP_ACL_5
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.5.0/24
+    action: permit
+    source: 239.255.5.0/24
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-l3leaf1b.yml
@@ -236,17 +236,20 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 standard_access_lists:
 - name: RP_ACL_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.2.0/24
+    action: permit
+    source: 239.255.2.0/24
 - name: RP_ACL_4
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.4.0/24
+    action: permit
+    source: 239.255.4.0/24
 - name: RP_ACL_5
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.5.0/24
+    action: permit
+    source: 239.255.5.0/24
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-l3leaf2a.yml
@@ -242,17 +242,20 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 standard_access_lists:
 - name: RP_ACL_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.2.0/24
+    action: permit
+    source: 239.255.2.0/24
 - name: RP_ACL_4
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.4.0/24
+    action: permit
+    source: 239.255.4.0/24
 - name: RP_ACL_5
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.5.0/24
+    action: permit
+    source: 239.255.5.0/24
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-l3leaf2b.yml
@@ -236,17 +236,20 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 standard_access_lists:
 - name: RP_ACL_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.2.0/24
+    action: permit
+    source: 239.255.2.0/24
 - name: RP_ACL_4
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.4.0/24
+    action: permit
+    source: 239.255.4.0/24
 - name: RP_ACL_5
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.5.0/24
+    action: permit
+    source: 239.255.5.0/24
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-spine1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/underlay-multicast-spine1.yml
@@ -257,17 +257,20 @@ spanning_tree:
   mode: none
 standard_access_lists:
 - name: RP_ACL_2
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.2.0/24
+    action: permit
+    source: 239.255.2.0/24
 - name: RP_ACL_4
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.4.0/24
+    action: permit
+    source: 239.255.4.0/24
 - name: RP_ACL_5
-  sequence_numbers:
+  entries:
   - sequence: 10
-    action: permit 239.255.5.0/24
+    action: permit
+    source: 239.255.5.0/24
 static_routes:
 - vrf: MGMT
   prefix: 0.0.0.0/0

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/standard_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/standard_access_lists.py
@@ -37,5 +37,5 @@ class StandardAccessListsMixin(Protocol):
 
                     standard_access_list = EosCliConfigGen.StandardAccessListsItem(name=rp_entry.access_list_name)
                     for index, group in enumerate(rp_entry.groups, 1):
-                        standard_access_list.sequence_numbers.append_new(sequence=(index) * 10, action=f"permit {group}")
+                        standard_access_list.entries.append_new(sequence=(index) * 10, action='permit', source=group)
                     self.structured_config.standard_access_lists.append(standard_access_list)

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/standard_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/standard_access_lists.py
@@ -37,5 +37,5 @@ class StandardAccessListsMixin(Protocol):
 
                     standard_access_list = EosCliConfigGen.StandardAccessListsItem(name=rp_entry.access_list_name)
                     for index, group in enumerate(rp_entry.groups, 1):
-                        standard_access_list.entries.append_new(sequence=(index) * 10, action='permit', source=group)
+                        standard_access_list.entries.append_new(sequence=(index) * 10, action="permit", source=group)
                     self.structured_config.standard_access_lists.append(standard_access_list)

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/standard_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/standard_access_lists.py
@@ -34,5 +34,5 @@ class StandardAccessListsMixin(Protocol):
                 continue
             standard_access_list = EosCliConfigGen.StandardAccessListsItem(name=rp_entry.access_list_name)
             for index, group in enumerate(rp_entry.groups):
-                standard_access_list.sequence_numbers.append_new(sequence=(index + 1) * 10, action=f"permit {group}")
+                standard_access_list.entries.append_new(sequence=(index + 1) * 10, action="permit", source=group)
             self.structured_config.standard_access_lists.append(standard_access_list)


### PR DESCRIPTION
## Change Summary

Fix deprecation warnings for `standard_access_lists[].sequence_numbers`.
```
[DEPRECATION WARNING]: [underlay-multicast-l3leaf1a]: The input data model 
'standard_access_lists[0].sequence_numbers' is deprecated. Use 'entries' 
instead. This feature will be removed from arista.avd in version 7.0.0. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: [underlay-multicast-l3leaf1a]: The input data model 
'standard_access_lists[1].sequence_numbers' is deprecated. Use 'entries' 
instead. This feature will be removed from arista.avd in version 7.0.0. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Fix deprecation warnings for `standard_access_lists[].sequence_numbers`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
