### PR TITLE
Doc: How-to WAN Settings

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/howto/artifacts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/artifacts.yml
@@ -141,3 +141,22 @@ artifacts:
       - header: "router bgp 65100"
     artifact: "spine1-bgp.cfg"
     output_dir: "ipv6_numbered/artifacts/"
+
+  # WAN Settings artifacts
+  - file: inventory/intended/configs/htws-edge1.cfg
+    sections:
+      - header: "ip security"
+    artifact: "htws-edge1-ipsec.cfg"
+    output_dir: "wan_settings/artifacts/"
+
+  - file: inventory/intended/configs/htws-pf1.cfg
+    sections:
+      - header: "router path-selection"
+    artifact: "htws-pf1-path-selection.cfg"
+    output_dir: "wan_settings/artifacts/"
+
+  - file: inventory/intended/configs/htws-pf1.cfg
+    sections:
+      - header: "router bgp 65000"
+    artifact: "htws-pf1-bgp.cfg"
+    output_dir: "wan_settings/artifacts/"

--- a/ansible_collections/arista/avd/extensions/molecule/howto/destroy.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/destroy.yml
@@ -29,3 +29,4 @@
         - ipv6_numbered/artifacts
         - network_services/artifacts
         - node_types/artifacts
+        - wan_settings/artifacts

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS/default_node_types.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS/default_node_types.yml
@@ -1,0 +1,8 @@
+---
+default_node_types:
+  - node_type: wan_rr
+    match_hostnames:
+      - "htws-pf.*"
+  - node_type: wan_router
+    match_hostnames:
+      - "htws-edge.*"

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS/fabric.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS/fabric.yml
@@ -1,0 +1,58 @@
+---
+# WAN Settings How-To Guide
+
+fabric_name: FABRIC
+
+wan_mode: cv-pathfinder # (1)!
+
+wan_ipsec_profiles: # (2)!
+  control_plane:
+    cleartext_shared_key: MyControlPlaneKey
+  data_plane:
+    cleartext_shared_key: MyDataPlaneKey
+
+wan_stun_dtls_disable: true # (3)!
+
+wan_encapsulation: path-selection # (4)!
+
+# WAN hierarchy required for cv-pathfinder mode
+cv_pathfinder_global_sites: # (5)!
+  - name: GLOBAL-SITE
+    location: "Global"
+
+cv_pathfinder_regions: # (6)!
+  - name: REGION1
+    id: 1
+    sites:
+      - name: SITE1
+        id: 101
+        location: "New York, US"
+
+wan_route_servers:
+  - hostname: htws-pf1
+
+wan_path_groups:
+  - name: INTERNET
+    id: 101
+
+wan_carriers:
+  - name: ISP1
+    path_group: INTERNET
+    trusted: true
+
+bgp_peer_groups:
+  wan_overlay_peers:
+    listen_range_prefixes:
+      - 10.255.9.0/27
+
+wan_virtual_topologies:
+  policies:
+    - name: DEFAULT-POLICY
+      default_virtual_topology:
+        path_groups:
+          - names: [INTERNET]
+            preference: preferred
+  vrfs:
+    - name: default
+      policy: DEFAULT-POLICY
+      wan_vni: 1

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS_EDGES/edges.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS_EDGES/edges.yml
@@ -1,0 +1,21 @@
+---
+wan_router:
+  defaults:
+    platform: vEOS-lab
+    loopback_ipv4_pool: 10.255.8.0/27
+    vtep_loopback_ipv4_pool: 10.255.9.0/27
+    bgp_as: 65000
+    cv_pathfinder_region: REGION1
+    cv_pathfinder_site: SITE1
+  nodes:
+    - name: htws-edge1
+      id: 3
+      mgmt_ip: 172.16.4.101/24
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: ISP1
+          wan_circuit_id: ISP1-EDGE1
+          ip_address: 100.64.2.1/30
+          peer_ip: 100.64.2.2
+          static_routes:
+            - prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS_PATHFINDERS/pathfinders.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS_PATHFINDERS/pathfinders.yml
@@ -1,0 +1,21 @@
+---
+wan_rr:
+  defaults:
+    platform: vEOS-lab
+    loopback_ipv4_pool: 10.255.8.0/27
+    vtep_loopback_ipv4_pool: 10.255.9.0/27
+    bgp_as: 65000
+    data_plane_cpu_allocation_max: 1
+    cv_pathfinder_site: GLOBAL-SITE
+  nodes:
+    - name: htws-pf1
+      id: 1
+      mgmt_ip: 172.16.4.11/24
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: ISP1
+          wan_circuit_id: ISP1-PF1
+          ip_address: 100.64.1.1/30
+          peer_ip: 100.64.1.2
+          static_routes:
+            - prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/hosts.yml
@@ -73,6 +73,16 @@ all:
                   ansible_host: 172.16.3.101
                 htipv6-numbered-leaf2:
                   ansible_host: 172.16.3.102
+        HTWS: # How-To WAN Settings
+          children:
+            HTWS_PATHFINDERS:
+              hosts:
+                htws-pf1:
+                  ansible_host: 172.16.7.11
+            HTWS_EDGES:
+              hosts:
+                htws-edge1:
+                  ansible_host: 172.16.7.101
 
     NETWORK_SERVICES:
       children:

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htws-edge1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htws-edge1.cfg
@@ -1,0 +1,231 @@
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username arista privilege 15 role network-admin secret sha512 $6$Enl0WfE32FthwyiJ$yTyGaEJ2uPKLU.F7314YtB7J1jrzrMi7ogXIRTEHQfLdLgKWWmr1UvNlZLN6AyuxET7G5aH3AI9OYRzxVTkB1.
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -taillogs -cvsourceintf=Management1
+   no shutdown
+!
+flow tracking hardware
+   tracker FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 300000
+      exporter CV-TELEMETRY
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 3600000
+   no shutdown
+!
+service routing protocols model multi-agent
+!
+kernel software forwarding ecmp
+!
+hostname htws-edge1
+ip domain lookup vrf MGMT source-interface Management1
+ip name-server vrf MGMT 192.168.1.1
+!
+router adaptive-virtual-topology
+   topology role edge
+   region REGION1 id 1
+   zone REGION1-ZONE id 1
+   site SITE1 id 101
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-POLICY-CONTROL-PLANE
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-CONTROL-PLANE id 254
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+!
+router path-selection
+   tcp mss ceiling ipv4 ingress
+   !
+   path-group INTERNET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+         stun server-profile INTERNET-htws-pf1-Ethernet1
+      !
+      peer dynamic
+      !
+      peer static router-ip 10.255.9.1
+         name htws-pf1
+         ipv4 address 100.64.1.1
+   !
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
+      path-group INTERNET
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INTERNET
+!
+spanning-tree mode none
+!
+vrf instance MGMT
+!
+ip security
+   ike policy CP-IKE-POLICY
+      local-id 10.255.9.3
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 013E1F275405121D2E407E05180B12390E15
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 022B1D7F0A120E11404F071C2E120B
+      dpd 10 50 clear
+      mode transport
+   !
+   key controller
+      profile DP-PROFILE
+!
+interface Dps1
+   description DPS Interface
+   mtu 9194
+   flow tracker hardware FLOW-TRACKER
+   ip address 10.255.9.3/32
+!
+interface Ethernet1
+   description ISP1_ISP1-EDGE1
+   no shutdown
+   no switchport
+   ip address 100.64.2.1/30
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 10.255.8.3/32
+!
+interface Management1
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 172.16.4.101/24
+!
+interface Vxlan1
+   description htws-edge1_VTEP
+   vxlan source-interface Dps1
+   vxlan udp-port 4789
+   vxlan vrf default vni 1
+!
+application traffic recognition
+   !
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
+   !
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+      10.255.9.1/32
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 10.255.8.3:101
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.255.8.0/27 eq 32
+!
+ip route 0.0.0.0/0 100.64.2.2
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 0.pool.ntp.org prefer
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   set extcommunity soo 10.255.8.3:101 additive
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 10.255.8.3:101 additive
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 10.255.8.3
+   no bgp default ipv4-unicast
+   maximum-paths 16
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   neighbor 10.255.9.1 peer group WAN-OVERLAY-PEERS
+   neighbor 10.255.9.1 description htws-pf1_Dps1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor WAN-OVERLAY-PEERS encapsulation path-selection
+   !
+   address-family ipv4
+      no neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      path-selection
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   vrf default
+      rd 10.255.8.3:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+!
+router traffic-engineering
+!
+stun
+   client
+      server-profile INTERNET-htws-pf1-Ethernet1
+         ip address 100.64.1.1
+!
+end

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htws-pf1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/configs/htws-pf1.cfg
@@ -1,0 +1,207 @@
+!
+no enable password
+no aaa root
+!
+username admin privilege 15 role network-admin nopassword
+username arista privilege 15 role network-admin secret sha512 $6$Enl0WfE32FthwyiJ$yTyGaEJ2uPKLU.F7314YtB7J1jrzrMi7ogXIRTEHQfLdLgKWWmr1UvNlZLN6AyuxET7G5aH3AI9OYRzxVTkB1.
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -taillogs -cvsourceintf=Management1
+   no shutdown
+!
+flow tracking hardware
+   tracker FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 300000
+      exporter CV-TELEMETRY
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 3600000
+   no shutdown
+!
+service routing protocols model multi-agent
+!
+kernel software forwarding ecmp
+!
+hostname htws-pf1
+ip domain lookup vrf MGMT source-interface Management1
+ip name-server vrf MGMT 192.168.1.1
+!
+router adaptive-virtual-topology
+   topology role pathfinder
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-POLICY-CONTROL-PLANE
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-CONTROL-PLANE id 254
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+!
+router path-selection
+   peer dynamic source stun
+   tcp mss ceiling ipv4 ingress
+   !
+   path-group INTERNET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+   !
+   path-group LAN_HA id 65535
+      flow assignment lan
+   !
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
+      path-group INTERNET
+      path-group LAN_HA
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INTERNET
+      path-group LAN_HA
+!
+platform sfe data-plane cpu allocation maximum 1
+!
+spanning-tree mode none
+!
+vrf instance MGMT
+!
+ip security
+   ike policy CP-IKE-POLICY
+      local-id 10.255.9.1
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 013E1F275405121D2E407E05180B12390E15
+      dpd 10 50 clear
+      mode transport
+!
+interface Dps1
+   description DPS Interface
+   mtu 9194
+   flow tracker hardware FLOW-TRACKER
+   ip address 10.255.9.1/32
+!
+interface Ethernet1
+   description ISP1_ISP1-PF1
+   no shutdown
+   no switchport
+   ip address 100.64.1.1/30
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 10.255.8.1/32
+!
+interface Management1
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 172.16.4.11/24
+!
+interface Vxlan1
+   description htws-pf1_VTEP
+   vxlan source-interface Dps1
+   vxlan udp-port 4789
+   vxlan vrf default vni 1
+!
+application traffic recognition
+   !
+   application ipv4 APP-CONTROL-PLANE
+      source prefix field-set PFX-LOCAL-VTEP-IP
+   !
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
+   !
+   field-set ipv4 prefix PFX-LOCAL-VTEP-IP
+      10.255.9.1/32
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 10.255.8.1:0
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.255.8.0/27 eq 32
+!
+ip route 0.0.0.0/0 100.64.1.2
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 0.pool.ntp.org prefer
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   set extcommunity soo 10.255.8.1:0 additive
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
+   match extcommunity ECL-EVPN-SOO
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 10.255.8.1
+   no bgp default ipv4-unicast
+   bgp cluster-id 10.255.8.1
+   maximum-paths 16
+   bgp listen range 10.255.9.0/27 peer-group WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-OVERLAY-PEERS route-reflector-client
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-OVERLAY-PEERS encapsulation path-selection
+      next-hop resolution disabled
+   !
+   address-family ipv4
+      no neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-OVERLAY-PEERS missing-policy direction out action deny
+      path-selection role consumer propagator
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   vrf default
+      rd 10.255.8.1:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+!
+router traffic-engineering
+!
+stun
+   server
+      local-interface Ethernet1
+!
+end

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htws-edge1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htws-edge1.yml
@@ -1,0 +1,376 @@
+aaa_root:
+  disabled: true
+application_traffic_recognition:
+  field_sets:
+    ipv4_prefixes:
+    - name: PFX-PATHFINDERS
+      prefix_values:
+      - 10.255.9.1/32
+  applications:
+    ipv4_applications:
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
+  application_profiles:
+  - name: APP-PROFILE-CONTROL-PLANE
+    applications:
+    - name: APP-CONTROL-PLANE
+config_end: true
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.1.12:9910
+  cvauth:
+    method: token
+    token_file: /tmp/token
+  cvsourceintf: Management1
+  cvvrf: MGMT
+  disable_aaa: true
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+dps_interfaces:
+- name: Dps1
+  description: DPS Interface
+  mtu: 9194
+  ip_address: 10.255.9.3/32
+  flow_tracker:
+    hardware: FLOW-TRACKER
+enable_password:
+  disabled: true
+ethernet_interfaces:
+- name: Ethernet1
+  description: ISP1_ISP1-EDGE1
+  shutdown: false
+  ip_address: 100.64.2.1/30
+  metadata:
+    peer_type: l3_interface
+  switchport:
+    enabled: false
+flow_tracking:
+  hardware:
+    trackers:
+    - name: FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 300000
+      exporters:
+      - name: CV-TELEMETRY
+        collectors:
+        - host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 3600000
+    shutdown: false
+hostname: htws-edge1
+ip_domain_lookup:
+  source_interfaces:
+  - name: Management1
+    vrf: MGMT
+ip_extcommunity_lists:
+- name: ECL-EVPN-SOO
+  entries:
+  - type: permit
+    extcommunities: soo 10.255.8.3:101
+ip_name_server:
+  vrfs:
+  - name: MGMT
+    servers:
+    - ip_address: 192.168.1.1
+ip_routing: true
+ip_security:
+  ike_policies:
+  - name: CP-IKE-POLICY
+    local_id: 10.255.9.3
+  sa_policies:
+  - name: DP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  profiles:
+  - name: DP-PROFILE
+    sa_policy: DP-SA-POLICY
+    connection: start
+    shared_key: 022B1D7F0A120E11404F071C2E120B
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  - name: CP-PROFILE
+    ike_policy: CP-IKE-POLICY
+    sa_policy: CP-SA-POLICY
+    connection: start
+    shared_key: 013E1F275405121D2E407E05180B12390E15
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  key_controller:
+    profile: DP-PROFILE
+kernel:
+  software_forwarding_ecmp: true
+local_users:
+- name: admin
+  privilege: 15
+  role: network-admin
+  no_password: true
+- name: arista
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$Enl0WfE32FthwyiJ$yTyGaEJ2uPKLU.F7314YtB7J1jrzrMi7ogXIRTEHQfLdLgKWWmr1UvNlZLN6AyuxET7G5aH3AI9OYRzxVTkB1.
+loopback_interfaces:
+- name: Loopback0
+  description: ROUTER_ID
+  shutdown: false
+  ip_address: 10.255.8.3/32
+management_interfaces:
+- name: Management1
+  description: OOB_MANAGEMENT
+  shutdown: false
+  vrf: MGMT
+  ip_address: 172.16.4.101/24
+  type: oob
+metadata:
+  is_deployed: true
+  platform: vEOS-lab
+  fabric_name: FABRIC
+  validate_hardware:
+    enabled: false
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: edge
+    - name: Region
+      value: REGION1
+    - name: Zone
+      value: REGION1-ZONE
+    - name: Site
+      value: SITE1
+    interface_tags:
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: ISP1
+      - name: Circuit
+        value: ISP1-EDGE1
+  cv_pathfinder:
+    role: edge
+    region: REGION1
+    zone: REGION1-ZONE
+    site: SITE1
+    vtep_ip: 10.255.9.3
+    pathfinders:
+    - vtep_ip: 10.255.9.1
+    interfaces:
+    - name: Ethernet1
+      carrier: ISP1
+      circuit_id: ISP1-EDGE1
+      pathgroup: INTERNET
+ntp:
+  local_interface:
+    name: Management1
+    vrf: MGMT
+  servers:
+  - name: 0.pool.ntp.org
+    preferred: true
+  vrf: MGMT
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.8.0/27 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    set:
+    - extcommunity soo 10.255.8.3:101 additive
+- name: RM-EVPN-SOO-IN
+  sequence_numbers:
+  - sequence: 10
+    type: deny
+    match:
+    - extcommunity ECL-EVPN-SOO
+  - sequence: 20
+    type: permit
+- name: RM-EVPN-SOO-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - extcommunity soo 10.255.8.3:101 additive
+- name: RM-EVPN-EXPORT-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - extcommunity ECL-EVPN-SOO
+router_adaptive_virtual_topology:
+  topology_role: edge
+  region:
+    name: REGION1
+    id: 1
+  zone:
+    name: REGION1-ZONE
+    id: 1
+  site:
+    name: SITE1
+    id: 101
+  profiles:
+  - name: DEFAULT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-POLICY-CONTROL-PLANE
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  policies:
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-POLICY-CONTROL-PLANE
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: DEFAULT-POLICY-CONTROL-PLANE
+      id: 254
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_bgp:
+  as: '65000'
+  router_id: 10.255.8.3
+  maximum_paths:
+    paths: 16
+  bgp:
+    default:
+      ipv4_unicast: false
+  peer_groups:
+  - name: WAN-OVERLAY-PEERS
+    metadata:
+      type: wan
+    remote_as: '65000'
+    update_source: Dps1
+    bfd: true
+    bfd_timers:
+      interval: 1000
+      min_rx: 1000
+      multiplier: 10
+    send_community: all
+    maximum_routes: 0
+    ttl_maximum_hops: 1
+  neighbors:
+  - ip_address: 10.255.9.1
+    peer_group: WAN-OVERLAY-PEERS
+    metadata:
+      peer: htws-pf1
+    description: htws-pf1_Dps1
+  redistribute:
+    connected:
+      enabled: true
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+      route_map_in: RM-EVPN-SOO-IN
+      route_map_out: RM-EVPN-SOO-OUT
+      encapsulation: path-selection
+  address_family_ipv4:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: false
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    path_selection:
+      roles:
+        producer: true
+  address_family_path_selection:
+    bgp:
+      additional_paths:
+        receive: true
+        send: any
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  vrfs:
+  - name: default
+    rd: 10.255.8.3:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+router_path_selection:
+  path_groups:
+  - name: INTERNET
+    id: 101
+    ipsec_profile: CP-PROFILE
+    local_interfaces:
+    - name: Ethernet1
+      stun:
+        server_profiles:
+        - INTERNET-htws-pf1-Ethernet1
+    dynamic_peers:
+      enabled: true
+    static_peers:
+    - router_ip: 10.255.9.1
+      name: htws-pf1
+      ipv4_addresses:
+      - 100.64.1.1
+  load_balance_policies:
+  - name: LB-DEFAULT-POLICY-CONTROL-PLANE
+    path_groups:
+    - name: INTERNET
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INTERNET
+  tcp_mss_ceiling:
+    ipv4: auto
+router_traffic_engineering:
+  enabled: true
+service_routing_protocols_model: multi-agent
+spanning_tree:
+  mode: none
+static_routes:
+- prefix: 0.0.0.0/0
+  next_hop: 100.64.2.2
+stun:
+  client:
+    server_profiles:
+    - name: INTERNET-htws-pf1-Ethernet1
+      ip_address: 100.64.1.1
+transceiver_qsfp_default_mode_4x10: false
+vrfs:
+- name: MGMT
+  ip_routing: false
+vxlan_interface:
+  vxlan1:
+    description: htws-edge1_VTEP
+    vxlan:
+      source_interface: Dps1
+      udp_port: 4789
+      vrfs:
+      - name: default
+        vni: 1

--- a/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htws-pf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/howto/inventory/intended/structured_configs/htws-pf1.yml
@@ -1,0 +1,373 @@
+aaa_root:
+  disabled: true
+application_traffic_recognition:
+  field_sets:
+    ipv4_prefixes:
+    - name: PFX-LOCAL-VTEP-IP
+      prefix_values:
+      - 10.255.9.1/32
+  applications:
+    ipv4_applications:
+    - name: APP-CONTROL-PLANE
+      src_prefix_set_name: PFX-LOCAL-VTEP-IP
+  application_profiles:
+  - name: APP-PROFILE-CONTROL-PLANE
+    applications:
+    - name: APP-CONTROL-PLANE
+config_end: true
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.1.12:9910
+  cvauth:
+    method: token
+    token_file: /tmp/token
+  cvsourceintf: Management1
+  cvvrf: MGMT
+  disable_aaa: true
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+dps_interfaces:
+- name: Dps1
+  description: DPS Interface
+  mtu: 9194
+  ip_address: 10.255.9.1/32
+  flow_tracker:
+    hardware: FLOW-TRACKER
+enable_password:
+  disabled: true
+ethernet_interfaces:
+- name: Ethernet1
+  description: ISP1_ISP1-PF1
+  shutdown: false
+  ip_address: 100.64.1.1/30
+  metadata:
+    peer_type: l3_interface
+  switchport:
+    enabled: false
+flow_tracking:
+  hardware:
+    trackers:
+    - name: FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 300000
+      exporters:
+      - name: CV-TELEMETRY
+        collectors:
+        - host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 3600000
+    shutdown: false
+hostname: htws-pf1
+ip_domain_lookup:
+  source_interfaces:
+  - name: Management1
+    vrf: MGMT
+ip_extcommunity_lists:
+- name: ECL-EVPN-SOO
+  entries:
+  - type: permit
+    extcommunities: soo 10.255.8.1:0
+ip_name_server:
+  vrfs:
+  - name: MGMT
+    servers:
+    - ip_address: 192.168.1.1
+ip_routing: true
+ip_security:
+  ike_policies:
+  - name: CP-IKE-POLICY
+    local_id: 10.255.9.1
+  sa_policies:
+  - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  profiles:
+  - name: CP-PROFILE
+    ike_policy: CP-IKE-POLICY
+    sa_policy: CP-SA-POLICY
+    connection: start
+    shared_key: 013E1F275405121D2E407E05180B12390E15
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+kernel:
+  software_forwarding_ecmp: true
+local_users:
+- name: admin
+  privilege: 15
+  role: network-admin
+  no_password: true
+- name: arista
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$Enl0WfE32FthwyiJ$yTyGaEJ2uPKLU.F7314YtB7J1jrzrMi7ogXIRTEHQfLdLgKWWmr1UvNlZLN6AyuxET7G5aH3AI9OYRzxVTkB1.
+loopback_interfaces:
+- name: Loopback0
+  description: ROUTER_ID
+  shutdown: false
+  ip_address: 10.255.8.1/32
+management_interfaces:
+- name: Management1
+  description: OOB_MANAGEMENT
+  shutdown: false
+  vrf: MGMT
+  ip_address: 172.16.4.11/24
+  type: oob
+metadata:
+  is_deployed: true
+  platform: vEOS-lab
+  fabric_name: FABRIC
+  validate_hardware:
+    enabled: false
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: pathfinder
+    - name: PathfinderSet
+      value: PATHFINDERS
+    interface_tags:
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: ISP1
+      - name: Circuit
+        value: ISP1-PF1
+  cv_pathfinder:
+    role: pathfinder
+    site: GLOBAL-SITE
+    vtep_ip: 10.255.9.1
+    address: Global
+    interfaces:
+    - name: Ethernet1
+      carrier: ISP1
+      circuit_id: ISP1-PF1
+      pathgroup: INTERNET
+      public_ip: 100.64.1.1
+    pathgroups:
+    - name: INTERNET
+      carriers:
+      - name: ISP1
+    regions:
+    - id: 1
+      name: REGION1
+      zones:
+      - id: 1
+        name: REGION1-ZONE
+        sites:
+        - id: 101
+          name: SITE1
+          location:
+            address: New York, US
+    vrfs:
+    - name: default
+      vni: 1
+      avts:
+      - id: 254
+        name: DEFAULT-POLICY-CONTROL-PLANE
+        pathgroups:
+        - name: INTERNET
+          preference: preferred
+        - name: LAN_HA
+          preference: preferred
+        application_profiles:
+        - APP-PROFILE-CONTROL-PLANE
+      - id: 1
+        name: DEFAULT-POLICY-DEFAULT
+        pathgroups:
+        - name: INTERNET
+          preference: preferred
+        - name: LAN_HA
+          preference: preferred
+    applications:
+      profiles:
+      - name: APP-PROFILE-CONTROL-PLANE
+        user_defined_applications:
+        - name: APP-CONTROL-PLANE
+ntp:
+  local_interface:
+    name: Management1
+    vrf: MGMT
+  servers:
+  - name: 0.pool.ntp.org
+    preferred: true
+  vrf: MGMT
+platform:
+  sfe:
+    data_plane_cpu_allocation_max: 1
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.255.8.0/27 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    set:
+    - extcommunity soo 10.255.8.1:0 additive
+- name: RM-EVPN-EXPORT-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - extcommunity ECL-EVPN-SOO
+router_adaptive_virtual_topology:
+  topology_role: pathfinder
+  profiles:
+  - name: DEFAULT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-POLICY-CONTROL-PLANE
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  policies:
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-POLICY-CONTROL-PLANE
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: DEFAULT-POLICY-CONTROL-PLANE
+      id: 254
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_bgp:
+  as: '65000'
+  router_id: 10.255.8.1
+  maximum_paths:
+    paths: 16
+  bgp_cluster_id: 10.255.8.1
+  bgp:
+    default:
+      ipv4_unicast: false
+  listen_ranges:
+  - prefix: 10.255.9.0/27
+    peer_group: WAN-OVERLAY-PEERS
+    remote_as: '65000'
+  peer_groups:
+  - name: WAN-OVERLAY-PEERS
+    metadata:
+      type: wan
+    remote_as: '65000'
+    update_source: Dps1
+    route_reflector_client: true
+    bfd: true
+    bfd_timers:
+      interval: 1000
+      min_rx: 1000
+      multiplier: 10
+    send_community: all
+    maximum_routes: 0
+    ttl_maximum_hops: 1
+  redistribute:
+    connected:
+      enabled: true
+      route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+      encapsulation: path-selection
+    next_hop:
+      resolution_disabled: true
+  address_family_ipv4:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: false
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+      missing_policy:
+        direction_out_action: deny
+    path_selection:
+      roles:
+        consumer: true
+        propagator: true
+  address_family_path_selection:
+    bgp:
+      additional_paths:
+        receive: true
+        send: any
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  vrfs:
+  - name: default
+    rd: 10.255.8.1:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+router_path_selection:
+  peer_dynamic_source: stun
+  path_groups:
+  - name: INTERNET
+    id: 101
+    ipsec_profile: CP-PROFILE
+    local_interfaces:
+    - name: Ethernet1
+  - name: LAN_HA
+    id: 65535
+    flow_assignment: lan
+  load_balance_policies:
+  - name: LB-DEFAULT-POLICY-CONTROL-PLANE
+    path_groups:
+    - name: INTERNET
+    - name: LAN_HA
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INTERNET
+    - name: LAN_HA
+  tcp_mss_ceiling:
+    ipv4: auto
+router_traffic_engineering:
+  enabled: true
+service_routing_protocols_model: multi-agent
+spanning_tree:
+  mode: none
+static_routes:
+- prefix: 0.0.0.0/0
+  next_hop: 100.64.1.2
+stun:
+  server:
+    local_interfaces:
+    - Ethernet1
+transceiver_qsfp_default_mode_4x10: false
+vrfs:
+- name: MGMT
+  ip_routing: false
+vxlan_interface:
+  vxlan1:
+    description: htws-pf1_VTEP
+    vxlan:
+      source_interface: Dps1
+      udp_port: 4789
+      vrfs:
+      - name: default
+        vni: 1

--- a/docs/howto/wan_settings/README.md
+++ b/docs/howto/wan_settings/README.md
@@ -1,0 +1,195 @@
+<!--
+  ~ Copyright (c) 2025-2026 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+
+# WAN Settings
+
+## Introduction
+
+**WAN Settings** are global AVD variables that control how all WAN devices in a fabric establish secure tunnels, select the WAN operating mode, and authenticate peers. These settings must be consistent across every device participating in the WAN network — from Pathfinders to Edge routers — because they define the shared IPsec profiles, BGP policies, and session negotiation parameters that enable the WAN overlay.
+
+Without correctly configured WAN settings, WAN devices cannot form DPS tunnels or exchange routing information through the EVPN overlay.
+
+### When to Use WAN Settings
+
+Configure WAN settings when:
+
+- **Deploying CV Pathfinder**: Set `wan_mode: cv-pathfinder` and define IPsec profiles for all WAN devices.
+- **Deploying AutoVPN only**: Set `wan_mode: legacy-autovpn` for simpler hub-and-spoke WAN without CloudVision integration.
+- **Customizing IPsec**: Override the default IKE policy, SA policy, or profile names for control-plane and data-plane tunnels.
+- **Disabling STUN DTLS for lab environments**: Use `wan_stun_dtls_disable: true` to skip certificate requirements in test deployments.
+- **Enabling WAN High Availability**: Configure `wan_ha` to set a custom LAN HA path-group name.
+
+## Concepts
+
+**wan_mode**: Selects between `cv-pathfinder` (default, uses CloudVision for metadata and certificate distribution) and `legacy-autovpn` (hub-and-spoke without CloudVision). This must be identical on every WAN device.
+
+**wan_ipsec_profiles**: Defines the IPsec security profiles used for WAN tunnel authentication. Separate profiles exist for `control_plane` (BGP overlay sessions) and `data_plane` (forwarding path tunnels). If `data_plane` is omitted, the control-plane profile is used for both.
+
+**wan_stun_dtls_disable**: By default, STUN connections for DPS path discovery are secured with DTLS and require certificates. Setting this to `true` disables DTLS — acceptable in isolated lab environments but must never be used on internet-connected WAN links.
+
+**wan_encapsulation**: Selects the EVPN encapsulation for WAN BGP peers. The default `path-selection` uses the DPS path-selection overlay. `vxlan` is an alternative when direct VXLAN encapsulation is preferred.
+
+**wan_ha**: Controls WAN High Availability settings. The `lan_ha_path_group_name` key (default: `LAN_HA`) names the auto-injected path-group used for direct LAN HA tunnels between HA-paired WAN routers.
+
+## Minimal WAN Settings Example
+
+The following example shows a complete minimal WAN deployment: one Pathfinder and one Edge router connected over a single ISP path group. The focus is on the global settings that must be defined once and shared across all WAN devices.
+
+### Global Settings
+
+```yaml title="group_vars/HTWS/fabric.yml"
+--8<--
+ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS/fabric.yml
+--8<--
+```
+
+1. `wan_mode: cv-pathfinder` selects CV Pathfinder mode. This must be the same on every WAN device.
+2. `wan_ipsec_profiles` defines the IPsec credentials. Both `control_plane` and `data_plane` keys are shown; if `data_plane` is omitted, the control-plane profile is reused for data-plane tunnels.
+3. `wan_stun_dtls_disable: true` is suitable for lab use. Remove this in production — CloudVision will automatically distribute certificates when using CV Pathfinder.
+4. `wan_encapsulation: path-selection` is the default and selects the DPS overlay. This line is optional since it matches the default value.
+5. `cv_pathfinder_global_sites` defines sites not tied to any region (typically Pathfinder locations).
+6. `cv_pathfinder_regions` defines the WAN hierarchy of regions and sites used by Edge routers.
+
+!!! warning
+    All variables in this file must have identical values on every device participating in the WAN fabric. Use a shared group or the `arista.avd.global_vars` plugin when devices span multiple inventories.
+
+### Pathfinder Node
+
+```yaml title="group_vars/HTWS_PATHFINDERS/pathfinders.yml"
+--8<--
+ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS_PATHFINDERS/pathfinders.yml
+--8<--
+```
+
+### Edge Router Node
+
+```yaml title="group_vars/HTWS_EDGES/edges.yml"
+--8<--
+ansible_collections/arista/avd/extensions/molecule/howto/inventory/group_vars/HTWS_EDGES/edges.yml
+--8<--
+```
+
+## Generated Configuration
+
+### IPsec Profiles (Edge Router)
+
+The `wan_ipsec_profiles` input produces separate IKE policies, SA policies, and IPsec profiles for control-plane and data-plane traffic:
+
+```cli title="htws-edge1: ip security"
+--8<--
+docs/howto/wan_settings/artifacts/htws-edge1-ipsec.cfg
+--8<--
+```
+
+Note that the shared keys are stored as Type 7 obfuscated values in the rendered configuration. The `cleartext_shared_key` input is never written in plaintext to the device — use Ansible Vault to protect the source variable.
+
+### Path Selection (Pathfinder)
+
+On the Pathfinder, AVD generates the `router path-selection` block to register the local WAN interface into the INTERNET path group, configure STUN, and define load-balance policies:
+
+```cli title="htws-pf1: router path-selection"
+--8<--
+docs/howto/wan_settings/artifacts/htws-pf1-path-selection.cfg
+--8<--
+```
+
+### BGP Overlay (Pathfinder)
+
+The Pathfinder uses a BGP listen range to accept sessions from any Edge router whose DPS IP falls within the configured `listen_range_prefixes`. All WAN devices use the same BGP AS (iBGP):
+
+```cli title="htws-pf1: router bgp 65000"
+--8<--
+docs/howto/wan_settings/artifacts/htws-pf1-bgp.cfg
+--8<--
+```
+
+## IPsec Profiles: Control Plane vs. Data Plane
+
+AVD generates two distinct IPsec profiles when both `control_plane` and `data_plane` keys are configured in `wan_ipsec_profiles`:
+
+| Profile | Purpose | Policy names |
+| ------- | ------- | ------------ |
+| `CP-PROFILE` | Secures EVPN BGP overlay sessions | CP-IKE-POLICY / CP-SA-POLICY |
+| `DP-PROFILE` | Secures DPS forwarding tunnels | DP-IKE-POLICY / DP-SA-POLICY |
+
+If only `control_plane` is defined, both profiles share the same credentials. Separating them with different keys is recommended for production so that compromise of one profile does not affect the other.
+
+You can also override the default profile and policy names using the optional `ike_policy_name`, `sa_policy_name`, and `profile_name` sub-keys.
+
+## WAN HA Settings
+
+When WAN HA is enabled at the node level (`wan_ha.enabled: true`), AVD automatically injects a `LAN_HA` path group to form DPS tunnels over the LAN between HA-paired routers. Use `wan_ha.lan_ha_path_group_name` to rename this path group if `LAN_HA` conflicts with existing path-group names in your design:
+
+```yaml
+wan_ha:
+  lan_ha_path_group_name: MY-HA-PATH-GROUP
+```
+
+!!! note
+    WAN HA is only supported in `cv-pathfinder` mode. `legacy-autovpn` does not support WAN HA.
+
+## Best Practices
+
+1. **Use Ansible Vault for shared keys**: Both `cleartext_shared_key` and `shared_key` contain sensitive credentials. Encrypt them with Ansible Vault and never commit plaintext keys to source control.
+2. **Separate control-plane and data-plane profiles**: Define distinct keys for `control_plane` and `data_plane` so that key rotation on one does not disrupt the other.
+3. **Keep wan_mode consistent**: Place all WAN settings in a group that includes every WAN device, or use `arista.avd.global_vars` to share variables across multiple inventories.
+4. **Disable STUN DTLS only in isolated labs**: `wan_stun_dtls_disable: true` removes authentication from STUN. Never use it on links exposed to untrusted networks.
+5. **Use trusted: true only for private carriers**: Mark a `wan_carrier` as `trusted: true` only for private MPLS or similar circuits. Internet-facing carriers should require `ipv4_acl_in` to restrict inbound traffic on WAN interfaces.
+
+## Troubleshooting
+
+### Edge router fails with "Dps1 IP is not in the Route Reflector listen range prefixes"
+
+**Issue**: Molecule or eos_designs reports that the edge's DPS IP is not covered by the Pathfinder's listen range.
+
+**Solution**:
+
+- The edge's DPS IP is drawn from `vtep_loopback_ipv4_pool`. Ensure `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` includes this pool:
+
+```yaml
+bgp_peer_groups:
+  wan_overlay_peers:
+    listen_range_prefixes:
+      - 10.255.9.0/27  # must match vtep_loopback_ipv4_pool
+```
+
+### Pathfinder fails with "data_plane_cpu_allocation_max must be set"
+
+**Issue**: AVD validation rejects the Pathfinder node.
+
+**Solution**:
+
+- Add `data_plane_cpu_allocation_max` to the `wan_rr.defaults` block. A value of `1` is appropriate for vEOS-lab; production hardware typically uses `2` or higher:
+
+```yaml
+wan_rr:
+  defaults:
+    data_plane_cpu_allocation_max: 1
+```
+
+### WAN interface fails with "ipv4_acl_in must be set"
+
+**Issue**: AVD rejects a WAN interface because the carrier is not marked as trusted.
+
+**Solution**:
+
+- Either add `trusted: true` to the carrier definition (for private circuits), or define a named ACL and reference it on the interface via `ipv4_acl_in`:
+
+```yaml
+wan_carriers:
+  - name: ISP1
+    path_group: INTERNET
+    trusted: true  # use only for private/trusted carriers
+```
+
+## Reference
+
+For complete details on all available properties, see:
+
+- [WAN Settings](../../../ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md#wan-settings)
+- [WAN Path Groups and Carriers](../../../ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md#wan-settings)
+- [WAN Virtual Topologies](../../../ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md#wan-settings)
+- [Node Type WAN Configuration](../../../ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md#node-type-wan-configuration)

--- a/docs/howto/wan_settings/artifacts/htws-edge1-ipsec.cfg
+++ b/docs/howto/wan_settings/artifacts/htws-edge1-ipsec.cfg
@@ -1,0 +1,30 @@
+ip security
+   ike policy CP-IKE-POLICY
+      local-id 10.255.9.3
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 013E1F275405121D2E407E05180B12390E15
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 022B1D7F0A120E11404F071C2E120B
+      dpd 10 50 clear
+      mode transport
+   !
+   key controller
+      profile DP-PROFILE
+!

--- a/docs/howto/wan_settings/artifacts/htws-pf1-bgp.cfg
+++ b/docs/howto/wan_settings/artifacts/htws-pf1-bgp.cfg
@@ -1,0 +1,44 @@
+router bgp 65000
+   router-id 10.255.8.1
+   no bgp default ipv4-unicast
+   bgp cluster-id 10.255.8.1
+   maximum-paths 16
+   bgp listen range 10.255.9.0/27 peer-group WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-OVERLAY-PEERS route-reflector-client
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-OVERLAY-PEERS encapsulation path-selection
+      next-hop resolution disabled
+   !
+   address-family ipv4
+      no neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-OVERLAY-PEERS missing-policy direction out action deny
+      path-selection role consumer propagator
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   vrf default
+      rd 10.255.8.1:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+!

--- a/docs/howto/wan_settings/artifacts/htws-pf1-path-selection.cfg
+++ b/docs/howto/wan_settings/artifacts/htws-pf1-path-selection.cfg
@@ -1,0 +1,20 @@
+router path-selection
+   peer dynamic source stun
+   tcp mss ceiling ipv4 ingress
+   !
+   path-group INTERNET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+   !
+   path-group LAN_HA id 65535
+      flow assignment lan
+   !
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
+      path-group INTERNET
+      path-group LAN_HA
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INTERNET
+      path-group LAN_HA
+!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -193,6 +193,7 @@ nav:
       - IPv6 Addressing: docs/howto/ipv6_numbered/README.md
       - Node Types: docs/howto/node_types/README.md
       - Network Services: docs/howto/network_services/README.md
+      - WAN Settings: docs/howto/wan_settings/README.md
       - Configuring PTP: ansible_collections/arista/avd/roles/eos_designs/docs/how-to/ptp.md
       - Configuring WAN: ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
       - Custom Descriptions and Names: ansible_collections/arista/avd/roles/eos_designs/docs/how-to/custom-descriptions-names.md


### PR DESCRIPTION
## Change Summary

- Adding how-to guide for WAN Settings (`wan_mode`, `wan_ipsec_profiles`, `wan_stun_dtls_disable`, `wan_encapsulation`, `wan_ha`).
- Created molecule inventory group `HTWS` with 1 Pathfinder (`htws-pf1`) and 1 Edge router (`htws-edge1`).
- Added artifact extraction entries to `artifacts.yml` for IPsec profiles, path selection, and BGP overlay.
- Added `WAN Settings` entry to the `How-to Guides` nav section in `mkdocs.yml`.

## Related Issue(s)

Closes aristanetworks/avd-internal#388

## Component(s) name

Docs

## Proposed changes

Please see the change summary.

## How to test

```bash
molecule test -s howto
```

## Checklist

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly.