### PR TITLE
Feat(eos_designs): Added the support of redistribute router-mac system command for SVIs

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn-multicast-disabled.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn-multicast-disabled.cfg
@@ -555,6 +555,7 @@ router bgp 65106
       rd 192.168.255.8:10001
       route-target both 10001:10001
       redistribute learned
+      redistribute router-mac system
    !
    vlan 2
       rd 192.168.255.8:10002

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn-multicast-l3leaf2a.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn-multicast-l3leaf2a.cfg
@@ -627,6 +627,7 @@ router bgp 65103
       route-target both 10001:10001
       redistribute igmp
       redistribute learned
+      redistribute router-mac system
    !
    vlan 2
       rd 192.168.255.5:10002

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn-multicast-l3leaf3a.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn-multicast-l3leaf3a.cfg
@@ -655,6 +655,7 @@ router bgp 65104
       route-target both 10001:10001
       redistribute igmp
       redistribute learned
+      redistribute router-mac system
    !
    vlan 2
       rd 192.168.255.6:10002

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn-multicast-l3leaf3b.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn-multicast-l3leaf3b.cfg
@@ -655,6 +655,7 @@ router bgp 65105
       route-target both 10001:10001
       redistribute igmp
       redistribute learned
+      redistribute router-mac system
    !
    vlan 2
       rd 192.168.255.7:10002

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-disabled.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-disabled.yml
@@ -296,6 +296,7 @@ router_bgp:
       - 10001:10001
     redistribute_routes:
     - learned
+    - router-mac system
   - id: 2
     metadata:
       tenants:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf2a.yml
@@ -352,6 +352,7 @@ router_bgp:
     redistribute_routes:
     - learned
     - igmp
+    - router-mac system
   - id: 2
     metadata:
       tenants:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf3a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf3a.yml
@@ -391,6 +391,7 @@ router_bgp:
     redistribute_routes:
     - learned
     - igmp
+    - router-mac system
   - id: 2
     metadata:
       tenants:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf3b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-multicast-l3leaf3b.yml
@@ -391,6 +391,7 @@ router_bgp:
     redistribute_routes:
     - learned
     - igmp
+    - router-mac system
   - id: 2
     metadata:
       tenants:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/EVPN_MULTICAST_TESTS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/EVPN_MULTICAST_TESTS.yml
@@ -175,6 +175,7 @@ tenants:
             # vrfs.svis.evpn_l2_multicast.enabled: true with igmp_snooping.fast_leave: true
             evpn_l2_multicast:
               enabled: true
+            evpn_redistribute_router_mac_system: true
             # To test vxlan_flood_multicast disabled at l2vlans but enabled at tenant
             vxlan_flood_multicast:
               enabled: false
@@ -185,6 +186,7 @@ tenants:
             tags: ["test_l3"]
             enabled: true
             ip_address_virtual: 10.0.2.1/24
+            evpn_redistribute_router_mac_system: false
             evpn_l2_multicast:
               enabled: true
             # To test vxlan_flood_multicast disabled at l2vlans but enabled at tenant with underlay_multicast_group

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
@@ -76,6 +76,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rd_override</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].rd_override") | String |  |  |  | By default the MAC VRF RD will be derived from mac_vrf_id_base + vlan_id.<br>The rt_override allows us to override this value and statically define it.<br>rd_override will default to rt_override or vni_override if set.<br><br>rd_override supports two formats:<br>  - A single number which will be used in the RD assigned number field instead of mac_vrf_id/mac_vrf_vni (see 'overlay_rd_type' for details).<br>  - A full RD string with colon separator which will override the full RD.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].trunk_groups.[]") | String |  |  |  | Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.<br>Requires "enable_trunk_groups: true".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_redistribute_router_mac_system</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].evpn_redistribute_router_mac_system") | Boolean |  | `False` |  | Configure 'redistribute router-mac system' under BGP for this L3 VLAN. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].vxlan") | Boolean |  | `True` |  | Extend this SVI over VXLAN. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].spanning_tree_priority") | Integer |  |  |  | Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.<br>The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].mtu") | Integer |  |  |  | Interface MTU. |
@@ -135,6 +136,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rd_override</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].rd_override") | String |  |  |  | By default the MAC VRF RD will be derived from mac_vrf_id_base + vlan_id.<br>The rt_override allows us to override this value and statically define it.<br>rd_override will default to rt_override or vni_override if set.<br><br>rd_override supports two formats:<br>  - A single number which will be used in the RD assigned number field instead of mac_vrf_id/mac_vrf_vni (see 'overlay_rd_type' for details).<br>  - A full RD string with colon separator which will override the full RD.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].trunk_groups.[]") | String |  |  |  | Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.<br>Requires "enable_trunk_groups: true".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_redistribute_router_mac_system</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_redistribute_router_mac_system") | Boolean |  | `False` |  | Configure 'redistribute router-mac system' under BGP for this L3 VLAN. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].vxlan") | Boolean |  | `True` |  | Extend this SVI over VXLAN. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].spanning_tree_priority") | Integer |  |  |  | Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.<br>The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].mtu") | Integer |  |  |  | Interface MTU. |
@@ -366,6 +368,9 @@
                         # Requires "enable_trunk_groups: true".
                       - <str>
 
+                    # Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
+                    evpn_redistribute_router_mac_system: <bool; default=False>
+
                     # Extend this SVI over VXLAN.
                     vxlan: <bool; default=True>
 
@@ -540,6 +545,9 @@
                     # Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.
                     # Requires "enable_trunk_groups: true".
                   - <str>
+
+                # Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
+                evpn_redistribute_router_mac_system: <bool; default=False>
 
                 # Extend this SVI over VXLAN.
                 vxlan: <bool; default=True>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
@@ -63,6 +63,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rd_override</samp>](## "svi_profiles.[].nodes.[].rd_override") | String |  |  |  | By default the MAC VRF RD will be derived from mac_vrf_id_base + vlan_id.<br>The rt_override allows us to override this value and statically define it.<br>rd_override will default to rt_override or vni_override if set.<br><br>rd_override supports two formats:<br>  - A single number which will be used in the RD assigned number field instead of mac_vrf_id/mac_vrf_vni (see 'overlay_rd_type' for details).<br>  - A full RD string with colon separator which will override the full RD.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "svi_profiles.[].nodes.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].nodes.[].trunk_groups.[]") | String |  |  |  | Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.<br>Requires "enable_trunk_groups: true".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_redistribute_router_mac_system</samp>](## "svi_profiles.[].nodes.[].evpn_redistribute_router_mac_system") | Boolean |  | `False` |  | Configure 'redistribute router-mac system' under BGP for this L3 VLAN. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "svi_profiles.[].nodes.[].vxlan") | Boolean |  | `True` |  | Extend this SVI over VXLAN. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "svi_profiles.[].nodes.[].spanning_tree_priority") | Integer |  |  |  | Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.<br>The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "svi_profiles.[].nodes.[].mtu") | Integer |  |  |  | Interface MTU. |
@@ -123,6 +124,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rd_override</samp>](## "svi_profiles.[].rd_override") | String |  |  |  | By default the MAC VRF RD will be derived from mac_vrf_id_base + vlan_id.<br>The rt_override allows us to override this value and statically define it.<br>rd_override will default to rt_override or vni_override if set.<br><br>rd_override supports two formats:<br>  - A single number which will be used in the RD assigned number field instead of mac_vrf_id/mac_vrf_vni (see 'overlay_rd_type' for details).<br>  - A full RD string with colon separator which will override the full RD.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "svi_profiles.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].trunk_groups.[]") | String |  |  |  | Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.<br>Requires "enable_trunk_groups: true".<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_redistribute_router_mac_system</samp>](## "svi_profiles.[].evpn_redistribute_router_mac_system") | Boolean |  | `False` |  | Configure 'redistribute router-mac system' under BGP for this L3 VLAN. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "svi_profiles.[].vxlan") | Boolean |  | `True` |  | Extend this SVI over VXLAN. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_priority</samp>](## "svi_profiles.[].spanning_tree_priority") | Integer |  |  |  | Setting spanning-tree priority per VLAN is only supported with `spanning_tree_mode: rapid-pvst` under node type settings.<br>The default priority for rapid-PVST is set under the node type settings with `spanning_tree_priority` (default=32768). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "svi_profiles.[].mtu") | Integer |  |  |  | Interface MTU. |
@@ -310,6 +312,9 @@
                 # Requires "enable_trunk_groups: true".
               - <str>
 
+            # Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
+            evpn_redistribute_router_mac_system: <bool; default=False>
+
             # Extend this SVI over VXLAN.
             vxlan: <bool; default=True>
 
@@ -487,6 +492,9 @@
             # Trunk groups are used for limiting vlans to trunk ports assigned to the same trunk group.
             # Requires "enable_trunk_groups: true".
           - <str>
+
+        # Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
+        evpn_redistribute_router_mac_system: <bool; default=False>
 
         # Extend this SVI over VXLAN.
         vxlan: <bool; default=True>

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -32178,6 +32178,7 @@ class EosDesigns(EosDesignsRootModel):
                 "rd_override": {"type": str},
                 "trunk_groups": {"type": TrunkGroups},
                 "evpn_l2_multicast": {"type": EvpnL2Multicast},
+                "evpn_redistribute_router_mac_system": {"type": bool, "default": False},
                 "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
                 "evpn_l3_multicast": {"type": EvpnL3Multicast},
                 "igmp_snooping": {"type": IgmpSnooping},
@@ -32337,6 +32338,12 @@ class EosDesigns(EosDesignsRootModel):
             Subclass
             of AvdModel.
             """
+            evpn_redistribute_router_mac_system: bool
+            """
+            Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
+
+            Default value: `False`
+            """
             vxlan_flood_multicast: VxlanFloodMulticast
             """Subclass of AvdModel."""
             evpn_l3_multicast: EvpnL3Multicast
@@ -32424,6 +32431,7 @@ class EosDesigns(EosDesignsRootModel):
                     rd_override: str | None | UndefinedType = Undefined,
                     trunk_groups: TrunkGroups | UndefinedType = Undefined,
                     evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
+                    evpn_redistribute_router_mac_system: bool | UndefinedType = Undefined,
                     vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
                     evpn_l3_multicast: EvpnL3Multicast | UndefinedType = Undefined,
                     igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
@@ -32551,6 +32559,7 @@ class EosDesigns(EosDesignsRootModel):
 
                            Subclass
                            of AvdModel.
+                        evpn_redistribute_router_mac_system: Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
                         vxlan_flood_multicast: Subclass of AvdModel.
                         evpn_l3_multicast:
                            Explicitly enable or disable evpn_l3_multicast to override setting of
@@ -33272,6 +33281,7 @@ class EosDesigns(EosDesignsRootModel):
             "rd_override": {"type": str},
             "trunk_groups": {"type": TrunkGroups},
             "evpn_l2_multicast": {"type": EvpnL2Multicast},
+            "evpn_redistribute_router_mac_system": {"type": bool, "default": False},
             "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
             "evpn_l3_multicast": {"type": EvpnL3Multicast},
             "igmp_snooping": {"type": IgmpSnooping},
@@ -33447,6 +33457,12 @@ class EosDesigns(EosDesignsRootModel):
         Subclass
         of AvdModel.
         """
+        evpn_redistribute_router_mac_system: bool
+        """
+        Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
+
+        Default value: `False`
+        """
         vxlan_flood_multicast: VxlanFloodMulticast
         """Subclass of AvdModel."""
         evpn_l3_multicast: EvpnL3Multicast
@@ -33536,6 +33552,7 @@ class EosDesigns(EosDesignsRootModel):
                 rd_override: str | None | UndefinedType = Undefined,
                 trunk_groups: TrunkGroups | UndefinedType = Undefined,
                 evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
+                evpn_redistribute_router_mac_system: bool | UndefinedType = Undefined,
                 vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
                 evpn_l3_multicast: EvpnL3Multicast | UndefinedType = Undefined,
                 igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
@@ -33675,6 +33692,7 @@ class EosDesigns(EosDesignsRootModel):
 
                        Subclass
                        of AvdModel.
+                    evpn_redistribute_router_mac_system: Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
                     vxlan_flood_multicast: Subclass of AvdModel.
                     evpn_l3_multicast:
                        Explicitly enable or disable evpn_l3_multicast to override setting of
@@ -62846,6 +62864,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "rd_override": {"type": str},
                                 "trunk_groups": {"type": TrunkGroups},
                                 "evpn_l2_multicast": {"type": EvpnL2Multicast},
+                                "evpn_redistribute_router_mac_system": {"type": bool, "default": False},
                                 "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
                                 "evpn_l3_multicast": {"type": EvpnL3Multicast},
                                 "igmp_snooping": {"type": IgmpSnooping},
@@ -63015,6 +63034,12 @@ class EosDesigns(EosDesignsRootModel):
                             Subclass
                             of AvdModel.
                             """
+                            evpn_redistribute_router_mac_system: bool
+                            """
+                            Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
+
+                            Default value: `False`
+                            """
                             vxlan_flood_multicast: VxlanFloodMulticast
                             """Subclass of AvdModel."""
                             evpn_l3_multicast: EvpnL3Multicast
@@ -63103,6 +63128,7 @@ class EosDesigns(EosDesignsRootModel):
                                     rd_override: str | None | UndefinedType = Undefined,
                                     trunk_groups: TrunkGroups | UndefinedType = Undefined,
                                     evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
+                                    evpn_redistribute_router_mac_system: bool | UndefinedType = Undefined,
                                     vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
                                     evpn_l3_multicast: EvpnL3Multicast | UndefinedType = Undefined,
                                     igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
@@ -63236,6 +63262,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                            Subclass
                                            of AvdModel.
+                                        evpn_redistribute_router_mac_system: Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
                                         vxlan_flood_multicast: Subclass of AvdModel.
                                         evpn_l3_multicast:
                                            Explicitly enable or disable evpn_l3_multicast to override setting of
@@ -63969,6 +63996,7 @@ class EosDesigns(EosDesignsRootModel):
                             "rd_override": {"type": str},
                             "trunk_groups": {"type": TrunkGroups},
                             "evpn_l2_multicast": {"type": EvpnL2Multicast},
+                            "evpn_redistribute_router_mac_system": {"type": bool, "default": False},
                             "vxlan_flood_multicast": {"type": VxlanFloodMulticast},
                             "evpn_l3_multicast": {"type": EvpnL3Multicast},
                             "igmp_snooping": {"type": IgmpSnooping},
@@ -64168,6 +64196,12 @@ class EosDesigns(EosDesignsRootModel):
                         Subclass
                         of AvdModel.
                         """
+                        evpn_redistribute_router_mac_system: bool
+                        """
+                        Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
+
+                        Default value: `False`
+                        """
                         vxlan_flood_multicast: VxlanFloodMulticast
                         """Subclass of AvdModel."""
                         evpn_l3_multicast: EvpnL3Multicast
@@ -64260,6 +64294,7 @@ class EosDesigns(EosDesignsRootModel):
                                 rd_override: str | None | UndefinedType = Undefined,
                                 trunk_groups: TrunkGroups | UndefinedType = Undefined,
                                 evpn_l2_multicast: EvpnL2Multicast | UndefinedType = Undefined,
+                                evpn_redistribute_router_mac_system: bool | UndefinedType = Undefined,
                                 vxlan_flood_multicast: VxlanFloodMulticast | UndefinedType = Undefined,
                                 evpn_l3_multicast: EvpnL3Multicast | UndefinedType = Undefined,
                                 igmp_snooping: IgmpSnooping | UndefinedType = Undefined,
@@ -64415,6 +64450,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                        Subclass
                                        of AvdModel.
+                                    evpn_redistribute_router_mac_system: Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
                                     vxlan_flood_multicast: Subclass of AvdModel.
                                     evpn_l3_multicast:
                                        Explicitly enable or disable evpn_l3_multicast to override setting of

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -14263,6 +14263,11 @@ $defs:
 
               but it is required to support forwarding of TTL=1 multicast traffic
               within the VLAN.'
+      evpn_redistribute_router_mac_system:
+        type: bool
+        default: false
+        description: Configure 'redistribute router-mac system' under BGP for this
+          L3 VLAN.
       vxlan_flood_multicast:
         documentation_options:
           table: network-services-multicast-settings

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
@@ -193,6 +193,11 @@ $defs:
               By default `redistribute igmp` is only configured when `evpn_l2_multicast` is True and `evpn_l3_multicast` for the VRF is False.
               Configuring `redistribute igmp` when both L2 and L3 EVPN Multicast is enabled will take up additional control-plane and data-plane resources,
               but it is required to support forwarding of TTL=1 multicast traffic within the VLAN.
+      evpn_redistribute_router_mac_system:
+        type: bool
+        default: false
+        description: |-
+          Configure 'redistribute router-mac system' under BGP for this L3 VLAN.
       vxlan_flood_multicast:
         documentation_options:
           table: network-services-multicast-settings

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/router_bgp.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/router_bgp.py
@@ -546,6 +546,12 @@ class RouterBgpMixin(Protocol):
         if self.inputs.dot1x_settings.enabled and self.inputs.dot1x_settings.redistribute_in_evpn:
             bgp_vlan.redistribute_routes.append("dot1x")
 
+        if (
+            isinstance(vlan, EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.SvisItem)
+            and vlan.evpn_redistribute_router_mac_system
+        ):
+            bgp_vlan.redistribute_routes.append("router-mac system")
+
         return bgp_vlan
 
     @staticmethod


### PR DESCRIPTION
## Change Summary

Added the support of redistribute router-mac system command for SVIs

## Related Issue(s)

Fixes #6792 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added the support of redistribute router-mac system command for SVIs.
`<network_services_keys.name>.[].vrfs.[].svis.[].evpn_redistribute_router_mac_system`
`<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].evpn_redistribute_router_mac_system`
`svi_profiles.[].nodes.[].evpn_redistribute_router_mac_system`
`svi_profiles.[].evpn_redistribute_router_mac_system`

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
