### PR TITLE
Feat(eos_designs): Added the support of ip hosts under dns_settings

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dns-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dns-settings-1.cfg
@@ -19,6 +19,8 @@ ip name-server vrf default 10.10.10.1 priority 1
 dns domain testfabric.local
 ip domain-list avd.lab
 ip domain-list other.net
+ip host dns-settings-1 10.1.1.1
+ip host dns-settings-2 1.1.1.1 2.2.2.2 4.4.4.4
 !
 vrf instance MGMT
 !

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-1.yml
@@ -24,6 +24,15 @@ ip_domain_lookup:
   - name: Vlan123
   - name: Management1
     vrf: MGMT
+ip_hosts:
+- hostname: dns-settings-1
+  ipv4_addresses:
+  - 10.1.1.1
+- hostname: dns-settings-2
+  ipv4_addresses:
+  - 4.4.4.4
+  - 2.2.2.2
+  - 1.1.1.1
 ip_igmp_snooping:
   globally_enabled: true
 ip_name_server:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dns-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dns-settings-1.yml
@@ -35,7 +35,7 @@ dns_settings:
     # Testing override of source for VRF default - no VRF in output source interface model.
     - name: default
       source_interface: Vlan123
-  
+
   ip_hosts:
     - hostname: dns-settings-1
       ipv4_addresses:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dns-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dns-settings-1.yml
@@ -35,3 +35,13 @@ dns_settings:
     # Testing override of source for VRF default - no VRF in output source interface model.
     - name: default
       source_interface: Vlan123
+  
+  ip_hosts:
+    - hostname: dns-settings-1
+      ipv4_addresses:
+        - 10.1.1.1
+    - hostname: dns-settings-2
+      ipv4_addresses:
+        - 4.4.4.4
+        - 2.2.2.2
+        - 1.1.1.1

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/dns-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/dns-settings.md
@@ -19,6 +19,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "dns_settings.vrfs.[].name") | String | Required, Unique |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "dns_settings.vrfs.[].source_interface") | String |  |  |  | Source interface to use for DNS lookups in this VRF.<br>If set for the VRFs defined by `mgmt_interface_vrf` or `inband_mgmt_vrf`, this setting will take precedence. |
     | [<samp>&nbsp;&nbsp;set_source_interfaces</samp>](## "dns_settings.set_source_interfaces") | Boolean |  | `True` |  | Automatically set source interface when VRF is set to `use_mgmt_interface_vrf`, `use_inband_mgmt_vrf` or `use_default_mgmt_method_vrf`.<br>Can be set to `false` to avoid changes when migrating from the old `name_servers` model. |
+    | [<samp>&nbsp;&nbsp;ip_hosts</samp>](## "dns_settings.ip_hosts") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;hostname</samp>](## "dns_settings.ip_hosts.[].hostname") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_addresses</samp>](## "dns_settings.ip_hosts.[].ipv4_addresses") | List, items: String | Required |  | Min Length: 1 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "dns_settings.ip_hosts.[].ipv4_addresses.[]") | String |  |  |  |  |
 
 === "YAML"
 
@@ -62,4 +66,8 @@
       # Automatically set source interface when VRF is set to `use_mgmt_interface_vrf`, `use_inband_mgmt_vrf` or `use_default_mgmt_method_vrf`.
       # Can be set to `false` to avoid changes when migrating from the old `name_servers` model.
       set_source_interfaces: <bool; default=True>
+      ip_hosts:
+        - hostname: <str; required; unique>
+          ipv4_addresses: # >=1 items; required
+            - <str>
     ```

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -17347,6 +17347,7 @@ class EosDesigns(EosDesignsRootModel):
             "servers": {"type": Servers},
             "vrfs": {"type": Vrfs},
             "set_source_interfaces": {"type": bool, "default": True},
+            "ip_hosts": {"type": EosCliConfigGen.IpHosts},
         }
         domain: str | None
         """DNS domain name like 'fabric.local'"""
@@ -17369,6 +17370,7 @@ class EosDesigns(EosDesignsRootModel):
 
         Default value: `True`
         """
+        ip_hosts: EosCliConfigGen.IpHosts
 
         if TYPE_CHECKING:
 
@@ -17380,6 +17382,7 @@ class EosDesigns(EosDesignsRootModel):
                 servers: Servers | UndefinedType = Undefined,
                 vrfs: Vrfs | UndefinedType = Undefined,
                 set_source_interfaces: bool | UndefinedType = Undefined,
+                ip_hosts: EosCliConfigGen.IpHosts | UndefinedType = Undefined,
             ) -> None:
                 """
                 DnsSettings.
@@ -17400,6 +17403,7 @@ class EosDesigns(EosDesignsRootModel):
                        `use_inband_mgmt_vrf` or `use_default_mgmt_method_vrf`.
                        Can be set to `false` to avoid changes when
                        migrating from the old `name_servers` model.
+                    ip_hosts: ip_hosts
 
                 """
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -2139,6 +2139,9 @@ keys:
 
           Can be set to `false` to avoid changes when migrating from the old `name_servers`
           model.'
+      ip_hosts:
+        type: list
+        $ref: eos_cli_config_gen#/keys/ip_hosts
   dot1x_settings:
     documentation_options:
       table: dot1x-settings

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/dns_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/dns_settings.schema.yml
@@ -70,3 +70,6 @@ keys:
         description: |-
           Automatically set source interface when VRF is set to `use_mgmt_interface_vrf`, `use_inband_mgmt_vrf` or `use_default_mgmt_method_vrf`.
           Can be set to `false` to avoid changes when migrating from the old `name_servers` model.
+      ip_hosts:
+        type: list
+        $ref: "eos_cli_config_gen#/keys/ip_hosts"

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -334,6 +334,13 @@ class AvdStructuredConfigBaseProtocol(
             ip_name_server_vrf.servers.append_new(ip_address=server.ip_address, priority=server.priority)
 
     @structured_config_contributor
+    def ip_hosts(self) -> None:
+        """Configure IP host setting based on the input data model."""
+        if not self.inputs.dns_settings.ip_hosts:
+            return
+        self.structured_config.ip_hosts = self.inputs.dns_settings.ip_hosts
+
+    @structured_config_contributor
     def logging(self) -> None:
         """
         Configures logging settings based on the input data model.

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -319,7 +319,7 @@ class AvdStructuredConfigBaseProtocol(
             return
 
         if self.inputs.dns_settings.ip_hosts:
-            self.structured_config.ip_hosts = EosCliConfigGen.IpHosts(self.inputs.dns_settings.ip_hosts)
+            self.structured_config.ip_hosts = self.inputs.dns_settings.ip_hosts
 
         if self.inputs.dns_settings.domain:
             self.structured_config.dns_domain = self.inputs.dns_settings.domain

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -309,10 +309,17 @@ class AvdStructuredConfigBaseProtocol(
         self.structured_config.queue_monitor_length = queue_monitor_length
 
     @structured_config_contributor
-    def ip_name_server(self) -> None:
-        """Set ip name servers using old name_servers model and new dns_settings model. Results will be combined."""
+    def dns_settings(self) -> None:
+        """
+        Configure DNS settings from the dns_settings input model.
+
+        Sets IP name servers (with VRF and priority), IP hosts, DNS domain, domain list, and domain-lookup source interfaces per VRF.
+        """
         if not self.inputs.dns_settings:
             return
+
+        if self.inputs.dns_settings.ip_hosts:
+            self.structured_config.ip_hosts = EosCliConfigGen.IpHosts(self.inputs.dns_settings.ip_hosts)
 
         if self.inputs.dns_settings.domain:
             self.structured_config.dns_domain = self.inputs.dns_settings.domain
@@ -332,13 +339,6 @@ class AvdStructuredConfigBaseProtocol(
 
             ip_name_server_vrf = self.structured_config.ip_name_server.vrfs.obtain(server_vrf)
             ip_name_server_vrf.servers.append_new(ip_address=server.ip_address, priority=server.priority)
-
-    @structured_config_contributor
-    def ip_hosts(self) -> None:
-        """Configure IP host setting based on the input data model."""
-        if not self.inputs.dns_settings.ip_hosts:
-            return
-        self.structured_config.ip_hosts = self.inputs.dns_settings.ip_hosts
 
     @structured_config_contributor
     def logging(self) -> None:


### PR DESCRIPTION
## Change Summary

Added the support of ip hosts under dns_settings

## Related Issue(s)

Fixes #6730 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added the support of ip hosts under dns_settings

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
