### PR TITLE
Feat(cv_deploy): Extend GRPCRequestHandler retry logic to handle RST_STREAM frames with INTERNAL_ERROR code for idempotent cv_deploy API calls 

### DIFF
--- a/python-avd/pyavd/_cv/client/async_decorators.py
+++ b/python-avd/pyavd/_cv/client/async_decorators.py
@@ -218,6 +218,24 @@ class GRPCRequestHandler:
 
         return _string_based_annotation is list or get_origin(annotation) is list, _string_based_annotation
 
+    async def _wait_before_retry_or_raise(self, e: Exception, attempt: int, func_name: str, call_args: tuple, call_kwargs: dict) -> None:
+        """Sleep before the next retry attempt or raise CVGRPCStatusUnavailable if retries are exhausted."""
+        if attempt <= self.max_retries:
+            delay = self.initial_delay * (self.factor ** (attempt - 1))
+            LOGGER.warning(
+                "%s: Attempt %s/%s to execute call '%s' returned '%s'. Retrying in %ss...",
+                self.__class__.__name__,
+                attempt,
+                self.max_retries + 1,
+                func_name,
+                e,
+                delay,
+            )
+            await asyncio_sleep(delay)
+        else:
+            msg = f"{self.__class__.__name__}: Attempt {attempt}/{self.max_retries + 1} to execute call '{func_name}' failed."
+            raise CVGRPCStatusUnavailable(msg, *e.args, call_args, call_kwargs)
+
     async def _execute_single_call_with_retries(self, call_args: tuple, call_kwargs: dict) -> None:
         """Executes a single call to self.func with retry logic for gRPC UNAVAILABLE."""
         func_name = self.func.__name__
@@ -242,22 +260,7 @@ class GRPCRequestHandler:
                                 raise CVTimeoutError(*e.args, call_args, call_kwargs)
 
                             case Status.UNAVAILABLE:
-                                if attempt <= self.max_retries:
-                                    delay = self.initial_delay * (self.factor ** (attempt - 1))
-                                    LOGGER.warning(
-                                        "%s: Attempt %s/%s to execute call '%s' returned '%s'. Retrying in %ss...",
-                                        self.__class__.__name__,
-                                        attempt,
-                                        self.max_retries + 1,
-                                        func_name,
-                                        e,
-                                        delay,
-                                    )
-                                    await asyncio_sleep(delay)
-                                # Use case where all retries for this specific call failed
-                                else:
-                                    msg = f"{self.__class__.__name__}: Attempt {attempt}/{self.max_retries + 1} to execute call '{func_name}' failed."
-                                    raise CVGRPCStatusUnavailable(msg, *e.args, call_args, call_kwargs)
+                                await self._wait_before_retry_or_raise(e, attempt, func_name, call_args, call_kwargs)
 
                             case Status.RESOURCE_EXHAUSTED:
                                 if matches := fullmatch(MSG_SIZE_EXCEEDED_REGEX, e.message):
@@ -275,21 +278,7 @@ class GRPCRequestHandler:
                         # Other error codes (e.g. NO_ERROR from timeout) fall through to CVClientException.
                         if not (matches := fullmatch(STREAM_RESET_ERROR_CODE_REGEX, str(e.args[0] if e.args else ""))) or int(matches.group("error_code")) != 2:
                             raise CVClientException(*e.args, call_args, call_kwargs)
-                        if attempt <= self.max_retries:
-                            delay = self.initial_delay * (self.factor ** (attempt - 1))
-                            LOGGER.warning(
-                                "%s: Attempt %s/%s to execute call '%s' returned '%s'. Retrying in %ss...",
-                                self.__class__.__name__,
-                                attempt,
-                                self.max_retries + 1,
-                                func_name,
-                                e,
-                                delay,
-                            )
-                            await asyncio_sleep(delay)
-                        else:
-                            msg = f"{self.__class__.__name__}: Attempt {attempt}/{self.max_retries + 1} to execute call '{func_name}' failed."
-                            raise CVGRPCStatusUnavailable(msg, *e.args, call_args, call_kwargs)
+                        await self._wait_before_retry_or_raise(e, attempt, func_name, call_args, call_kwargs)
 
                     case _:
                         raise CVClientException(*e.args, call_args, call_kwargs)

--- a/python-avd/pyavd/_cv/client/async_decorators.py
+++ b/python-avd/pyavd/_cv/client/async_decorators.py
@@ -14,7 +14,7 @@ from types import UnionType
 from typing import TYPE_CHECKING, Any, ClassVar, ParamSpec, TypeVar, get_args, get_origin
 
 from grpclib import Status
-from grpclib.exceptions import GRPCError
+from grpclib.exceptions import GRPCError, StreamTerminatedError
 
 from pyavd._cv.client.exceptions import CVClientBulkAPIError, CVClientException, CVGRPCError, CVResourceNotFound, CVTimeoutError
 from pyavd._utils import batch
@@ -34,6 +34,7 @@ T = TypeVar("T")
 
 
 MSG_SIZE_EXCEEDED_REGEX = re_compile(r"grpc: received message larger than max \((?P<size>\d+) vs\. (?P<max>\d+)\)")
+STREAM_RESET_ERROR_CODE_REGEX = re_compile(r"Stream reset by remote party, error_code: (?P<error_code>\d+)")
 
 
 class LimitCvVersion:
@@ -124,6 +125,9 @@ class GRPCRequestHandler:
         list_field (str): Name of the parameter to be split if Status.RESOURCE_EXHAUSTED is received.
         min_items_for_splitting_attempt (int): Minimum length of the item that we'll still try to split.
         check_bulk_response_errors (bool): Check for the presence of the 'error' inside each response tuple for bulk (stream-based) gRPC calls.
+        retry_on_stream_reset (bool): Retry on StreamTerminatedError (RST_STREAM INTERNAL_ERROR from server) using the same backoff as UNAVAILABLE.
+            Should be enabled for streaming calls (GetAll, GetSome, Subscribe) where transient server resets are possible.
+            It is ok to enable it for calls mixing GetAll or GetSome with GetOne.
     """
 
     max_retries: int
@@ -132,6 +136,7 @@ class GRPCRequestHandler:
     list_field: str | None
     min_items_for_splitting_attempt: int
     check_bulk_response_errors: bool
+    retry_on_stream_reset: bool
     func: Callable
     func_signature: Signature
     bound_arguments: BoundArguments
@@ -145,6 +150,7 @@ class GRPCRequestHandler:
         list_field: str | None = None,
         min_items_for_splitting_attempt: int = 2,
         check_bulk_response_errors: bool = False,
+        retry_on_stream_reset: bool = False,
     ) -> None:
         self.max_retries = max_retries
         self.initial_delay = initial_delay
@@ -152,6 +158,7 @@ class GRPCRequestHandler:
         self.list_field = list_field
         self.min_items_for_splitting_attempt = max(2, min_items_for_splitting_attempt)
         self.check_bulk_response_errors = check_bulk_response_errors
+        self.retry_on_stream_reset = retry_on_stream_reset
 
     def __call__(self, func: Callable[P, T]) -> Callable[P, T]:
         self.func = func
@@ -262,6 +269,27 @@ class GRPCRequestHandler:
                             case _:
                                 # All other gRPC errors are converted to CVGRPCError
                                 raise CVGRPCError(*e.args, call_args, call_kwargs)
+
+                    case StreamTerminatedError() if self.retry_on_stream_reset:
+                        # Only retry on HTTP2 RST_STREAM INTERNAL_ERROR (error_code: 2) - transient server-side fault.
+                        # Other error codes (e.g. NO_ERROR from timeout) fall through to CVClientException.
+                        if not (matches := fullmatch(STREAM_RESET_ERROR_CODE_REGEX, str(e.args[0] if e.args else ""))) or int(matches.group("error_code")) != 2:
+                            raise CVClientException(*e.args, call_args, call_kwargs)
+                        if attempt <= self.max_retries:
+                            delay = self.initial_delay * (self.factor ** (attempt - 1))
+                            LOGGER.warning(
+                                "%s: Attempt %s/%s to execute call '%s' returned '%s'. Retrying in %ss...",
+                                self.__class__.__name__,
+                                attempt,
+                                self.max_retries + 1,
+                                func_name,
+                                e,
+                                delay,
+                            )
+                            await asyncio_sleep(delay)
+                        else:
+                            msg = f"{self.__class__.__name__}: Attempt {attempt}/{self.max_retries + 1} to execute call '{func_name}' failed."
+                            raise CVGRPCStatusUnavailable(msg, *e.args, call_args, call_kwargs)
 
                     case _:
                         raise CVClientException(*e.args, call_args, call_kwargs)

--- a/python-avd/pyavd/_cv/client/change_control.py
+++ b/python-avd/pyavd/_cv/client/change_control.py
@@ -177,7 +177,7 @@ class ChangeControlMixin(Protocol):
 
         return response.value
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def wait_for_change_control_state(
         self: CVClientProtocol,
         cc_id: str,

--- a/python-avd/pyavd/_cv/client/configlet.py
+++ b/python-avd/pyavd/_cv/client/configlet.py
@@ -56,7 +56,7 @@ class ConfigletMixin(Protocol):
 
     configlet_api_version: Literal["v1"] = "v1"
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def get_configlet_containers(
         self: CVClientProtocol,
         workspace_id: str,
@@ -249,7 +249,7 @@ class ConfigletMixin(Protocol):
 
         return response.value
 
-    @GRPCRequestHandler(list_field="configlet_ids")
+    @GRPCRequestHandler(list_field="configlet_ids", retry_on_stream_reset=True)
     async def get_configlets(
         self: CVClientProtocol,
         workspace_id: str,

--- a/python-avd/pyavd/_cv/client/inventory.py
+++ b/python-avd/pyavd/_cv/client/inventory.py
@@ -22,7 +22,7 @@ class InventoryMixin(Protocol):
 
     inventory_api_version: Literal["v1"] = "v1"
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def get_inventory_devices(
         self: CVClientProtocol,
         devices: set[tuple[str | None, str | None, str | None]] | None = None,

--- a/python-avd/pyavd/_cv/client/studio.py
+++ b/python-avd/pyavd/_cv/client/studio.py
@@ -51,7 +51,7 @@ class StudioMixin(Protocol):
 
     studio_api_version: Literal["v1"] = "v1"
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def get_studio(
         self: CVClientProtocol,
         studio_id: str,
@@ -123,7 +123,7 @@ class StudioMixin(Protocol):
 
         return response.value
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def get_studio_inputs(
         self: CVClientProtocol,
         studio_id: str,
@@ -221,7 +221,7 @@ class StudioMixin(Protocol):
 
         return studio_inputs or default_value
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def get_studio_inputs_with_path(
         self: CVClientProtocol,
         studio_id: str,

--- a/python-avd/pyavd/_cv/client/swg.py
+++ b/python-avd/pyavd/_cv/client/swg.py
@@ -72,7 +72,7 @@ class SwgMixin(Protocol):
 
         return response.time, response.value
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def wait_for_swg_endpoint_status(
         self: CVClientProtocol,
         device_id: str,

--- a/python-avd/pyavd/_cv/client/tag.py
+++ b/python-avd/pyavd/_cv/client/tag.py
@@ -56,7 +56,7 @@ class TagMixin(Protocol):
 
     tags_api_version: Literal["v2"] = "v2"
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def get_tags(
         self: CVClientProtocol,
         workspace_id: str,
@@ -155,7 +155,7 @@ class TagMixin(Protocol):
 
         return [response.key async for response in responses]
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def get_tag_assignments(
         self: CVClientProtocol,
         workspace_id: str,

--- a/python-avd/pyavd/_cv/client/workspace.py
+++ b/python-avd/pyavd/_cv/client/workspace.py
@@ -234,7 +234,7 @@ class WorkspaceMixin(Protocol):
         LOGGER.debug("submit_workspace: Got response to submission: %s", response.value)
         return response.value
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def wait_for_workspace_response(
         self: CVClientProtocol,
         workspace_id: str,
@@ -282,7 +282,7 @@ class WorkspaceMixin(Protocol):
         # TODO: Consider raising a more specific CVWorkspaceFailed exception.
         raise CVResourceNotFound(msg)
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def wait_for_workspace_state(
         self: CVClientProtocol,
         workspace_id: str,
@@ -322,7 +322,7 @@ class WorkspaceMixin(Protocol):
         msg = f"Workspace '{workspace_id}' has not reached desired state '{state}'."
         raise CVWorkspaceFailed(msg)
 
-    @GRPCRequestHandler()
+    @GRPCRequestHandler(retry_on_stream_reset=True)
     async def get_workspace_build_details(
         self: CVClientProtocol,
         workspace_id: str,

--- a/python-avd/tests/pyavd/cv/client/test_async_decorators.py
+++ b/python-avd/tests/pyavd/cv/client/test_async_decorators.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from grpclib import Status
-from grpclib.exceptions import GRPCError
+from grpclib.exceptions import GRPCError, StreamTerminatedError
 
 from pyavd._cv.client.async_decorators import GRPCRequestHandler, LimitCvVersion
 from pyavd._cv.client.exceptions import (
@@ -45,6 +45,76 @@ VALID_VERSION_TESTS = [
     pytest.param("2024.1.5", ("2024.1.0", "2024.1.99"), id="valid_version_2"),
     pytest.param("2025.42.25", ("2025.1.0", "2025.99.99"), id="valid_version_3"),
     pytest.param(CVAAS_VERSION_STRING, (CVAAS_VERSION_STRING, CVAAS_VERSION_STRING), id="valid_version_4"),
+]
+
+STREAM_RESET_RETRY_TESTS = [
+    # Format: failures, error_code, message, async_sleep_calls, log_patterns, outer_exception
+    pytest.param(
+        1,
+        2,
+        None,
+        1,
+        [
+            "Attempt 1/6 to execute call '.*' returned '.*'\\. Retrying in [0-9]+s",
+        ],
+        does_not_raise(),
+        id="ONE_STREAM_RESET_INTERNAL_ERROR_RECOVERS",
+    ),
+    pytest.param(
+        3,
+        2,
+        None,
+        3,
+        [
+            "Attempt 1/6 to execute call '.*' returned '.*'\\. Retrying in [0-9]+s.*",
+            "Attempt 2/6 to execute call '.*' returned '.*'\\. Retrying in [0-9]+s.*",
+            "Attempt 3/6 to execute call '.*' returned '.*'\\. Retrying in [0-9]+s.*",
+        ],
+        does_not_raise(),
+        id="THREE_STREAM_RESET_INTERNAL_ERRORS_RECOVERS",
+    ),
+    pytest.param(
+        6,
+        2,
+        None,
+        5,
+        [
+            "Attempt 1/6 to execute call '.*' returned '.*'\\. Retrying in [0-9]+s.*",
+            "Attempt 2/6 to execute call '.*' returned '.*'\\. Retrying in [0-9]+s.*",
+            "Attempt 3/6 to execute call '.*' returned '.*'\\. Retrying in [0-9]+s.*",
+            "Attempt 4/6 to execute call '.*' returned '.*'\\. Retrying in [0-9]+s.*",
+            "Attempt 5/6 to execute call '.*' returned '.*'\\. Retrying in [0-9]+s.*",
+        ],
+        pytest.raises(CVGRPCStatusUnavailable),
+        id="SIX_STREAM_RESET_INTERNAL_ERRORS_EXHAUSTED",
+    ),
+    pytest.param(
+        1,
+        0,
+        None,
+        0,
+        [],
+        pytest.raises(CVClientException),
+        id="STREAM_RESET_NO_ERROR_NOT_RETRIED",
+    ),
+    pytest.param(
+        1,
+        20,
+        None,
+        0,
+        [],
+        pytest.raises(CVClientException),
+        id="STREAM_RESET_ERROR_CODE_20_NOT_RETRIED",
+    ),
+    pytest.param(
+        1,
+        2,
+        "Protocol error",
+        0,
+        [],
+        pytest.raises(CVClientException),
+        id="STREAM_RESET_PROTOCOL_ERROR_NOT_RETRIED",
+    ),
 ]
 
 MSG_SIZE_HANDLER_TESTS = [
@@ -86,6 +156,7 @@ class CvClass:
         self._grpc_call_count = defaultdict(int)
         self._grpc_msgsize_unlimited_call_count = defaultdict(int)
         self._grpc_msgsize_limited_call_count = defaultdict(lambda: defaultdict(int))
+        self._stream_reset_call_count = defaultdict(int)
 
     @LimitCvVersion(min_ver="2024.1.0", max_ver="2024.1.99")
     async def version_limited_method(self) -> tuple[str, str]:
@@ -121,6 +192,33 @@ class CvClass:
     async def msgsize_unlimited_grpc_method_exception(self, inner_exception: Exception) -> Exception:
         self._grpc_msgsize_unlimited_call_count[self.msgsize_unlimited_grpc_method_exception.__name__] += 1
         raise inner_exception
+
+    @GRPCRequestHandler(retry_on_stream_reset=True)
+    async def stream_reset_retry_method(self, failures: int = 0, error_code: int = 2, message: str | None = None) -> str:
+        self._stream_reset_call_count[self.stream_reset_retry_method.__name__] += 1
+        if self._stream_reset_call_count[self.stream_reset_retry_method.__name__] <= failures:
+            raise StreamTerminatedError(message if message is not None else f"Stream reset by remote party, error_code: {error_code}")
+        return "gRPC call succeeded"
+
+    @GRPCRequestHandler(retry_on_stream_reset=True)
+    async def mixed_retry_method(self, exceptions: list[Exception]) -> str:
+        self._stream_reset_call_count[self.mixed_retry_method.__name__] += 1
+        if (attempt := self._stream_reset_call_count[self.mixed_retry_method.__name__]) <= len(exceptions):
+            raise exceptions[attempt - 1]
+        return "gRPC call succeeded"
+
+    @GRPCRequestHandler(retry_on_stream_reset=True)
+    async def streaming_with_mid_reset_method(self, items: list[str], fail_on_attempt: int = 1) -> list[str]:
+        """Simulates streaming: processes items one by one, raises RST_STREAM mid-stream on the specified attempt."""
+        self._stream_reset_call_count[self.streaming_with_mid_reset_method.__name__] += 1
+        attempt = self._stream_reset_call_count[self.streaming_with_mid_reset_method.__name__]
+        result = []
+        msg = "Stream reset by remote party, error_code: 2"
+        for i, item in enumerate(items):
+            if attempt == fail_on_attempt and i == len(items) // 2:
+                raise StreamTerminatedError(msg)
+            result.append(item)
+        return result
 
     @GRPCRequestHandler()
     async def msgsize_unlimited_grpc_method_failure(self, failures: int = 0) -> Exception | str:
@@ -628,6 +726,18 @@ async def test_grpc_request_handler_unlimited_success(
             pytest.raises(CVResourceNotFound, match=r"Raising the same CV exception."),
             id="GRPC_DEADLINE_EXCEEDED_DEADLINE_EXCEEDED",
         ),
+        pytest.param(
+            ["Preparing call.*with 1 item"],
+            StreamTerminatedError("Stream reset by remote party, error_code: 2"),
+            pytest.raises(CVClientException),
+            id="STREAM_RESET_INTERNAL_ERROR_NO_RETRY_FLAG",
+        ),
+        pytest.param(
+            ["Preparing call.*with 1 item"],
+            StreamTerminatedError("Protocol error"),
+            pytest.raises(CVClientException),
+            id="STREAM_RESET_PROTOCOL_ERROR_NO_RETRY_FLAG",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -753,6 +863,99 @@ async def test_responses_all_errors(caplog: pytest.LogCaptureFixture) -> None:
         assert isinstance(response, tuple)
         assert response[0].response_id == str(item)
         assert response[1] == f"Error for item {item}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    (
+        "failures",
+        "error_code",
+        "message",
+        "async_sleep_calls",
+        "log_patterns",
+        "outer_exception",
+    ),
+    STREAM_RESET_RETRY_TESTS,
+)
+async def test_grpc_request_handler_stream_reset_retry(
+    caplog: pytest.LogCaptureFixture,
+    failures: int,
+    error_code: int,
+    message: str | None,
+    async_sleep_calls: int,
+    log_patterns: list[str],
+    outer_exception: ExpectedExceptionContext,
+) -> None:
+    with patch("pyavd._cv.client.async_decorators.asyncio_sleep", new_callable=AsyncMock) as sleep_mock:
+        mocked_cv_client = CvClass(CvVersion(CVAAS_VERSION_STRING))
+        with caplog.at_level(logging.WARNING), outer_exception:
+            _ = await mocked_cv_client.stream_reset_retry_method(failures=failures, error_code=error_code, message=message)
+
+        # Assert that log messages match expected log patterns
+        for current_pattern, current_record in zip(log_patterns, caplog.records, strict=False):
+            assert re.search(re.compile(current_pattern), current_record.message)
+
+        # Assert correct number of sleep calls (retries)
+        assert sleep_mock.call_count == async_sleep_calls
+
+        # Assert exponential backoff on retried cases
+        delay_pattern = re.compile(r"Retrying in (?P<delay>\d+)s")
+        current_call_delays = [int(delay_match.group("delay")) for record in caplog.records if (delay_match := delay_pattern.search(record.message))]
+        assert all((y / x == 2) for x, y in pairwise(current_call_delays))
+
+
+@pytest.mark.asyncio
+async def test_grpc_request_handler_stream_reset_mid_stream(caplog: pytest.LogCaptureFixture) -> None:
+    """RST_STREAM occurs mid-stream after processing some items — partial results must not leak and retry must return full response."""
+    items = ["a", "b", "c", "d", "e"]
+
+    with patch("pyavd._cv.client.async_decorators.asyncio_sleep", new_callable=AsyncMock) as sleep_mock:
+        mocked_cv_client = CvClass(CvVersion(CVAAS_VERSION_STRING))
+        with caplog.at_level(logging.WARNING):
+            result = await mocked_cv_client.streaming_with_mid_reset_method(items=items, fail_on_attempt=1)
+
+        # Full response from the retried call — no partial results from the failed attempt
+        assert result == items
+
+        # Exactly one retry
+        assert sleep_mock.call_count == 1
+
+        # Log correctly names the RST_STREAM exception
+        assert re.search(
+            re.compile(r"Attempt 1/6 to execute call '.*' returned '.*Stream reset by remote party, error_code: 2.*'\. Retrying in [0-9]+s"),
+            caplog.records[0].message,
+        )
+
+
+@pytest.mark.asyncio
+async def test_grpc_request_handler_mixed_unavailable_and_stream_reset(caplog: pytest.LogCaptureFixture) -> None:
+    """UNAVAILABLE and RST_STREAM INTERNAL_ERROR failures alternate — retry counter is shared and each log names the correct exception."""
+    exceptions = [
+        GRPCError(Status.UNAVAILABLE),
+        StreamTerminatedError("Stream reset by remote party, error_code: 2"),
+        GRPCError(Status.UNAVAILABLE),
+    ]
+    log_patterns = [
+        r"Attempt 1/6 to execute call '.*' returned '.*UNAVAILABLE.*'\. Retrying in [0-9]+s",
+        r"Attempt 2/6 to execute call '.*' returned '.*Stream reset by remote party, error_code: 2.*'\. Retrying in [0-9]+s",
+        r"Attempt 3/6 to execute call '.*' returned '.*UNAVAILABLE.*'\. Retrying in [0-9]+s",
+    ]
+
+    with patch("pyavd._cv.client.async_decorators.asyncio_sleep", new_callable=AsyncMock) as sleep_mock:
+        mocked_cv_client = CvClass(CvVersion(CVAAS_VERSION_STRING))
+        with caplog.at_level(logging.WARNING):
+            result = await mocked_cv_client.mixed_retry_method(exceptions=exceptions)
+
+        assert result == "gRPC call succeeded"
+        assert sleep_mock.call_count == 3
+
+        for current_pattern, current_record in zip(log_patterns, caplog.records, strict=False):
+            assert re.search(re.compile(current_pattern), current_record.message)
+
+        # Assert exponential backoff across mixed failure types
+        delay_pattern = re.compile(r"Retrying in (?P<delay>\d+)s")
+        delays = [int(m.group("delay")) for r in caplog.records if (m := delay_pattern.search(r.message))]
+        assert all((y / x == 2) for x, y in pairwise(delays))
 
 
 @pytest.mark.asyncio

--- a/python-avd/tests/pyavd/cv/mockery.py
+++ b/python-avd/tests/pyavd/cv/mockery.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+from asyncio.exceptions import TimeoutError as AsyncioTimeoutError
 from hashlib import sha1
 from logging import getLogger
 from os import environ
@@ -11,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
 from grpclib import GRPCError, Status
+from grpclib.exceptions import ProtocolError, StreamTerminatedError
 
 from pyavd._cv.workflows.models import CVDevice
 from pyavd._utils import get_v2
@@ -59,6 +61,28 @@ def get_recording_file(route: str, request: IProtoMessage, cv_server: str, recor
     return recording_file
 
 
+def _serialize_exception(e: Exception) -> str:
+    """Serialize a known exception raised by the grpclib to a JSON string for recording."""
+    # non-OK gRPC status (e.g. NOT_FOUND, UNAVAILABLE)
+    if isinstance(e, GRPCError):
+        raise_dict = {"type": "GRPCError", "status": str(e.args[0]).removeprefix("Status."), "message": e.args[1]}
+    # RST_STREAM from server, TCP connection lost, GOAWAY frame, or HTTP/2 protocol error.
+    elif isinstance(e, StreamTerminatedError):
+        raise_dict = {"type": "StreamTerminatedError", "message": e.args[0]}
+    # Local grpc-timeout deadline expired
+    elif isinstance(e, AsyncioTimeoutError):
+        raise_dict = {"type": "AsyncioTimeoutError", "message": e.args[0]}
+    # Client code violated the gRPC protocol (e.g. double recv, send after end).
+    elif isinstance(e, ProtocolError):
+        raise_dict = {"type": "ProtocolError", "message": e.args[0]}
+    # Unknown/new exception - serialize dynamically.
+    else:
+        raise_dict = {"type": type(e).__name__}
+        if e.args:
+            raise_dict["message"] = e.args[0]
+    return json.dumps({"raise": raise_dict}, indent=4)
+
+
 async def recording_unary_unary(
     self: ServiceStub,
     route: str,
@@ -76,17 +100,8 @@ async def recording_unary_unary(
     # Catch returned gRPC Exception (like Workspace is not found, etc.)
     except Exception as e:
         LOGGER.debug("recording_unary_unary: Got exception executing request '%s': %s", request, e)
-        stringified_exception = (
-            "{\n"
-            '\t"raise": {\n'
-            f'\t\t"type": "{type(e).__name__}",\n'
-            f'\t\t"status": "{str(e.args[0]).removeprefix("Status.")}",\n'
-            f'\t\t"message": "{e.args[1]}"\n'
-            "\t}\n"
-            "}"
-        )
-        # Dump gRPC exception details into the recording file so that it can be easily replayed
-        recording_file.write_text(stringified_exception)
+        # Dump exception details into the recording file so that it can be easily replayed
+        recording_file.write_text(_serialize_exception(e))
         # Re-raise exception so that it is passed to and processed by our gRPC decorator
         raise
     else:
@@ -107,6 +122,7 @@ async def recording_unary_stream(
     LOGGER.info("recording_unary_stream: Recording API request: %s", request)
     recording_file = get_recording_file(route, request, cv_server=self.channel._host)
     messages_as_json = []
+    exception_only = False
     try:
         async for message in self._org_unary_stream(route, request, response_type, timeout=timeout, deadline=deadline, metadata=metadata):
             messages_as_json.append(message.to_json(indent=4))
@@ -114,30 +130,23 @@ async def recording_unary_stream(
     # Catch returned gRPC Exception
     except Exception as e:
         LOGGER.debug("recording_unary_stream: Got exception executing request '%s': %s", request, e)
-        stringified_exception = (
-            "{\n"
-            '\t"raise": {\n'
-            f'\t\t"type": "{type(e).__name__}",\n'
-            f'\t\t"status": "{str(e.args[0]).removeprefix("Status.")}",\n'
-            f'\t\t"message": "{e.args[1]}"\n'
-            "\t}\n"
-            "}"
-        )
-        # If no messages were yet recorded - just dump gRPC exception details into the recording file so that exception can be re-raised.
+        # If no messages were yet recorded - just dump exception details into the recording file so that exception can be re-raised.
         if not messages_as_json:
-            recording_file.write_text(stringified_exception)
+            recording_file.write_text(_serialize_exception(e))
+            exception_only = True
         # If some messages were already recorded - dump exception into the list of messages.
         else:
-            messages_as_json.append(stringified_exception)
+            messages_as_json.append(_serialize_exception(e))
         # Re-raise exception so that it is passed to and processed by our gRPC decorator
         raise
     finally:
-        # Write messages together with stringified exception if some messages were recorded prior to exception
-        if messages_as_json:
-            recording_file.write_text(f"[{', '.join(messages_as_json)}]")
-        # No messages were received. Write an empty list
-        else:
-            recording_file.write_text("[]")
+        if not exception_only:
+            # Write messages together with stringified exception if some messages were recorded prior to exception
+            if messages_as_json:
+                recording_file.write_text(f"[{', '.join(messages_as_json)}]")
+            # No messages were received. Write an empty list
+            else:
+                recording_file.write_text("[]")
 
 
 async def playback_unary_unary(
@@ -242,10 +251,17 @@ def raise_recorded_exception(recorded_exception: dict[str, Any]) -> None:
     exception_message = get_v2(recorded_exception, "message")
 
     match exception_type:
-        # TODO: Add additional match/case statements below this line to match new exception types once they are faced
-        # Raise GRPC exception.
         case "GRPCError":
             raise GRPCError(Status[exception_status], exception_message)
+        case "StreamTerminatedError":
+            raise StreamTerminatedError(exception_message)
+        case "AsyncioTimeoutError":
+            raise AsyncioTimeoutError(exception_message)
+        case "ProtocolError":
+            raise ProtocolError(exception_message)
         case _:
-            msg = "Unknown error returned. Update mockery.py"
+            msg = f"Unknown recorded exception type '{exception_type}'"
+            if exception_message:
+                msg += f": {exception_message}"
+            msg += ". Update mockery.py."
             raise NotImplementedError(msg)


### PR DESCRIPTION
## Change Summary

Extend GRPCRequestHandler retry logic to handle RST_STREAM frames with INTERNAL_ERROR code for idempotent cv_deploy API calls:
 - GetAll
 - GetSome
 - Subscribe
 - plus methods which have a mixes of above with GetOne

## Related Issue(s)

Fixes #6881

## Component(s) name

`arista.avd.cv_deploy`

## Proposed changes
- Extend `GRPCRequestHandler` to gracefully retry (up to the max times) when `RST_STREAM` HTTP2 frame with `INTERNAL_ERROR` code is received for the HTTP2 stream related to the idempotent (decorated with `retry_on_stream_reset=True`) cv_deploy gRPC methods
- Enable this extra retry logic for all existing `CVClient` idempotent methods 

## How to test
pytest `python-avd/tests/pyavd/cv/client/test_async_decorators.py`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
