### PR TITLE
CI: Change dependabot strategy to increase-if-necessary and remove autogenerated file from targets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ version: 2
 updates:
   # Maintain dependencies for Python
   - package-ecosystem: "pip"
+    versioning-strategy: increase-if-necessary
     directories:
       - "/"
       - "/python-avd/"
-      - "/ansible_collections/arista/avd/"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
So dependabot changed the behavior of the default strategy to increase out version and looking at the doc the best option we have today is to move to increase-if-necessary (could consider widen in the future)

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--

Also the file in `ansible_collections/arista/avd` is auto generated via pdm these days so no point in keeping the target dir.