### PR TITLE
Feat(eos_cli_config_gen): Support for type8a radius key

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -1613,6 +1613,7 @@ radius proxy
 | default | 10.10.11.156 | - | - | - | 34 | 45 |
 | default | 10.10.11.156 | True | 345 | - | - | - |
 | default | 10.10.10.249 | - | - | - | 1 | 1 |
+| default | 10.10.10.249 | - | - | - | 1 | 1 |
 | mgt | 10.10.10.157 | - | - | - | 1 | 1 |
 | mgt | 10.10.11.159 | - | - | - | - | 1 |
 | mgt | 10.10.11.160 | - | - | - | 1 | - |
@@ -1629,15 +1630,16 @@ radius-server attribute 32 include-in-access-req hostname
 radius-server dynamic-authorization port 1700
 radius-server tls ssl-profile GLOBAL_RADIUS_SSL_PROFILE
 radius-server dynamic-authorization tls ssl-profile SSL_PROFILE
-radius-server host 10.10.10.158 timeout 1 retransmit 1 key 7 <removed>
+radius-server host 10.10.10.158 timeout 1 retransmit 1 key 7<removed>
 radius-server host 10.10.11.156 tls port 1700 timeout 1 retransmit 1
-radius-server host 10.10.11.156 timeout 34 retransmit 45 key 7 <removed>
+radius-server host 10.10.11.156 timeout 34 retransmit 45 key 7<removed>
 radius-server host 10.10.11.156 tls port 345
-radius-server host 10.10.10.249 timeout 1 retransmit 1 key 7 <removed>
-radius-server host 10.10.10.157 vrf mgt timeout 1 retransmit 1 key 7 <removed>
-radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7 <removed>
-radius-server host 10.10.11.160 vrf mgt timeout 1 key 7 <removed>
-radius-server host 10.10.11.248 vrf mgt key 7 <removed>
+radius-server host 10.10.10.249 timeout 1 retransmit 1 key 0<removed>
+radius-server host 10.10.10.249 timeout 1 retransmit 1 key 8a<removed>
+radius-server host 10.10.10.157 vrf mgt timeout 1 retransmit 1 key 7<removed>
+radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7<removed>
+radius-server host 10.10.11.160 vrf mgt timeout 1 key 8a<removed>
+radius-server host 10.10.11.248 vrf mgt key 0<removed>
 radius-server host 10.10.11.155 vrf mgt tls ssl-profile HOST_SSL_PROFILE port 2083 timeout 1 retransmit 1
 radius-server host 10.10.11.158 vrf mgt tls ssl-profile SSL_PROFILE
 ```

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -1630,16 +1630,16 @@ radius-server attribute 32 include-in-access-req hostname
 radius-server dynamic-authorization port 1700
 radius-server tls ssl-profile GLOBAL_RADIUS_SSL_PROFILE
 radius-server dynamic-authorization tls ssl-profile SSL_PROFILE
-radius-server host 10.10.10.158 timeout 1 retransmit 1 key 7<removed>
+radius-server host 10.10.10.158 timeout 1 retransmit 1 key 7 <removed>
 radius-server host 10.10.11.156 tls port 1700 timeout 1 retransmit 1
-radius-server host 10.10.11.156 timeout 34 retransmit 45 key 7<removed>
+radius-server host 10.10.11.156 timeout 34 retransmit 45 key 7 <removed>
 radius-server host 10.10.11.156 tls port 345
-radius-server host 10.10.10.249 timeout 1 retransmit 1 key 0<removed>
-radius-server host 10.10.10.249 timeout 1 retransmit 1 key 8a<removed>
-radius-server host 10.10.10.157 vrf mgt timeout 1 retransmit 1 key 7<removed>
-radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7<removed>
-radius-server host 10.10.11.160 vrf mgt timeout 1 key 8a<removed>
-radius-server host 10.10.11.248 vrf mgt key 0<removed>
+radius-server host 10.10.10.249 timeout 1 retransmit 1 key 0 <removed>
+radius-server host 10.10.10.249 timeout 1 retransmit 1 key 8a <removed>
+radius-server host 10.10.10.157 vrf mgt timeout 1 retransmit 1 key 7 <removed>
+radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7 <removed>
+radius-server host 10.10.11.160 vrf mgt timeout 1 key 8a <removed>
+radius-server host 10.10.11.248 vrf mgt key 0 <removed>
 radius-server host 10.10.11.155 vrf mgt tls ssl-profile HOST_SSL_PROFILE port 2083 timeout 1 retransmit 1
 radius-server host 10.10.11.158 vrf mgt tls ssl-profile SSL_PROFILE
 ```

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1879,16 +1879,16 @@ radius-server attribute 32 include-in-access-req hostname
 radius-server dynamic-authorization port 1700
 radius-server tls ssl-profile GLOBAL_RADIUS_SSL_PROFILE
 radius-server dynamic-authorization tls ssl-profile SSL_PROFILE
-radius-server host 10.10.10.158 timeout 1 retransmit 1 key 7071B245F5A
+radius-server host 10.10.10.158 timeout 1 retransmit 1 key 7 071B245F5A
 radius-server host 10.10.11.156 tls port 1700 timeout 1 retransmit 1
-radius-server host 10.10.11.156 timeout 34 retransmit 45 key 7071B245F5A
+radius-server host 10.10.11.156 timeout 34 retransmit 45 key 7 071B245F5A
 radius-server host 10.10.11.156 tls port 345
-radius-server host 10.10.10.249 timeout 1 retransmit 1 key 0secret
-radius-server host 10.10.10.249 timeout 1 retransmit 1 key 8a$kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
-radius-server host 10.10.10.157 vrf mgt timeout 1 retransmit 1 key 7071B245F5A
-radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7071B245F5A
-radius-server host 10.10.11.160 vrf mgt timeout 1 key 8a$kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
-radius-server host 10.10.11.248 vrf mgt key 0Secret
+radius-server host 10.10.10.249 timeout 1 retransmit 1 key 0 secret
+radius-server host 10.10.10.249 timeout 1 retransmit 1 key 8a $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
+radius-server host 10.10.10.157 vrf mgt timeout 1 retransmit 1 key 7 071B245F5A
+radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7 071B245F5A
+radius-server host 10.10.11.160 vrf mgt timeout 1 key 8a $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
+radius-server host 10.10.11.248 vrf mgt key 0 Secret
 radius-server host 10.10.11.155 vrf mgt tls ssl-profile HOST_SSL_PROFILE port 2083 timeout 1 retransmit 1
 radius-server host 10.10.11.158 vrf mgt tls ssl-profile SSL_PROFILE
 !

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1879,15 +1879,16 @@ radius-server attribute 32 include-in-access-req hostname
 radius-server dynamic-authorization port 1700
 radius-server tls ssl-profile GLOBAL_RADIUS_SSL_PROFILE
 radius-server dynamic-authorization tls ssl-profile SSL_PROFILE
-radius-server host 10.10.10.158 timeout 1 retransmit 1 key 7 071B245F5A
+radius-server host 10.10.10.158 timeout 1 retransmit 1 key 7071B245F5A
 radius-server host 10.10.11.156 tls port 1700 timeout 1 retransmit 1
-radius-server host 10.10.11.156 timeout 34 retransmit 45 key 7 071B245F5A
+radius-server host 10.10.11.156 timeout 34 retransmit 45 key 7071B245F5A
 radius-server host 10.10.11.156 tls port 345
-radius-server host 10.10.10.249 timeout 1 retransmit 1 key 7 071B245F5A
-radius-server host 10.10.10.157 vrf mgt timeout 1 retransmit 1 key 7 071B245F5A
-radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7 071B245F5A
-radius-server host 10.10.11.160 vrf mgt timeout 1 key 7 071B245F5A
-radius-server host 10.10.11.248 vrf mgt key 7 071B245F5A
+radius-server host 10.10.10.249 timeout 1 retransmit 1 key 0secret
+radius-server host 10.10.10.249 timeout 1 retransmit 1 key 8a$kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
+radius-server host 10.10.10.157 vrf mgt timeout 1 retransmit 1 key 7071B245F5A
+radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7071B245F5A
+radius-server host 10.10.11.160 vrf mgt timeout 1 key 8a$kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
+radius-server host 10.10.11.248 vrf mgt key 0Secret
 radius-server host 10.10.11.155 vrf mgt tls ssl-profile HOST_SSL_PROFILE port 2083 timeout 1 retransmit 1
 radius-server host 10.10.11.158 vrf mgt tls ssl-profile SSL_PROFILE
 !

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/radius-server.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/radius-server.yml
@@ -29,7 +29,13 @@ radius_server:
         enabled: true
         port: 345
     - host: 10.10.10.249
-      key: 071B245F5A
+      key: secret
+      key_type: 0
+      timeout: 1
+      retransmit: 1
+    - host: 10.10.10.249
+      key: $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
+      key_type: 8a
       timeout: 1
       retransmit: 1
   vrfs:
@@ -44,9 +50,11 @@ radius_server:
           key: 071B245F5A
         - host: 10.10.11.160
           timeout: 1
-          key: 071B245F5A
+          key: $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
+          key_type: 8a
         - host: 10.10.11.248
-          key: 071B245F5A
+          key: Secret
+          key_type: 0
         - host: 10.10.11.155
           timeout: 1
           retransmit: 1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/radius-server.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/radius-server.md
@@ -23,7 +23,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "radius_server.servers.[].tls.port") | Integer |  |  | Min: 0<br>Max: 65535 | TCP Port used for TLS. EOS default is 2083. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "radius_server.servers.[].timeout") | Integer |  |  | Min: 1<br>Max: 1000 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;retransmit</samp>](## "radius_server.servers.[].retransmit") | Integer |  |  | Min: 0<br>Max: 100 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "radius_server.servers.[].key") | String |  |  |  | Encrypted key - only type 7 supported.<br>When TLS is configured, `key` is ignored. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "radius_server.servers.[].key") | String |  |  |  | Encrypted key.<br>When TLS is configured, `key` is ignored. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "radius_server.servers.[].key_type") | String |  | `7` | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> |  |
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "radius_server.vrfs") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "radius_server.vrfs.[].name") | String | Required, Unique |  |  | Non-defualt VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;servers</samp>](## "radius_server.vrfs.[].servers") | List, items: Dictionary | Required |  |  | Hosts configuration for VRF default. |
@@ -34,7 +35,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "radius_server.vrfs.[].servers.[].tls.port") | Integer |  |  | Min: 0<br>Max: 65535 | TCP Port used for TLS. EOS default is 2083. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "radius_server.vrfs.[].servers.[].timeout") | Integer |  |  | Min: 1<br>Max: 1000 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;retransmit</samp>](## "radius_server.vrfs.[].servers.[].retransmit") | Integer |  |  | Min: 0<br>Max: 100 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "radius_server.vrfs.[].servers.[].key") | String |  |  |  | Encrypted key - only type 7 supported.<br>When TLS is configured, `key` is ignored. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "radius_server.vrfs.[].servers.[].key") | String |  |  |  | Encrypted key.<br>When TLS is configured, `key` is ignored. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "radius_server.vrfs.[].servers.[].key_type") | String |  | `7` | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> |  |
     | [<samp>&nbsp;&nbsp;tls_ssl_profile</samp>](## "radius_server.tls_ssl_profile") | String |  |  |  | Name of global TLS profile. |
 
 === "YAML"
@@ -77,9 +79,10 @@
           timeout: <int; 1-1000>
           retransmit: <int; 0-100>
 
-          # Encrypted key - only type 7 supported.
+          # Encrypted key.
           # When TLS is configured, `key` is ignored.
           key: <str>
+          key_type: <str; "0" | "7" | "8a"; default="7">
       vrfs:
 
           # Non-defualt VRF name.
@@ -105,9 +108,10 @@
               timeout: <int; 1-1000>
               retransmit: <int; 0-100>
 
-              # Encrypted key - only type 7 supported.
+              # Encrypted key.
               # When TLS is configured, `key` is ignored.
               key: <str>
+              key_type: <str; "0" | "7" | "8a"; default="7">
 
       # Name of global TLS profile.
       tls_ssl_profile: <str>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/radius-server.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/radius-server.j2
@@ -45,7 +45,7 @@ radius-server dynamic-authorization tls ssl-profile {{ radius_server.dynamic_aut
 {%             set radius_cli = radius_cli ~ " retransmit " ~ radius_host.retransmit %}
 {%         endif %}
 {%         if radius_host.key is arista.avd.defined and radius_host.tls.enabled is not arista.avd.defined(true) %}
-{%             set radius_cli = radius_cli ~ " key " ~ radius_host.key_type | arista.avd.default('7') ~ radius_host.key | arista.avd.hide_passwords(hide_passwords) %}
+{%             set radius_cli = radius_cli ~ " key " ~ radius_host.key_type | arista.avd.default('7') ~ " " ~ radius_host.key | arista.avd.hide_passwords(hide_passwords) %}
 {%         endif %}
 {{ radius_cli }}
 {%     endfor %}
@@ -68,7 +68,7 @@ radius-server dynamic-authorization tls ssl-profile {{ radius_server.dynamic_aut
 {%                 set radius_cli = radius_cli ~ " retransmit " ~ radius_host.retransmit %}
 {%             endif %}
 {%             if radius_host.key is arista.avd.defined and radius_host.tls.enabled is not arista.avd.defined(true) %}
-{%                 set radius_cli = radius_cli ~ " key " ~ radius_host.key_type | arista.avd.default('7')  ~ radius_host.key | arista.avd.hide_passwords(hide_passwords) %}
+{%                 set radius_cli = radius_cli ~ " key " ~ radius_host.key_type | arista.avd.default('7')  ~ " " ~  radius_host.key | arista.avd.hide_passwords(hide_passwords) %}
 {%             endif %}
 {{ radius_cli }}
 {%         endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/radius-server.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/radius-server.j2
@@ -45,7 +45,7 @@ radius-server dynamic-authorization tls ssl-profile {{ radius_server.dynamic_aut
 {%             set radius_cli = radius_cli ~ " retransmit " ~ radius_host.retransmit %}
 {%         endif %}
 {%         if radius_host.key is arista.avd.defined and radius_host.tls.enabled is not arista.avd.defined(true) %}
-{%             set radius_cli = radius_cli ~ " key 7 " ~ radius_host.key | arista.avd.hide_passwords(hide_passwords) %}
+{%             set radius_cli = radius_cli ~ " key " ~ radius_host.key_type | arista.avd.default('7') ~ radius_host.key | arista.avd.hide_passwords(hide_passwords) %}
 {%         endif %}
 {{ radius_cli }}
 {%     endfor %}
@@ -68,7 +68,7 @@ radius-server dynamic-authorization tls ssl-profile {{ radius_server.dynamic_aut
 {%                 set radius_cli = radius_cli ~ " retransmit " ~ radius_host.retransmit %}
 {%             endif %}
 {%             if radius_host.key is arista.avd.defined and radius_host.tls.enabled is not arista.avd.defined(true) %}
-{%                 set radius_cli = radius_cli ~ " key 7 " ~ radius_host.key | arista.avd.hide_passwords(hide_passwords) %}
+{%                 set radius_cli = radius_cli ~ " key " ~ radius_host.key_type | arista.avd.default('7')  ~ radius_host.key | arista.avd.hide_passwords(hide_passwords) %}
 {%             endif %}
 {{ radius_cli }}
 {%         endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -39231,7 +39231,15 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         """
 
-            _fields: ClassVar[dict] = {"host": {"type": str}, "tls": {"type": Tls}, "timeout": {"type": int}, "retransmit": {"type": int}, "key": {"type": str}}
+            KeyType: TypeAlias = Literal["0", "7", "8a"]
+            _fields: ClassVar[dict] = {
+                "host": {"type": str},
+                "tls": {"type": Tls},
+                "timeout": {"type": int},
+                "retransmit": {"type": int},
+                "key": {"type": str},
+                "key_type": {"type": str, "default": "7"},
+            }
             host: str
             """
             -> Host IP address or name. Multiple server with the same hostname/IP address can be configured for
@@ -39247,9 +39255,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             retransmit: int | None
             key: str | None
             """
-            Encrypted key - only type 7 supported.
+            Encrypted key.
             When TLS is configured, `key` is ignored.
             """
+            key_type: KeyType
+            """Default value: `"7"`"""
 
             if TYPE_CHECKING:
 
@@ -39261,6 +39271,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     timeout: int | None | UndefinedType = Undefined,
                     retransmit: int | None | UndefinedType = Undefined,
                     key: str | None | UndefinedType = Undefined,
+                    key_type: KeyType | UndefinedType = Undefined,
                 ) -> None:
                     """
                     ServersItem.
@@ -39279,8 +39290,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         timeout: timeout
                         retransmit: retransmit
                         key:
-                           Encrypted key - only type 7 supported.
+                           Encrypted key.
                            When TLS is configured, `key` is ignored.
+                        key_type: key_type
 
                     """
 
@@ -39328,12 +39340,14 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                             """
 
+                KeyType: TypeAlias = Literal["0", "7", "8a"]
                 _fields: ClassVar[dict] = {
                     "host": {"type": str},
                     "tls": {"type": Tls},
                     "timeout": {"type": int},
                     "retransmit": {"type": int},
                     "key": {"type": str},
+                    "key_type": {"type": str, "default": "7"},
                 }
                 host: str
                 """
@@ -39350,9 +39364,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 retransmit: int | None
                 key: str | None
                 """
-                Encrypted key - only type 7 supported.
+                Encrypted key.
                 When TLS is configured, `key` is ignored.
                 """
+                key_type: KeyType
+                """Default value: `"7"`"""
 
                 if TYPE_CHECKING:
 
@@ -39364,6 +39380,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         timeout: int | None | UndefinedType = Undefined,
                         retransmit: int | None | UndefinedType = Undefined,
                         key: str | None | UndefinedType = Undefined,
+                        key_type: KeyType | UndefinedType = Undefined,
                     ) -> None:
                         """
                         ServersItem.
@@ -39382,8 +39399,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             timeout: timeout
                             retransmit: retransmit
                             key:
-                               Encrypted key - only type 7 supported.
+                               Encrypted key.
                                When TLS is configured, `key` is ignored.
+                            key_type: key_type
 
                         """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -14951,9 +14951,18 @@ keys:
               - str
             key:
               type: str
-              description: 'Encrypted key - only type 7 supported.
+              description: 'Encrypted key.
 
                 When TLS is configured, `key` is ignored.'
+            key_type:
+              type: str
+              convert_types:
+              - int
+              valid_values:
+              - '0'
+              - '7'
+              - 8a
+              default: '7'
       vrfs:
         type: list
         primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/radius_server.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/radius_server.schema.yml
@@ -81,8 +81,14 @@ keys:
             key:
               type: str
               description: |-
-                Encrypted key - only type 7 supported.
+                Encrypted key.
                 When TLS is configured, `key` is ignored.
+            key_type:
+              type: str
+              convert_types:
+                - int
+              valid_values: ["0", "7", "8a"]
+              default: "7"
       vrfs:
         type: list
         primary_key: name


### PR DESCRIPTION
## Change Summary

Support for type8a radius key

## Related Issue(s)

Fixes #https://github.com/aristanetworks/avd/issues/6853

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Support for type8a radius key

## How to test
Run Molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
