### PR TITLE
CI: Ignore beta Sonar rule text:s8565

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -46,3 +46,8 @@ sonar.coverage.exclusions=\
 # Ignore issues on all compiled templates using regex match
 sonar.issue.ignore.allfile=e1
 sonar.issue.ignore.allfile.e1.fileRegexp=^name = .*\.j2\'$
+
+# Ignore the requirements to check in lock file for pyproject.toml
+sonar.issue.ignore.multicriteria=ignore_s8565_pyproject
+sonar.issue.ignore.multicriteria.ignore_s8565_pyproject.ruleKey=text:S8565
+sonar.issue.ignore.multicriteria.ignore_s8565_pyproject.resourceKey=**/pyproject.toml


### PR DESCRIPTION
## Change Summary

Right now merge queue is failing because of a new rule introduced May 4th 2026 that requires us to add a lock file to the git repo to pin dependencies. We don't want to do this now as pyavd is a library (this is one of the reason suggested to omit the rule: https://sonarcloud.io/organizations/aristanetworks-1/rules?open=text%3AS8565&rule_key=text%3AS8565)

## Related Issue(s)

CI failing in merge queueu

## Component(s) name

`ci`

## Proposed changes

Add voodoo syntax to sonar-cloud.properties to ignore the rule

## How to test

need to merge `\(╯°□°）╯`
