### PR TITLE
Fix(pyavd): Refactor and fix static configuration studio deployment workflow

### DIFF
--- a/python-avd/pyavd/_cv/workflows/deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/pyavd/_cv/workflows/deploy_static_config_studio_manifest_to_cv.py
@@ -3,24 +3,21 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from asyncio import gather
 from logging import getLogger
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
-from .models import AVD_ENTITY_PREFIX, CVManifest
+from .static_configuration_studio.deploy import execute_plan, fetch_existing_state
+from .static_configuration_studio.models import DeploymentPlan, DesiredState, ResolvedState
 
 if TYPE_CHECKING:
-    from pyavd._cv.api.arista.configlet.v1 import ConfigletAssignment
     from pyavd._cv.client import CVClient
 
-    from .models import AvdManifest, CVContainer, DeployToCvResult
+    from .models import AvdManifest, DeployToCvResult
 
 LOGGER = getLogger(__name__)
 
 
-STATIC_CONFIGURATION_STUDIO_ID = "studio-static-configlet"
-
-
+# TODO: Move this to the workflows/static_configuration_studio package.
 async def deploy_static_config_studio_manifest_to_cv(manifest: AvdManifest, deployment_result: DeployToCvResult, cv_client: CVClient) -> None:
     """
     Deploy a manifest (configlets/containers) to CloudVision using the "Static Configuration" Studio.
@@ -31,152 +28,21 @@ async def deploy_static_config_studio_manifest_to_cv(manifest: AvdManifest, depl
     workspace_id = deployment_result.workspace.id
     LOGGER.info("deploy_static_config_studio_manifest_to_cv: Starting manifest deployment for workspace '%s'.", workspace_id)
 
-    # Build the desired CloudVision manifest from the AVD manifest.
-    cv_manifest = CVManifest.from_avd_manifest(manifest)
+    # Build the desired state from the AVD manifest.
+    desired = DesiredState.from_avd_manifest(manifest)
 
     LOGGER.info(
         "deploy_static_config_studio_manifest_to_cv: Calculated desired state: %d containers and %d unique configlets.",
-        len(cv_manifest.containers),
-        len(cv_manifest.configlets),
+        len(desired.containers_by_id),
+        len(desired.configlets_by_id),
     )
-    if not cv_manifest.configlets and not cv_manifest.containers:
+    if not desired.configlets_by_id and not desired.containers_by_id:
         return
 
-    # Perform synchronization tasks.
-    await _sync_configlets(cv_manifest=cv_manifest, deployment_result=deployment_result, cv_client=cv_client)
-    await _sync_containers(cv_manifest=cv_manifest, deployment_result=deployment_result, cv_client=cv_client)
-    await _sync_studio_roots(cv_manifest=cv_manifest, deployment_result=deployment_result, cv_client=cv_client)
+    existing = await fetch_existing_state(cv_client, workspace_id)
+    resolved = ResolvedState.build(desired, existing)
+    plan = DeploymentPlan.build(desired, existing, resolved)
+    await execute_plan(plan, workspace_id, deployment_result, cv_client)
 
     # Done.
     LOGGER.info("deploy_static_config_studio_manifest_to_cv: Completed manifest deployment for workspace '%s'.", workspace_id)
-
-
-async def _sync_containers(cv_manifest: CVManifest, deployment_result: DeployToCvResult, cv_client: CVClient) -> dict[str, ConfigletAssignment]:
-    """Synchronize containers. Fetch existing ones and push any required creates or updates."""
-    workspace_id = deployment_result.workspace.id
-
-    LOGGER.info("deploy_static_config_studio_manifest_to_cv: Fetching all existing configlet containers from CloudVision...")
-    existing_containers = await cv_client.get_configlet_containers(workspace_id=workspace_id)
-    existing_containers_by_id = {cast("str", container.key.configlet_assignment_id): container for container in existing_containers}
-
-    containers_to_push: list[CVContainer] = []
-    for desired_container in cv_manifest.containers:
-        existing_container = existing_containers_by_id.get(desired_container.id)
-
-        # Container is new or has changed, so it needs to be pushed.
-        if not existing_container or not desired_container.matches_configlet_assignment(existing_container):
-            containers_to_push.append(desired_container)
-        else:
-            # Container is unchanged.
-            deployment_result.skipped_static_config_containers.append(desired_container.avd_container)
-
-    if containers_to_push:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Applying changes for %d containers (create/update)...", len(containers_to_push))
-        deployment_result.deployed_static_config_containers.extend(container.avd_container for container in containers_to_push)
-        container_tuples = [container.api_tuple for container in containers_to_push]
-        await cv_client.set_configlet_containers(workspace_id=workspace_id, containers=container_tuples)
-    else:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: No container creations or updates are needed.")
-
-    # Delete unused AVD-managed containers.
-    desired_container_ids = {container.id for container in cv_manifest.containers}
-    containers_to_delete = {
-        container_id: cast("str", container.display_name)
-        for container_id, container in existing_containers_by_id.items()
-        if container_id.startswith(AVD_ENTITY_PREFIX) and container_id not in desired_container_ids
-    }
-
-    if containers_to_delete:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Removing %d AVD-managed containers which are no longer used.", len(containers_to_delete))
-        deployment_result.removed_static_config_containers.extend(containers_to_delete.values())
-        # TODO: Build a 'delete_configlet_containers' gRPC API
-        await gather(*[cv_client.delete_configlet_container(workspace_id=workspace_id, assignment_id=container_id) for container_id in containers_to_delete])
-    else:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: No AVD-managed container deletions are needed.")
-
-
-async def _sync_configlets(cv_manifest: CVManifest, deployment_result: DeployToCvResult, cv_client: CVClient) -> None:
-    """Synchronize configlets. Create/update declared ones and optionally delete not declared AVD-managed ones."""
-    workspace_id = deployment_result.workspace.id
-
-    # Create or update configlets.
-    if cv_manifest.configlets:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Applying changes for %d configlets (create/update)...", len(cv_manifest.configlets))
-        deployment_result.deployed_static_config_configlets.extend(configlet.avd_configlet for configlet in cv_manifest.configlets)
-        configlet_tuples = [configlet.api_tuple for configlet in cv_manifest.configlets]
-        await cv_client.set_configlets_from_files(workspace_id=workspace_id, configlets=configlet_tuples)
-    else:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: No configlet creations or updates are needed.")
-
-    # In "additive" mode, don't delete any configlets.
-    if cv_manifest.configlet_policy == "additive":
-        LOGGER.debug("deploy_static_config_studio_manifest_to_cv: No configlet deletions when configlet_policy is set to additive.")
-        return
-
-    # In "managed" mode, delete manifest-managed configlets not declared in this manifest and not assigned to any container.
-    existing_configlets = await cv_client.get_configlets(workspace_id=workspace_id)
-    desired_configlet_ids = {configlet.id for configlet in cv_manifest.configlets}
-    configlets_to_delete = {
-        configlet_id: cast("str", configlet.display_name)
-        for configlet in existing_configlets
-        if (configlet_id := cast("str", configlet.key.configlet_id)).startswith(AVD_ENTITY_PREFIX) and configlet_id not in desired_configlet_ids
-    }
-
-    if configlets_to_delete:
-        LOGGER.info(
-            "deploy_static_config_studio_manifest_to_cv: Deleting %d manifest-managed "
-            "configlets not declared in this manifest and not assigned to any container.",
-            len(configlets_to_delete),
-        )
-        deployment_result.removed_static_config_configlets.extend(configlets_to_delete.values())
-        await cv_client.delete_configlets(workspace_id=workspace_id, configlet_ids=list(configlets_to_delete.keys()))
-    else:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: No AVD-managed configlet deletions are needed.")
-
-
-async def _sync_studio_roots(cv_manifest: CVManifest, deployment_result: DeployToCvResult, cv_client: CVClient) -> None:
-    """
-    Synchronize Studio root containers. Update root container assignments.
-
-    Note:
-        When new manifest root container IDs are introduced, all manifest containers are placed first,
-        followed by any existing root containers.
-        When only removing manifest root containers, the existing order is preserved and removed entries
-        are filtered out, keeping existing root containers in their current positions.
-    """
-    workspace_id = deployment_result.workspace.id
-
-    LOGGER.info("deploy_static_config_studio_manifest_to_cv: Syncing Static Config Studio root container assignments...")
-
-    # Get the existing list of root container IDs from the Studio inputs.
-    existing_root_ids: list[str] = await cv_client.get_studio_inputs_with_path(
-        studio_id=STATIC_CONFIGURATION_STUDIO_ID,
-        workspace_id=workspace_id,
-        input_path=["configletAssignmentRoots"],
-        default_value=[],
-    )
-
-    # Calculate which desired roots are missing.
-    desired_root_ids = [container.id for container in cv_manifest.containers if container.is_root]
-    desired_root_ids_set = set(desired_root_ids)
-    existing_root_ids_set = set(existing_root_ids)
-    missing_ids = desired_root_ids_set - existing_root_ids_set
-
-    if missing_ids:
-        non_manifest_root_ids = [container_id for container_id in existing_root_ids if not container_id.startswith(AVD_ENTITY_PREFIX)]
-        new_ordered_ids = desired_root_ids + non_manifest_root_ids
-    else:
-        new_ordered_ids = [
-            container_id for container_id in existing_root_ids if container_id in desired_root_ids_set or not container_id.startswith(AVD_ENTITY_PREFIX)
-        ]
-
-    if new_ordered_ids != existing_root_ids:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Updating Studio root container assignment list...")
-        await cv_client.set_studio_inputs(
-            studio_id=STATIC_CONFIGURATION_STUDIO_ID,
-            workspace_id=workspace_id,
-            input_path=["configletAssignmentRoots"],
-            inputs=new_ordered_ids,
-        )
-    else:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Studio root container assignments are already in the desired state.")

--- a/python-avd/pyavd/_cv/workflows/models.py
+++ b/python-avd/pyavd/_cv/workflows/models.py
@@ -7,14 +7,13 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
-from uuid import NAMESPACE_DNS, uuid4, uuid5
+from uuid import uuid4
 
 from pyavd._cv.client.configlet import ASSIGNMENT_MATCH_POLICY_MAP
 from pyavd._cv.client.exceptions import CVManifestError
 from pyavd._cv.client.models import CVTag, CVTagAssignment
 
-AVD_NAMESPACE = uuid5(NAMESPACE_DNS, "avd.arista.com")
-AVD_ENTITY_PREFIX = "avd_"
+from .static_configuration_studio.ids import AvdId
 
 if TYPE_CHECKING:
     from pyavd._cv.api.arista.configlet.v1 import ConfigletAssignment
@@ -395,78 +394,91 @@ class AvdManifest:
             raise ValueError(msg) from e
 
 
+# TODO: Rename this class to DesiredState and move it to the workflows/static_configuration_studio package.
 @dataclass(frozen=True)
 class CVManifest:
     """CloudVision manifest to be created/updated to the "Static Configuration" Studio."""
 
     configlet_policy: Literal["managed", "additive"]
-    configlets: tuple[CVConfiglet, ...]
-    containers: tuple[CVContainer, ...]
+    configlets_by_id: dict[str, CVConfiglet]
+    containers_by_id: dict[str, CVContainer]
+    root_ids: list[str]
 
     @classmethod
     def from_avd_manifest(cls, avd_manifest: AvdManifest) -> CVManifest:
         """Build the desired CVManifest from the AVD input manifest."""
-        cv_configlet_map: dict[str, CVConfiglet] = {}
-        cv_container_map: dict[str, CVContainer] = {}
+        configlets_by_id: dict[str, CVConfiglet] = {}
+        containers_by_id: dict[str, CVContainer] = {}
+        root_ids: list[str] = []
 
-        # Create all CVConfiglet objects first.
+        # Create all CVConfiglet objects first so containers can resolve their configlet name references.
         for avd_configlet in avd_manifest.configlets:
             cv_configlet = CVConfiglet(
-                avd_configlet=avd_configlet, id=cls._generate_deterministic_id(avd_configlet.name), description="Configlet created and uploaded by AVD."
+                avd_configlet=avd_configlet,
+                id=AvdId.generate(avd_configlet.name),
+                description="Configlet created and uploaded by AVD.",
             )
-            if cv_configlet.name in cv_configlet_map:
+            if cv_configlet.id in configlets_by_id:
                 msg = f"Duplicate configlet name found: '{cv_configlet.name}'. All AVD-managed configlet names must be unique."
                 raise CVManifestError(msg)
-            cv_configlet_map[cv_configlet.name] = cv_configlet
+            configlets_by_id[cv_configlet.id] = cv_configlet
 
-        # Recursively process all containers.
+        # Build each declared root container (and its subtree) into the by-id mappings.
         for root_container in avd_manifest.containers:
-            cls._process_container_recursively(container=root_container, parent_path="", cv_configlet_map=cv_configlet_map, cv_container_map=cv_container_map)
+            root_id = cls._build_container_subtree(
+                container=root_container, parent_path="", configlets_by_id=configlets_by_id, containers_by_id=containers_by_id
+            )
+            root_ids.append(root_id)
 
         # Return the completed manifest.
-        return cls(configlet_policy=avd_manifest.configlet_policy, configlets=tuple(cv_configlet_map.values()), containers=tuple(cv_container_map.values()))
+        return cls(
+            configlet_policy=avd_manifest.configlet_policy,
+            configlets_by_id=configlets_by_id,
+            containers_by_id=containers_by_id,
+            root_ids=root_ids,
+        )
 
     @classmethod
-    def _process_container_recursively(
-        cls, container: AvdContainer, parent_path: str, cv_configlet_map: dict[str, CVConfiglet], cv_container_map: dict[str, CVContainer]
+    def _build_container_subtree(
+        cls,
+        container: AvdContainer,
+        parent_path: str,
+        configlets_by_id: dict[str, CVConfiglet],
+        containers_by_id: dict[str, CVContainer],
     ) -> str:
-        """Recursively traverse the container tree, populating the cv_ mappings along the way. Returns the generated ID for the current container."""
+        """Recursively build the given container and all its sub-containers into the by-id mappings. Returns the generated ID of the current container."""
         current_path = f"{parent_path}/{container.name}" if parent_path else container.name
 
-        # Process sub-containers.
+        # Process sub-containers first so their IDs are available when populating the current container child_ids.
         child_ids = [
-            cls._process_container_recursively(sub_container, current_path, cv_configlet_map, cv_container_map) for sub_container in container.sub_containers
+            cls._build_container_subtree(sub_container, current_path, configlets_by_id, containers_by_id) for sub_container in container.sub_containers
         ]
 
         # Process configlets attached to this container.
         configlet_ids = []
         for configlet_name in container.configlets:
-            if configlet_name not in cv_configlet_map:
+            configlet_id = AvdId.generate(configlet_name)
+            if configlet_id not in configlets_by_id:
                 msg = f"Configlet '{configlet_name}' is assigned to a container but is not found in the input definition."
                 raise CVManifestError(msg)
-            configlet_ids.append(cv_configlet_map[configlet_name].id)
+            configlet_ids.append(configlet_id)
 
         # Create the parent CVContainer object.
         cv_container = CVContainer(
             avd_container=container,
-            id=cls._generate_deterministic_id(current_path),
+            id=AvdId.generate(current_path),
             is_root=(parent_path == ""),
             configlet_ids=tuple(configlet_ids),
             child_ids=tuple(child_ids),
         )
 
         # Store it in the main dictionary.
-        if current_path in cv_container_map:
+        if cv_container.id in containers_by_id:
             msg = f"Duplicate container name found: '{current_path}'. All AVD-managed sibling containers must have unique names."
             raise CVManifestError(msg)
-        cv_container_map[current_path] = cv_container
+        containers_by_id[cv_container.id] = cv_container
 
         return cv_container.id
-
-    @staticmethod
-    def _generate_deterministic_id(key: str) -> str:
-        """Generate a deterministic ID from AVD_NAMESPACE and the provided key."""
-        return f"{AVD_ENTITY_PREFIX}{uuid5(AVD_NAMESPACE, key)}"
 
 
 @dataclass(frozen=True)

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/__init__.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
@@ -47,14 +47,14 @@ async def execute_plan(plan: DeploymentPlan, workspace_id: str, deployment_resul
     if plan.configlets_to_upsert:
         LOGGER.info("deploy_static_config_studio_manifest_to_cv: Applying changes for %d configlets (create/update)...", len(plan.configlets_to_upsert))
         deployment_result.deployed_static_config_configlets.extend(configlet.avd_configlet for configlet in plan.configlets_to_upsert)
-        await cv_client.set_configlets_from_files(workspace_id=workspace_id, configlets=[c.api_tuple for c in plan.configlets_to_upsert])
+        await cv_client.set_configlets_from_files(workspace_id=workspace_id, configlets=[configlet.api_tuple for configlet in plan.configlets_to_upsert])
     else:
         LOGGER.debug("deploy_static_config_studio_manifest_to_cv: No configlet creations or updates are needed.")
 
     if plan.containers_to_upsert:
         LOGGER.info("deploy_static_config_studio_manifest_to_cv: Applying changes for %d containers (create/update)...", len(plan.containers_to_upsert))
         deployment_result.deployed_static_config_containers.extend(container.avd_container for container in plan.containers_to_upsert)
-        await cv_client.set_configlet_containers(workspace_id=workspace_id, containers=[c.api_tuple for c in plan.containers_to_upsert])
+        await cv_client.set_configlet_containers(workspace_id=workspace_id, containers=[container.api_tuple for container in plan.containers_to_upsert])
     else:
         LOGGER.debug("deploy_static_config_studio_manifest_to_cv: No container creations or updates are needed.")
 

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
@@ -84,3 +84,19 @@ async def execute_plan(plan: DeploymentPlan, workspace_id: str, deployment_resul
         await cv_client.delete_configlets(workspace_id=workspace_id, configlet_ids=list(plan.configlets_to_delete))
     else:
         LOGGER.debug("deploy_static_config_studio_manifest_to_cv: No configlet deletions are needed.")
+
+    if plan.preserved_avd_containers:
+        LOGGER.warning(
+            "deploy_static_config_studio_manifest_to_cv: %d manifest-managed containers cannot be deleted because they are still attached to "
+            "non-manifest containers in CloudVision: %s",
+            len(plan.preserved_avd_containers),
+            ", ".join(sorted(plan.preserved_avd_containers.values())),
+        )
+
+    if plan.preserved_avd_configlets:
+        LOGGER.warning(
+            "deploy_static_config_studio_manifest_to_cv: %d manifest-managed configlets cannot be deleted because they are still assigned to "
+            "non-manifest containers in CloudVision: %s",
+            len(plan.preserved_avd_configlets),
+            ", ".join(sorted(plan.preserved_avd_configlets.values())),
+        )

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
@@ -85,18 +85,18 @@ async def execute_plan(plan: DeploymentPlan, workspace_id: str, deployment_resul
     else:
         LOGGER.debug("deploy_static_config_studio_manifest_to_cv: No configlet deletions are needed.")
 
-    if plan.preserved_avd_containers:
+    if plan.containers_preserved:
         LOGGER.warning(
             "deploy_static_config_studio_manifest_to_cv: %d manifest-managed containers cannot be deleted because they are still attached to "
             "non-manifest containers in CloudVision: %s",
-            len(plan.preserved_avd_containers),
-            ", ".join(sorted(plan.preserved_avd_containers.values())),
+            len(plan.containers_preserved),
+            ", ".join(sorted(plan.containers_preserved.values())),
         )
 
-    if plan.preserved_avd_configlets:
+    if plan.configlets_preserved:
         LOGGER.warning(
             "deploy_static_config_studio_manifest_to_cv: %d manifest-managed configlets cannot be deleted because they are still assigned to "
             "non-manifest containers in CloudVision: %s",
-            len(plan.preserved_avd_configlets),
-            ", ".join(sorted(plan.preserved_avd_configlets.values())),
+            len(plan.configlets_preserved),
+            ", ".join(sorted(plan.configlets_preserved.values())),
         )

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from asyncio import gather
+from logging import getLogger
+from typing import TYPE_CHECKING, cast
+
+from .models import DeploymentPlan, ExistingState
+
+if TYPE_CHECKING:
+    from pyavd._cv.client import CVClient
+    from pyavd._cv.workflows.models import DeployToCvResult
+
+LOGGER = getLogger(__name__)
+
+
+STATIC_CONFIGURATION_STUDIO_ID = "studio-static-configlet"
+
+
+async def fetch_existing_state(cv_client: CVClient, workspace_id: str) -> ExistingState:
+    """Fetch the current root container list, containers and configlets from CloudVision."""
+    LOGGER.info("deploy_static_config_studio_manifest_to_cv: Fetching existing state from CloudVision...")
+
+    existing_root_ids, existing_containers, existing_configlets = await gather(
+        cv_client.get_studio_inputs_with_path(
+            studio_id=STATIC_CONFIGURATION_STUDIO_ID,
+            workspace_id=workspace_id,
+            input_path=["configletAssignmentRoots"],
+            default_value=[],
+        ),
+        cv_client.get_configlet_containers(workspace_id=workspace_id),
+        cv_client.get_configlets(workspace_id=workspace_id),
+    )
+
+    return ExistingState(
+        root_ids=existing_root_ids,
+        containers_by_id={cast("str", container.key.configlet_assignment_id): container for container in existing_containers},
+        configlets_by_id={cast("str", configlet.key.configlet_id): configlet for configlet in existing_configlets},
+    )
+
+
+async def execute_plan(plan: DeploymentPlan, workspace_id: str, deployment_result: DeployToCvResult, cv_client: CVClient) -> None:
+    """Execute the deployment plan and populate the deployment result."""
+    # Configlets must exist before containers reference them.
+    if plan.configlets_to_upsert:
+        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Applying changes for %d configlets (create/update)...", len(plan.configlets_to_upsert))
+        deployment_result.deployed_static_config_configlets.extend(configlet.avd_configlet for configlet in plan.configlets_to_upsert)
+        await cv_client.set_configlets_from_files(workspace_id=workspace_id, configlets=[c.api_tuple for c in plan.configlets_to_upsert])
+    else:
+        LOGGER.debug("deploy_static_config_studio_manifest_to_cv: No configlet creations or updates are needed.")
+
+    if plan.containers_to_upsert:
+        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Applying changes for %d containers (create/update)...", len(plan.containers_to_upsert))
+        deployment_result.deployed_static_config_containers.extend(container.avd_container for container in plan.containers_to_upsert)
+        await cv_client.set_configlet_containers(workspace_id=workspace_id, containers=[c.api_tuple for c in plan.containers_to_upsert])
+    else:
+        LOGGER.debug("deploy_static_config_studio_manifest_to_cv: No container creations or updates are needed.")
+
+    deployment_result.skipped_static_config_containers.extend(container.avd_container for container in plan.containers_unchanged)
+
+    if plan.final_root_ids is not None:
+        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Updating Studio root container assignment list...")
+        await cv_client.set_studio_inputs(
+            studio_id=STATIC_CONFIGURATION_STUDIO_ID,
+            workspace_id=workspace_id,
+            input_path=["configletAssignmentRoots"],
+            inputs=plan.final_root_ids,
+        )
+    else:
+        LOGGER.debug("deploy_static_config_studio_manifest_to_cv: Studio root container assignment list is already in the desired state.")
+
+    if plan.containers_to_delete:
+        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Deleting %d containers...", len(plan.containers_to_delete))
+        deployment_result.removed_static_config_containers.extend(plan.containers_to_delete.values())
+        # TODO: Build a 'delete_configlet_containers' gRPC API
+        await gather(*[cv_client.delete_configlet_container(workspace_id=workspace_id, assignment_id=cid) for cid in plan.containers_to_delete])
+    else:
+        LOGGER.debug("deploy_static_config_studio_manifest_to_cv: No container deletions are needed.")
+
+    if plan.configlets_to_delete:
+        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Deleting %d configlets...", len(plan.configlets_to_delete))
+        deployment_result.removed_static_config_configlets.extend(plan.configlets_to_delete.values())
+        await cv_client.delete_configlets(workspace_id=workspace_id, configlet_ids=list(plan.configlets_to_delete))
+    else:
+        LOGGER.debug("deploy_static_config_studio_manifest_to_cv: No configlet deletions are needed.")

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/deploy.py
@@ -43,7 +43,6 @@ async def fetch_existing_state(cv_client: CVClient, workspace_id: str) -> Existi
 
 async def execute_plan(plan: DeploymentPlan, workspace_id: str, deployment_result: DeployToCvResult, cv_client: CVClient) -> None:
     """Execute the deployment plan and populate the deployment result."""
-    # Configlets must exist before containers reference them.
     if plan.configlets_to_upsert:
         LOGGER.info("deploy_static_config_studio_manifest_to_cv: Applying changes for %d configlets (create/update)...", len(plan.configlets_to_upsert))
         deployment_result.deployed_static_config_configlets.extend(configlet.avd_configlet for configlet in plan.configlets_to_upsert)

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/ids.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/ids.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from functools import lru_cache
+from uuid import NAMESPACE_DNS, uuid5
+
+
+class AvdId:
+    """Namespace for AVD-managed entity IDs."""
+
+    NAMESPACE = uuid5(NAMESPACE_DNS, "avd.arista.com")
+    PREFIX = "avd_"
+
+    @staticmethod
+    def is_managed(entity_id: str) -> bool:
+        """Return True if the given entity ID belongs to the AVD-managed namespace."""
+        return entity_id.startswith(AvdId.PREFIX)
+
+    @staticmethod
+    @lru_cache(maxsize=1024)
+    def generate(key: str) -> str:
+        """Generate a deterministic ID from the AVD namespace and the provided key."""
+        return f"{AvdId.PREFIX}{uuid5(AvdId.NAMESPACE, key)}"

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/models.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/models.py
@@ -137,6 +137,10 @@ class DeploymentPlan:
     """Mapping of container_id to display_name."""
     configlets_to_delete: dict[str, str] = field(default_factory=dict)
     """Mapping of configlet_id to display_name."""
+    preserved_avd_containers: dict[str, str] = field(default_factory=dict)
+    """Mapping of container_id to display_name for AVD-managed containers preserved because they are reachable through non-manifest containers."""
+    preserved_avd_configlets: dict[str, str] = field(default_factory=dict)
+    """Mapping of configlet_id to display_name for AVD-managed configlets preserved because they are still assigned to non-manifest containers."""
 
     @classmethod
     def build(cls, desired: DesiredState, existing: ExistingState, resolved: ResolvedState) -> DeploymentPlan:
@@ -162,20 +166,26 @@ class DeploymentPlan:
         if resolved.root_ids != existing.root_ids:
             plan.final_root_ids = resolved.root_ids
 
-        # Unreachable AVD-managed containers are deleted.
-        plan.containers_to_delete = {
-            container_id: cast("str", container.display_name)
-            for container_id, container in existing.containers_by_id.items()
-            if AvdId.is_managed(container_id) and container_id not in resolved.reachable_container_ids
-        }
+        # Classify each AVD-managed existing container as deletable (unreachable) or preserved (still reachable through non-manifest containers).
+        for container_id, container in existing.containers_by_id.items():
+            if not AvdId.is_managed(container_id):
+                continue
+            display_name = cast("str", container.display_name)
+            if container_id not in resolved.reachable_container_ids:
+                plan.containers_to_delete[container_id] = display_name
+            elif container_id not in desired.containers_by_id:
+                plan.preserved_avd_containers[container_id] = display_name
 
-        # In "managed" mode, delete AVD-managed configlets not declared in this manifest and not assigned to any container.
-        if desired.configlet_policy == "managed":
-            plan.configlets_to_delete = {
-                configlet_id: cast("str", configlet.display_name)
-                for configlet_id, configlet in existing.configlets_by_id.items()
-                if AvdId.is_managed(configlet_id) and configlet_id not in desired.configlets_by_id and configlet_id not in resolved.assigned_configlet_ids
-            }
+        # In "managed" mode, classify each AVD-managed existing configlet not in this manifest as deletable (unassigned) or preserved (still assigned).
         # In "additive" mode, don't delete any configlets.
+        if desired.configlet_policy == "managed":
+            for configlet_id, configlet in existing.configlets_by_id.items():
+                if not AvdId.is_managed(configlet_id) or configlet_id in desired.configlets_by_id:
+                    continue
+                display_name = cast("str", configlet.display_name)
+                if configlet_id in resolved.assigned_configlet_ids:
+                    plan.preserved_avd_configlets[configlet_id] = display_name
+                else:
+                    plan.configlets_to_delete[configlet_id] = display_name
 
         return plan

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/models.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/models.py
@@ -59,10 +59,11 @@ class ResolvedState:
         """
         Compute the final root container list.
 
-        When new manifest root container IDs are introduced, all manifest containers are placed first,
-        followed by any existing root containers.
-        When only removing manifest root containers, the existing order is preserved and removed entries
-        are filtered out, keeping existing root containers in their current positions.
+        Note:
+            When new manifest root container IDs are introduced, all manifest containers are placed first,
+            followed by any existing root containers.
+            When only removing manifest root containers, the existing order is preserved and removed entries
+            are filtered out, keeping existing root containers in their current positions.
         """
         # TODO: Add root_policy handling here in the future.
         declared_root_ids_set = set(desired.root_ids)
@@ -109,17 +110,15 @@ class ResolvedState:
 
     @staticmethod
     def _compute_assigned_configlet_ids(reachable_container_ids: set[str], desired: DesiredState, existing: ExistingState) -> set[str]:
-        """Compute the set of configlet IDs assigned to reachable AVD-managed containers in the final hierarchy."""
+        """Compute the set of configlet IDs assigned to any reachable container in the final hierarchy."""
         assigned: set[str] = set()
 
         for container_id in reachable_container_ids:
-            if not AvdId.is_managed(container_id):
-                continue
-
             if container_id in desired.containers_by_id:
+                # Container is in the new manifest. Use its proposed configlets.
                 assigned.update(desired.containers_by_id[container_id].configlet_ids)
             elif container_id in existing.containers_by_id:
-                # Existing AVD container reachable through a non-AVD parent: keep its current configlets.
+                # Container exists but isn't in the current manifest. Keep its existing configlets.
                 assigned.update(existing.containers_by_id[container_id].configlet_ids.values)
 
         return assigned
@@ -127,7 +126,7 @@ class ResolvedState:
 
 @dataclass
 class DeploymentPlan:
-    """All decisions for a single deployment, computed from the desired state, the existing state, and the resolved graph."""
+    """All decisions for a single deployment, computed from the desired state, the existing state, and the resolved state."""
 
     configlets_to_upsert: list[CVConfiglet] = field(default_factory=list)
     containers_to_upsert: list[CVContainer] = field(default_factory=list)
@@ -144,16 +143,20 @@ class DeploymentPlan:
         """Build the deployment plan from the desired state, the existing CloudVision state, and the resolved state."""
         plan = cls()
 
+        # Always push configlets for now.
         plan.configlets_to_upsert = list(desired.configlets_by_id.values())
 
         for container_id, desired_container in desired.containers_by_id.items():
+            # Rebuild the container with resolved children from the final hierarchy.
             resolved_children = resolved.child_ids_by_container_id[container_id]
             proposed_container = replace(desired_container, child_ids=tuple(resolved_children))
 
             existing_container = existing.containers_by_id.get(container_id)
             if not existing_container or not proposed_container.matches_configlet_assignment(existing_container):
+                # Container is new or has changed, so it needs to be pushed.
                 plan.containers_to_upsert.append(proposed_container)
             else:
+                # Container is unchanged.
                 plan.containers_unchanged.append(proposed_container)
 
         if resolved.root_ids != existing.root_ids:
@@ -166,12 +169,13 @@ class DeploymentPlan:
             if AvdId.is_managed(container_id) and container_id not in resolved.reachable_container_ids
         }
 
-        # In "additive" mode, don't delete any configlets.
+        # In "managed" mode, delete AVD-managed configlets not declared in this manifest and not assigned to any container.
         if desired.configlet_policy == "managed":
             plan.configlets_to_delete = {
                 configlet_id: cast("str", configlet.display_name)
                 for configlet_id, configlet in existing.configlets_by_id.items()
                 if AvdId.is_managed(configlet_id) and configlet_id not in desired.configlets_by_id and configlet_id not in resolved.assigned_configlet_ids
             }
+        # In "additive" mode, don't delete any configlets.
 
         return plan

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/models.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/models.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, cast
+
+from pyavd._cv.workflows.models import CVManifest
+
+from .ids import AvdId
+
+if TYPE_CHECKING:
+    from pyavd._cv.api.arista.configlet.v1 import Configlet, ConfigletAssignment
+    from pyavd._cv.workflows.models import CVConfiglet, CVContainer
+
+DesiredState = CVManifest
+
+
+@dataclass(frozen=True)
+class ExistingState:
+    """Snapshot of the current state on CloudVision, fetched once at the start of a deployment."""
+
+    root_ids: list[str]
+    containers_by_id: dict[str, ConfigletAssignment]
+    configlets_by_id: dict[str, Configlet]
+
+
+@dataclass(frozen=True)
+class ResolvedState:
+    """
+    The final container hierarchy after applying the desired state on top of the existing state.
+
+    Container reachability and assigned configlets are pre-computed for the deployment plan to consume.
+    """
+
+    root_ids: list[str]
+    child_ids_by_container_id: dict[str, list[str]]
+    reachable_container_ids: set[str]
+    assigned_configlet_ids: set[str]
+
+    @classmethod
+    def build(cls, desired: DesiredState, existing: ExistingState) -> ResolvedState:
+        """Build the resolved state."""
+        root_ids = cls._compute_root_ids(desired, existing)
+        child_ids_by_container_id = cls._compute_child_map(desired, existing)
+        reachable_container_ids = cls._compute_reachable_container_ids(root_ids, child_ids_by_container_id)
+        assigned_configlet_ids = cls._compute_assigned_configlet_ids(reachable_container_ids, desired, existing)
+        return cls(
+            root_ids=root_ids,
+            child_ids_by_container_id=child_ids_by_container_id,
+            reachable_container_ids=reachable_container_ids,
+            assigned_configlet_ids=assigned_configlet_ids,
+        )
+
+    @staticmethod
+    def _compute_root_ids(desired: DesiredState, existing: ExistingState) -> list[str]:
+        """
+        Compute the final root container list.
+
+        When new manifest root container IDs are introduced, all manifest containers are placed first,
+        followed by any existing root containers.
+        When only removing manifest root containers, the existing order is preserved and removed entries
+        are filtered out, keeping existing root containers in their current positions.
+        """
+        # TODO: Add root_policy handling here in the future.
+        declared_root_ids_set = set(desired.root_ids)
+        existing_root_ids_set = set(existing.root_ids)
+        missing_ids = declared_root_ids_set - existing_root_ids_set
+
+        if missing_ids:
+            non_manifest_root_ids = [root_id for root_id in existing.root_ids if not AvdId.is_managed(root_id)]
+            return list(desired.root_ids) + non_manifest_root_ids
+
+        return [root_id for root_id in existing.root_ids if root_id in declared_root_ids_set or not AvdId.is_managed(root_id)]
+
+    @staticmethod
+    def _compute_child_map(desired: DesiredState, existing: ExistingState) -> dict[str, list[str]]:
+        """
+        Compute the parent-to-children mapping for the final hierarchy, using the existing CloudVision relationships as the baseline.
+
+        Manifest containers replace their existing children.
+        """
+        # TODO: Add sub_container_policy handling here in the future.
+        child_map = {container_id: list(container.child_assignment_ids.values) for container_id, container in existing.containers_by_id.items()}
+        for container_id, desired_container in desired.containers_by_id.items():
+            child_map[container_id] = list(desired_container.child_ids)
+        return child_map
+
+    @staticmethod
+    def _compute_reachable_container_ids(root_ids: list[str], child_ids_by_container_id: dict[str, list[str]]) -> set[str]:
+        """
+        Compute the set of container IDs still attached to a Studio root in the final hierarchy.
+
+        Containers not in this set are orphans and become deletion candidates if AVD-managed.
+        """
+        reachable_container_ids: set[str] = set()
+        traversal_queue: deque[str] = deque(root_ids)
+
+        while traversal_queue:
+            container_id = traversal_queue.popleft()
+            if container_id in reachable_container_ids:
+                continue
+            reachable_container_ids.add(container_id)
+            traversal_queue.extend(child_ids_by_container_id.get(container_id, []))
+
+        return reachable_container_ids
+
+    @staticmethod
+    def _compute_assigned_configlet_ids(reachable_container_ids: set[str], desired: DesiredState, existing: ExistingState) -> set[str]:
+        """Compute the set of configlet IDs assigned to reachable AVD-managed containers in the final hierarchy."""
+        assigned: set[str] = set()
+
+        for container_id in reachable_container_ids:
+            if not AvdId.is_managed(container_id):
+                continue
+
+            if container_id in desired.containers_by_id:
+                assigned.update(desired.containers_by_id[container_id].configlet_ids)
+            elif container_id in existing.containers_by_id:
+                # Existing AVD container reachable through a non-AVD parent: keep its current configlets.
+                assigned.update(existing.containers_by_id[container_id].configlet_ids.values)
+
+        return assigned
+
+
+@dataclass
+class DeploymentPlan:
+    """All decisions for a single deployment, computed from the desired state, the existing state, and the resolved graph."""
+
+    configlets_to_upsert: list[CVConfiglet] = field(default_factory=list)
+    containers_to_upsert: list[CVContainer] = field(default_factory=list)
+    containers_unchanged: list[CVContainer] = field(default_factory=list)
+    final_root_ids: list[str] | None = None
+    """None means the root list is unchanged and no API call is needed."""
+    containers_to_delete: dict[str, str] = field(default_factory=dict)
+    """Mapping of container_id to display_name."""
+    configlets_to_delete: dict[str, str] = field(default_factory=dict)
+    """Mapping of configlet_id to display_name."""
+
+    @classmethod
+    def build(cls, desired: DesiredState, existing: ExistingState, resolved: ResolvedState) -> DeploymentPlan:
+        """Build the deployment plan from the desired state, the existing CloudVision state, and the resolved state."""
+        plan = cls()
+
+        plan.configlets_to_upsert = list(desired.configlets_by_id.values())
+
+        for container_id, desired_container in desired.containers_by_id.items():
+            resolved_children = resolved.child_ids_by_container_id[container_id]
+            proposed_container = replace(desired_container, child_ids=tuple(resolved_children))
+
+            existing_container = existing.containers_by_id.get(container_id)
+            if not existing_container or not proposed_container.matches_configlet_assignment(existing_container):
+                plan.containers_to_upsert.append(proposed_container)
+            else:
+                plan.containers_unchanged.append(proposed_container)
+
+        if resolved.root_ids != existing.root_ids:
+            plan.final_root_ids = resolved.root_ids
+
+        # Unreachable AVD-managed containers are deleted.
+        plan.containers_to_delete = {
+            container_id: cast("str", container.display_name)
+            for container_id, container in existing.containers_by_id.items()
+            if AvdId.is_managed(container_id) and container_id not in resolved.reachable_container_ids
+        }
+
+        # In "additive" mode, don't delete any configlets.
+        if desired.configlet_policy == "managed":
+            plan.configlets_to_delete = {
+                configlet_id: cast("str", configlet.display_name)
+                for configlet_id, configlet in existing.configlets_by_id.items()
+                if AvdId.is_managed(configlet_id) and configlet_id not in desired.configlets_by_id and configlet_id not in resolved.assigned_configlet_ids
+            }
+
+        return plan

--- a/python-avd/pyavd/_cv/workflows/static_configuration_studio/models.py
+++ b/python-avd/pyavd/_cv/workflows/static_configuration_studio/models.py
@@ -137,9 +137,9 @@ class DeploymentPlan:
     """Mapping of container_id to display_name."""
     configlets_to_delete: dict[str, str] = field(default_factory=dict)
     """Mapping of configlet_id to display_name."""
-    preserved_avd_containers: dict[str, str] = field(default_factory=dict)
+    containers_preserved: dict[str, str] = field(default_factory=dict)
     """Mapping of container_id to display_name for AVD-managed containers preserved because they are reachable through non-manifest containers."""
-    preserved_avd_configlets: dict[str, str] = field(default_factory=dict)
+    configlets_preserved: dict[str, str] = field(default_factory=dict)
     """Mapping of configlet_id to display_name for AVD-managed configlets preserved because they are still assigned to non-manifest containers."""
 
     @classmethod
@@ -174,7 +174,7 @@ class DeploymentPlan:
             if container_id not in resolved.reachable_container_ids:
                 plan.containers_to_delete[container_id] = display_name
             elif container_id not in desired.containers_by_id:
-                plan.preserved_avd_containers[container_id] = display_name
+                plan.containers_preserved[container_id] = display_name
 
         # In "managed" mode, classify each AVD-managed existing configlet not in this manifest as deletable (unassigned) or preserved (still assigned).
         # In "additive" mode, don't delete any configlets.
@@ -184,7 +184,7 @@ class DeploymentPlan:
                     continue
                 display_name = cast("str", configlet.display_name)
                 if configlet_id in resolved.assigned_configlet_ids:
-                    plan.preserved_avd_configlets[configlet_id] = display_name
+                    plan.configlets_preserved[configlet_id] = display_name
                 else:
                     plan.configlets_to_delete[configlet_id] = display_name
 

--- a/python-avd/tests/pyavd/cv/workflows/helpers.py
+++ b/python-avd/tests/pyavd/cv/workflows/helpers.py
@@ -16,7 +16,7 @@ from pyavd._cv.api.arista.tag.v2 import (
     TagKey,
 )
 from pyavd._cv.api.fmp import RepeatedString
-from pyavd._cv.workflows.models import CVManifest
+from pyavd._cv.workflows.static_configuration_studio.ids import AvdId
 
 DEFAULT_TIMESTAMP = _DateTime.fromisoformat("2025-10-03T00:00:00")
 
@@ -153,4 +153,4 @@ def get_interface_tag_assignments_cv_state() -> list[TagAssignment]:
 
 def generate_id(key: str) -> str:
     """Helper to consistently generate expected IDs for tests."""
-    return CVManifest._generate_deterministic_id(key)
+    return AvdId.generate(key)

--- a/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
@@ -741,13 +741,13 @@ class TestDeployStaticConfigStudio:
                 description="",
                 query="device:*",
                 child_ids=[legacy_avd_container_id],
+                configlet_ids=[legacy_avd_configlet_id],
             ),
             create_grpc_container(
                 container_id=legacy_avd_container_id,
                 name="LEGACY_AVD_CONTAINER",
                 description="",
                 query="device:LEAF",
-                configlet_ids=[legacy_avd_configlet_id],
             ),
         ]
         existing_configlets = [
@@ -766,7 +766,7 @@ class TestDeployStaticConfigStudio:
         mock_cv_client.delete_configlet_container.assert_not_called()
         assert "LEGACY_AVD_CONTAINER" not in deployment_result.removed_static_config_containers
 
-        # Legacy AVD configlet is preserved (still assigned to a reachable AVD container, even in 'managed' mode).
+        # Legacy AVD configlet is preserved (still assigned to a reachable container, even in 'managed' mode).
         mock_cv_client.delete_configlets.assert_not_called()
         assert "LEGACY_AVD_CONFIGLET" not in deployment_result.removed_static_config_configlets
 

--- a/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
@@ -824,6 +824,56 @@ class TestDeployStaticConfigStudio:
             inputs=[new_root_id, manual_container_id],
         )
 
+    async def test_warns_when_avd_entities_cannot_be_cleaned_up(
+        self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """
+        Test that a WARNING is logged when AVD-managed containers/configlets are preserved due to non-manifest references.
+
+        When an AVD entity is no longer in the current manifest but is still reachable through a non-manifest container
+        (or assigned to one), the workflow keeps it but warns the operator that manual cleanup may be needed in CloudVision.
+        """
+        manual_root_id = "manually-created-root-xyz"
+        legacy_avd_container_id = generate_id("LEGACY_AVD_CONTAINER")
+        legacy_avd_configlet_id = generate_id("LEGACY_AVD_CONFIGLET")
+
+        existing_containers = [
+            create_grpc_container(
+                container_id=manual_root_id,
+                name="MANUAL_ROOT",
+                description="",
+                query="device:*",
+                child_ids=[legacy_avd_container_id],
+            ),
+            create_grpc_container(
+                container_id=legacy_avd_container_id,
+                name="LEGACY_AVD_CONTAINER",
+                description="",
+                query="device:LEAF",
+                configlet_ids=[legacy_avd_configlet_id],
+            ),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=legacy_avd_configlet_id), display_name="LEGACY_AVD_CONFIGLET"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = [manual_root_id]
+
+        new_root = AvdContainer(name="NEW_ROOT", tag_query="device:*")
+        manifest = AvdManifest(configlet_policy="managed", containers=(new_root,))
+
+        with caplog.at_level("WARNING", logger="pyavd._cv.workflows.static_configuration_studio.deploy"):
+            await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        warning_messages = [record.getMessage() for record in caplog.records if record.levelname == "WARNING"]
+        assert any("LEGACY_AVD_CONTAINER" in msg and "non-manifest" in msg for msg in warning_messages), (
+            f"Expected a WARNING about the preserved AVD container; got: {warning_messages}"
+        )
+        assert any("LEGACY_AVD_CONFIGLET" in msg and "non-manifest" in msg for msg in warning_messages), (
+            f"Expected a WARNING about the preserved AVD configlet; got: {warning_messages}"
+        )
+
     async def test_avd_configlet_assigned_only_to_orphan_avd_container_is_deleted(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
         """
         Test that an AVD-managed configlet is still deleted when its only assigner is an orphan AVD container (in 'managed' mode).

--- a/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025-2026 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
+# pylint: disable=too-many-lines
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -724,6 +725,57 @@ class TestDeployStaticConfigStudio:
             workspace_id=deployment_result.workspace.id,
             input_path=["configletAssignmentRoots"],
             inputs=[new_root_id],
+        )
+
+    async def test_avd_entities_reachable_through_non_avd_parent_are_preserved(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that AVD-managed containers (and their assigned configlets) are preserved when reachable through a non-AVD parent."""
+        manual_root_id = "manually-created-root-xyz"
+        legacy_avd_container_id = generate_id("LEGACY_AVD_CONTAINER")
+        legacy_avd_configlet_id = generate_id("LEGACY_AVD_CONFIGLET")
+        new_root_id = generate_id("NEW_ROOT")
+
+        existing_containers = [
+            create_grpc_container(
+                container_id=manual_root_id,
+                name="MANUAL_ROOT",
+                description="",
+                query="device:*",
+                child_ids=[legacy_avd_container_id],
+            ),
+            create_grpc_container(
+                container_id=legacy_avd_container_id,
+                name="LEGACY_AVD_CONTAINER",
+                description="",
+                query="device:LEAF",
+                configlet_ids=[legacy_avd_configlet_id],
+            ),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=legacy_avd_configlet_id), display_name="LEGACY_AVD_CONFIGLET"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = [manual_root_id]
+
+        new_root = AvdContainer(name="NEW_ROOT", tag_query="device:*")
+        manifest = AvdManifest(configlet_policy="managed", containers=(new_root,))
+
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # Legacy AVD container is preserved (reachable through the non-AVD parent).
+        mock_cv_client.delete_configlet_container.assert_not_called()
+        assert "LEGACY_AVD_CONTAINER" not in deployment_result.removed_static_config_containers
+
+        # Legacy AVD configlet is preserved (still assigned to a reachable AVD container, even in 'managed' mode).
+        mock_cv_client.delete_configlets.assert_not_called()
+        assert "LEGACY_AVD_CONFIGLET" not in deployment_result.removed_static_config_configlets
+
+        # The Studio root list is updated to include the new root alongside the manual one.
+        mock_cv_client.set_studio_inputs.assert_called_once_with(
+            studio_id="studio-static-configlet",
+            workspace_id=deployment_result.workspace.id,
+            input_path=["configletAssignmentRoots"],
+            inputs=[new_root_id, manual_root_id],
         )
 
     async def test_avd_parent_unassigns_non_avd_sub_container(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:

--- a/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
@@ -778,6 +778,103 @@ class TestDeployStaticConfigStudio:
             inputs=[new_root_id, manual_root_id],
         )
 
+    async def test_avd_configlet_assigned_to_non_avd_container_is_preserved(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """
+        Test that an AVD-managed configlet is preserved when assigned to a non-AVD container, even if not declared in the new manifest.
+
+        The non-AVD container is reachable from the Studio root list. The AVD configlet attached to it must not be deleted because it is
+        still in use. Deleting it would leave a dangling reference and trigger a workspace build error on CloudVision.
+        """
+        manual_container_id = "manually-created-container-xyz"
+        legacy_avd_configlet_id = generate_id("LEGACY_AVD_CONFIGLET")
+        new_root_id = generate_id("NEW_ROOT")
+
+        # A manually-created (non-AVD) container that holds an AVD-managed configlet.
+        existing_containers = [
+            create_grpc_container(
+                container_id=manual_container_id,
+                name="MANUAL_CONTAINER",
+                description="",
+                query="device:*",
+                configlet_ids=[legacy_avd_configlet_id],
+            ),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=legacy_avd_configlet_id), display_name="LEGACY_AVD_CONFIGLET"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = [manual_container_id]
+
+        # The new manifest declares an unrelated root and no configlets.
+        new_root = AvdContainer(name="NEW_ROOT", tag_query="device:*")
+        manifest = AvdManifest(configlet_policy="managed", containers=(new_root,))
+
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # The AVD configlet is preserved because it's still assigned to a reachable (non-AVD) container.
+        mock_cv_client.delete_configlets.assert_not_called()
+        assert "LEGACY_AVD_CONFIGLET" not in deployment_result.removed_static_config_configlets
+
+        # The Studio root list is updated to include the new root alongside the manual container.
+        mock_cv_client.set_studio_inputs.assert_called_once_with(
+            studio_id="studio-static-configlet",
+            workspace_id=deployment_result.workspace.id,
+            input_path=["configletAssignmentRoots"],
+            inputs=[new_root_id, manual_container_id],
+        )
+
+    async def test_avd_configlet_assigned_only_to_orphan_avd_container_is_deleted(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """
+        Test that an AVD-managed configlet is still deleted when its only assigner is an orphan AVD container (in 'managed' mode).
+
+        Orphan AVD containers are themselves deleted, so the configlet has no surviving assignment and must also be cleaned up.
+        Confirms the "any reachable container" rule does not over-preserve configlets attached only to entities that will be deleted.
+        """
+        orphan_avd_container_id = generate_id("ORPHAN_AVD_CONTAINER")
+        orphan_avd_configlet_id = generate_id("ORPHAN_AVD_CONFIGLET")
+        new_root_id = generate_id("NEW_ROOT")
+
+        # An orphan AVD container holding an AVD configlet, neither referenced by the studio root list nor the new manifest.
+        existing_containers = [
+            create_grpc_container(
+                container_id=orphan_avd_container_id,
+                name="ORPHAN_AVD_CONTAINER",
+                description="",
+                query="device:LEAF",
+                configlet_ids=[orphan_avd_configlet_id],
+            ),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=orphan_avd_configlet_id), display_name="ORPHAN_AVD_CONFIGLET"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = []
+
+        new_root = AvdContainer(name="NEW_ROOT", tag_query="device:*")
+        manifest = AvdManifest(configlet_policy="managed", containers=(new_root,))
+
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # The orphan AVD container is deleted.
+        mock_cv_client.delete_configlet_container.assert_called_once()
+        assert "ORPHAN_AVD_CONTAINER" in deployment_result.removed_static_config_containers
+
+        # The AVD configlet is deleted because its only assigner is the orphan container that's also being removed.
+        mock_cv_client.delete_configlets.assert_called_once()
+        deleted_configlet_ids = mock_cv_client.delete_configlets.call_args[1]["configlet_ids"]
+        assert orphan_avd_configlet_id in deleted_configlet_ids
+        assert "ORPHAN_AVD_CONFIGLET" in deployment_result.removed_static_config_configlets
+
+        # New root is added.
+        mock_cv_client.set_studio_inputs.assert_called_once_with(
+            studio_id="studio-static-configlet",
+            workspace_id=deployment_result.workspace.id,
+            input_path=["configletAssignmentRoots"],
+            inputs=[new_root_id],
+        )
+
     async def test_avd_parent_unassigns_non_avd_sub_container(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
         """Test that a non-AVD sub-container under an AVD parent is unassigned (not deleted) when the parent is re-pushed."""
         avd_parent_id = generate_id("PARENT")

--- a/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
@@ -417,7 +417,6 @@ class TestDeployStaticConfigStudio:
         mock_cv_client.set_configlets_from_files.assert_called_once()
 
         # No configlets should be deleted (additive mode).
-        mock_cv_client.get_configlets.assert_not_called()
         mock_cv_client.delete_configlets.assert_not_called()
         assert not deployment_result.removed_static_config_configlets
 

--- a/python-avd/tests/pyavd/cv/workflows/test_models.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_models.py
@@ -179,6 +179,8 @@ class TestCVManifestGeneration:
         assert len(cv_manifest.configlets_by_id) == 0
         assert len(cv_manifest.containers_by_id) == 0
 
+
+class TestAvdId:
     def test_deterministic_id_generation(self) -> None:
         """Ensures the ID generation function is deterministic and consistent."""
         id1 = AvdId.generate("my_key")
@@ -188,6 +190,20 @@ class TestCVManifestGeneration:
         assert id1 == id2
         assert id1 != id3
         assert id1.startswith(AvdId.PREFIX)
+
+    @pytest.mark.parametrize(
+        ("entity_id", "expected"),
+        [
+            pytest.param("avd_b73a8c2c-3b51-543a-8eaf-3a5e63a9b67e", True, id="generated_avd_id"),
+            pytest.param("avd_anything", True, id="prefix_only"),
+            pytest.param("manually-created-id", False, id="manual_id"),
+            pytest.param("AVD_uppercase_prefix", False, id="case_sensitive"),
+            pytest.param("", False, id="empty_string"),
+        ],
+    )
+    def test_is_managed_recognizes_avd_prefix(self, entity_id: str, expected: bool) -> None:
+        """Tests that AvdId.is_managed correctly identifies AVD-prefixed entity IDs."""
+        assert AvdId.is_managed(entity_id) is expected
 
 
 class TestCVContainerMatching:

--- a/python-avd/tests/pyavd/cv/workflows/test_models.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_models.py
@@ -10,7 +10,8 @@ import pytest
 from pyavd._cv.api.arista.configlet.v1 import ConfigletAssignment, ConfigletAssignmentKey, MatchPolicy
 from pyavd._cv.api.fmp import RepeatedString
 from pyavd._cv.client.exceptions import CVManifestError
-from pyavd._cv.workflows.models import AVD_ENTITY_PREFIX, AvdConfiglet, AvdContainer, AvdManifest, CVContainer, CVManifest
+from pyavd._cv.workflows.models import AvdConfiglet, AvdContainer, AvdManifest, CVContainer, CVManifest
+from pyavd._cv.workflows.static_configuration_studio.ids import AvdId
 
 from .helpers import generate_id
 
@@ -67,12 +68,12 @@ class TestCVManifestGeneration:
         cv_manifest = CVManifest.from_avd_manifest(complex_avd_manifest)
 
         # Verify counts.
-        assert len(cv_manifest.configlets) == 3
-        assert len(cv_manifest.containers) == 4  # 2 roots + 2 children
+        assert len(cv_manifest.configlets_by_id) == 3
+        assert len(cv_manifest.containers_by_id) == 4  # 2 roots + 2 children
 
         # Organize results for easier lookup.
-        container_map = {c.name: c for c in cv_manifest.containers}
-        configlet_map = {c.name: c for c in cv_manifest.configlets}
+        container_map = {c.name: c for c in cv_manifest.containers_by_id.values()}
+        configlet_map = {c.name: c for c in cv_manifest.configlets_by_id.values()}
 
         # Verify configlet properties (CVConfiglet).
         assert "configlet_leaf" in configlet_map
@@ -154,8 +155,8 @@ class TestCVManifestGeneration:
 
         cv_manifest = CVManifest.from_avd_manifest(avd_manifest)
 
-        assert len(cv_manifest.configlets) == 1
-        assert len(cv_manifest.containers) == 0
+        assert len(cv_manifest.configlets_by_id) == 1
+        assert len(cv_manifest.containers_by_id) == 0
 
     def test_manifest_with_containers_only(self) -> None:
         """Tests a manifest that has containers but no configlets defined globally."""
@@ -165,28 +166,28 @@ class TestCVManifestGeneration:
         avd_manifest = AvdManifest(configlets=(), containers=(container,))
 
         cv_manifest = CVManifest.from_avd_manifest(avd_manifest)
-        container_map = {c.name: c for c in cv_manifest.containers}
+        container_map = {c.name: c for c in cv_manifest.containers_by_id.values()}
 
-        assert len(cv_manifest.configlets) == 0
-        assert len(cv_manifest.containers) == 1
+        assert len(cv_manifest.configlets_by_id) == 0
+        assert len(cv_manifest.containers_by_id) == 1
         assert container_map["ROOT"].name == "ROOT"
 
     def test_empty_manifest(self) -> None:
         """Tests an entirely empty manifest."""
         avd_manifest = AvdManifest(configlets=(), containers=())
         cv_manifest = CVManifest.from_avd_manifest(avd_manifest)
-        assert len(cv_manifest.configlets) == 0
-        assert len(cv_manifest.containers) == 0
+        assert len(cv_manifest.configlets_by_id) == 0
+        assert len(cv_manifest.containers_by_id) == 0
 
     def test_deterministic_id_generation(self) -> None:
         """Ensures the ID generation function is deterministic and consistent."""
-        id1 = CVManifest._generate_deterministic_id("my_key")
-        id2 = CVManifest._generate_deterministic_id("my_key")
-        id3 = CVManifest._generate_deterministic_id("another_key")
+        id1 = AvdId.generate("my_key")
+        id2 = AvdId.generate("my_key")
+        id3 = AvdId.generate("another_key")
 
         assert id1 == id2
         assert id1 != id3
-        assert id1.startswith(AVD_ENTITY_PREFIX)
+        assert id1.startswith(AvdId.PREFIX)
 
 
 class TestCVContainerMatching:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

Refactor of the static configuration studio deployment workflow into a "fetch -> resolve -> plan -> execute" pipeline in a new sub-package. Existing deployments behave the same.

This sets the stage for the upcoming root policy and sub-container policy features: https://github.com/aristanetworks/avd/pull/6732.

The refactor also fixes a bug in the issue below. New unit tests have been added to cover the fix for the bug.

## Related Issue(s)

Fixes #https://github.com/aristanetworks/avd/issues/6952

## Component(s) name

PyAVD

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- New `static_configuration_studio/` sub-package to hold related modules
- Moved "no work to do" logs from info to debug
- Added TODOs for future work

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
CI is green.
Internal CI is green --> https://github.com/aristanetworks/avd-internal/actions/runs/25700818681/job/75460685982

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- [x] Need to determine if we keep today's behavior of attempting to delete undeclared manifest objects still assigned, causing the workspace build to fail, or we keep them.

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
