### PR TITLE
CI: Add ansible-core 2.16 to ansible-test sanity

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -421,23 +421,29 @@ jobs:
         include:
           - ansible_version: first_stable
             pip_installation: "ansible-core<2.17.0"
+            python_version: |
+              3.10
+              3.11
+              3.12
           - ansible_version: latest_stable
             pip_installation: "ansible-core<2.21.0"
+            python_version: |
+              3.12
+              3.13
+              3.14
           - ansible_version: devel
             pip_installation: "ansible-core @ git+https://github.com/ansible/ansible.git@milestone"
             # Skip ansible-doc due to testing with ansible-core @ devel and raising error on supported Ansible version
             skip_test: "--skip-test ansible-doc"
+            python_version: |
+              3.14
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python 3
         uses: actions/setup-python@v6
         with:
           python-version: |
-            3.10
-            3.11
-            3.12
-            3.13
-            3.14
+            ${{ matrix.python_version }}
       - name: Download pyavd Artifact
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -417,22 +417,18 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ansible_version: [first_stable, latest_stable, devel]
         include:
-          - ansible_version: first_stable
-            pip_installation: "ansible-core<2.17.0"
+          - pip_installation: "ansible-core<2.17.0"
             python_version: |
               3.10
               3.11
               3.12
-          - ansible_version: latest_stable
-            pip_installation: "ansible-core<2.21.0"
+          - pip_installation: "ansible-core<2.21.0"
             python_version: |
               3.12
               3.13
               3.14
-          - ansible_version: devel
-            pip_installation: "ansible-core @ git+https://github.com/ansible/ansible.git@milestone"
+          - pip_installation: "ansible-core @ git+https://github.com/ansible/ansible.git@milestone"
             # Skip ansible-doc due to testing with ansible-core @ devel and raising error on supported Ansible version
             skip_test: "--skip-test ansible-doc"
             python_version: |

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -425,6 +425,7 @@ jobs:
             pip_installation: "ansible-core<2.21.0"
           - ansible_version: devel
             pip_installation: "ansible-core @ git+https://github.com/ansible/ansible.git@milestone"
+            # Skip ansible-doc due to testing with ansible-core @ devel and raising error on supported Ansible version
             skip_test: "--skip-test ansible-doc"
     steps:
       - uses: actions/checkout@v6
@@ -447,7 +448,6 @@ jobs:
           pip install "${{ matrix.pip_installation }}" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]"
       - name: Run ansible-test sanity
         working-directory: ansible_collections/arista/avd
-        # Skip ansible-doc due to testing with ansible-core @ devel and raising error on supported Ansible version
         run: |
           ansible-test sanity --color yes -v ${{ matrix.skip_test }}
 

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -418,17 +418,20 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - pip_installation: "ansible-core<2.17.0"
+          - ansible_version: first_stable
+            pip_installation: "ansible-core<2.17.0"
             python_version: |
               3.10
               3.11
               3.12
-          - pip_installation: "ansible-core<2.21.0"
+          - ansible_version: latest_stable
+            pip_installation: "ansible-core<2.21.0"
             python_version: |
               3.12
               3.13
               3.14
-          - pip_installation: "ansible-core @ git+https://github.com/ansible/ansible.git@milestone"
+          - ansible_version: devel
+            pip_installation: "ansible-core @ git+https://github.com/ansible/ansible.git@milestone"
             # Skip ansible-doc due to testing with ansible-core @ devel and raising error on supported Ansible version
             skip_test: "--skip-test ansible-doc"
             python_version: |

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -417,9 +417,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ansible_version: [stable, devel]
+        ansible_version: [first_stable, latest_stable, devel]
         include:
-          - ansibe_version: stable
+          - ansibe_version: first_stable
+            pip_installation: "ansible-core<2.17.0"
+          - ansibe_version: latest_stable
             pip_installation: "ansible-core<2.21.0"
           - ansibe_version: devel
             pip_installation: "ansible-core @ git+https://github.com/ansible/ansible.git@milestone"

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -419,11 +419,11 @@ jobs:
       matrix:
         ansible_version: [first_stable, latest_stable, devel]
         include:
-          - ansibe_version: first_stable
+          - ansible_version: first_stable
             pip_installation: "ansible-core<2.17.0"
-          - ansibe_version: latest_stable
+          - ansible_version: latest_stable
             pip_installation: "ansible-core<2.21.0"
-          - ansibe_version: devel
+          - ansible_version: devel
             pip_installation: "ansible-core @ git+https://github.com/ansible/ansible.git@milestone"
             skip_test: "--skip-test ansible-doc"
     steps:


### PR DESCRIPTION
## Change Summary

As per Red Hat certification testing guidelines, run ansible-test sanity against Ansible Core 2.16 and Python 3.12.

Reference: https://forum.ansible.com/t/red-hat-ansible-automation-platform-is-ending-support-for-ansible-core-2-15-and-python-3-11/45574

