### PR TITLE
Refactor(eos_designs): Only generate BGP outbound route-map when ipv4_prefix_list_out is defined

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -550,8 +550,6 @@ route-map RM-BGP-172.16.9.4-IN permit 10
    match ip address prefix-list ALLOW-DEFAULT
    set community no-advertise additive
 !
-route-map RM-BGP-172.16.9.4-OUT deny 10
-!
 route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.42.1:511 additive
@@ -609,7 +607,6 @@ router bgp 65000
    neighbor 172.16.9.4 remote-as 64520
    neighbor 172.16.9.4 description ATT_666_peer3_Ethernet42
    neighbor 172.16.9.4 route-map RM-BGP-172.16.9.4-IN in
-   neighbor 172.16.9.4 route-map RM-BGP-172.16.9.4-OUT out
    neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.0.0 remote-as 65199
    neighbor 172.17.0.0 description site-ha-disabled-leaf_Ethernet1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -718,8 +718,6 @@ route-map RM-BGP-172.31.0.10-IN permit 10
    match ip address prefix-list PL2
    set community no-advertise additive
 !
-route-map RM-BGP-172.31.0.10-OUT deny 10
-!
 route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
    set extcommunity soo 192.168.42.2:511 additive
@@ -775,7 +773,6 @@ router bgp 65000
    neighbor 172.31.0.10 remote-as 64520
    neighbor 172.31.0.10 description Orange_peerDevice10_Port-Channel455
    neighbor 172.31.0.10 route-map RM-BGP-172.31.0.10-IN in
-   neighbor 172.31.0.10 route-map RM-BGP-172.31.0.10-OUT out
    neighbor 192.168.144.2 peer group WAN-OVERLAY-PEERS
    neighbor 192.168.144.2 description cv-pathfinder-pathfinder1_Dps1
    neighbor 192.168.144.3 peer group WAN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-interfaces-bgp.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-interfaces-bgp.cfg
@@ -39,6 +39,8 @@ route-map RM-BGP-192.168.42.1-IN permit 10
    match ip address prefix-list ALLOW-DEFAULT
    set community no-advertise additive
 !
+route-map RM-BGP-192.168.42.1-OUT deny 10
+!
 route-map RM-BGP-192.168.44.1-OUT permit 10
    match ip address prefix-list ALLOW-DEFAULT
 !
@@ -52,6 +54,7 @@ router bgp 65000
    neighbor 192.168.42.1 remote-as 65042
    neighbor 192.168.42.1 description INTERNET
    neighbor 192.168.42.1 route-map RM-BGP-192.168.42.1-IN in
+   neighbor 192.168.42.1 route-map RM-BGP-192.168.42.1-OUT out
    neighbor 192.168.44.1 remote-as 65044
    neighbor 192.168.44.1 description PEER44_BGP
    neighbor 192.168.44.1 route-map RM-BGP-192.168.44.1-OUT out

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-interfaces-bgp.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-interfaces-bgp.cfg
@@ -18,6 +18,12 @@ interface Ethernet43
    no switchport
    ip address 192.168.42.42/24
 !
+interface Ethernet44
+   description PEER44_BGP
+   shutdown
+   no switchport
+   ip address 192.168.44.44/24
+!
 interface Loopback0
    description ROUTER_ID
    no shutdown
@@ -33,7 +39,10 @@ route-map RM-BGP-192.168.42.1-IN permit 10
    match ip address prefix-list ALLOW-DEFAULT
    set community no-advertise additive
 !
-route-map RM-BGP-192.168.42.1-OUT deny 10
+route-map RM-BGP-192.168.44.1-OUT permit 10
+   match ip address prefix-list ALLOW-DEFAULT
+!
+route-map RM-BGP-192.168.44.1-OUT deny 20
 !
 router bgp 65000
    router-id 192.168.255.1
@@ -43,10 +52,13 @@ router bgp 65000
    neighbor 192.168.42.1 remote-as 65042
    neighbor 192.168.42.1 description INTERNET
    neighbor 192.168.42.1 route-map RM-BGP-192.168.42.1-IN in
-   neighbor 192.168.42.1 route-map RM-BGP-192.168.42.1-OUT out
+   neighbor 192.168.44.1 remote-as 65044
+   neighbor 192.168.44.1 description PEER44_BGP
+   neighbor 192.168.44.1 route-map RM-BGP-192.168.44.1-OUT out
    redistribute connected
    !
    address-family ipv4
       neighbor 192.168.42.1 activate
+      neighbor 192.168.44.1 activate
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-port-channels.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-port-channels.cfg
@@ -59,6 +59,8 @@ router path-selection
       !
       local interface Port-Channel19
       !
+      local interface Port-Channel21
+      !
       peer dynamic
    !
    load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
@@ -165,6 +167,12 @@ interface Port-Channel19
    no switchport
    ip address 192.168.1.19/31
 !
+interface Port-Channel21
+   description BlizzardFast_peerDevice5_Port-Channel21
+   no shutdown
+   no switchport
+   ip address 192.168.21.21/31
+!
 interface Dps1
    description DPS Interface
    mtu 9194
@@ -205,6 +213,11 @@ interface Ethernet1/20
    shutdown
    channel-group 19 mode active
 !
+interface Ethernet1/21
+   description peerDevice5_Ethernet1/21
+   no shutdown
+   channel-group 21 mode active
+!
 interface Ethernet2
    description peer1
    no shutdown
@@ -242,10 +255,22 @@ no ip routing vrf MGMT
 !
 ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.255.1:511
 !
+ip prefix-list ALLOW-DEFAULT
+   seq 10 permit 0.0.0.0/0
+!
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
 !
 ip route 0.0.0.0/0 192.168.1.103
+!
+route-map RM-BGP-192.168.21.20-IN permit 10
+   match ip address prefix-list ALLOW-DEFAULT
+   set community no-advertise additive
+!
+route-map RM-BGP-192.168.21.20-OUT permit 10
+   match ip address prefix-list ALLOW-DEFAULT
+!
+route-map RM-BGP-192.168.21.20-OUT deny 20
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
@@ -262,7 +287,14 @@ router bgp 65005
    update wait-install
    no bgp default ipv4-unicast
    maximum-paths 16
+   neighbor 192.168.21.20 remote-as 65021
+   neighbor 192.168.21.20 description BlizzardFast_peerDevice5_Port-Channel21
+   neighbor 192.168.21.20 route-map RM-BGP-192.168.21.20-IN in
+   neighbor 192.168.21.20 route-map RM-BGP-192.168.21.20-OUT out
    redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family ipv4
+      neighbor 192.168.21.20 activate
    !
    address-family link-state
       path-selection

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -501,10 +501,6 @@ route_maps:
     - ip address prefix-list ALLOW-DEFAULT
     set:
     - community no-advertise additive
-- name: RM-BGP-172.16.9.4-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: deny
 - name: RM-BGP-172.16.5.4-IN
   sequence_numbers:
   - sequence: 10
@@ -706,7 +702,6 @@ router_bgp:
     remote_as: '64520'
     description: ATT_666_peer3_Ethernet42
     route_map_in: RM-BGP-172.16.9.4-IN
-    route_map_out: RM-BGP-172.16.9.4-OUT
   - ip_address: 172.16.5.4
     remote_as: '64520'
     description: Colt_10555

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -786,10 +786,6 @@ route_maps:
     - ip address prefix-list PL2
     set:
     - community no-advertise additive
-- name: RM-BGP-172.31.0.10-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: deny
 - name: RM-CONN-2-BGP
   sequence_numbers:
   - sequence: 10
@@ -965,7 +961,6 @@ router_bgp:
     remote_as: '64520'
     description: Orange_peerDevice10_Port-Channel455
     route_map_in: RM-BGP-172.31.0.10-IN
-    route_map_out: RM-BGP-172.31.0.10-OUT
   - ip_address: 172.17.0.2
     peer_group: IPv4-UNDERLAY-PEERS
     remote_as: '65199'

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-interfaces-bgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-interfaces-bgp.yml
@@ -12,6 +12,14 @@ ethernet_interfaces:
     peer_type: l3_interface
   switchport:
     enabled: false
+- name: Ethernet44
+  description: PEER44_BGP
+  shutdown: true
+  ip_address: 192.168.44.44/24
+  metadata:
+    peer_type: l3_interface
+  switchport:
+    enabled: false
 hostname: node-type-l3-interfaces-bgp
 ip_igmp_snooping:
   globally_enabled: true
@@ -38,9 +46,13 @@ route_maps:
     - ip address prefix-list ALLOW-DEFAULT
     set:
     - community no-advertise additive
-- name: RM-BGP-192.168.42.1-OUT
+- name: RM-BGP-192.168.44.1-OUT
   sequence_numbers:
   - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list ALLOW-DEFAULT
+  - sequence: 20
     type: deny
 router_bgp:
   as: '65000'
@@ -57,13 +69,18 @@ router_bgp:
     remote_as: '65042'
     description: INTERNET
     route_map_in: RM-BGP-192.168.42.1-IN
-    route_map_out: RM-BGP-192.168.42.1-OUT
+  - ip_address: 192.168.44.1
+    remote_as: '65044'
+    description: PEER44_BGP
+    route_map_out: RM-BGP-192.168.44.1-OUT
   redistribute:
     connected:
       enabled: true
   address_family_ipv4:
     neighbors:
     - ip_address: 192.168.42.1
+      activate: true
+    - ip_address: 192.168.44.1
       activate: true
 service_routing_protocols_model: multi-agent
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-interfaces-bgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-interfaces-bgp.yml
@@ -46,6 +46,10 @@ route_maps:
     - ip address prefix-list ALLOW-DEFAULT
     set:
     - community no-advertise additive
+- name: RM-BGP-192.168.42.1-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: deny
 - name: RM-BGP-192.168.44.1-OUT
   sequence_numbers:
   - sequence: 10
@@ -69,6 +73,7 @@ router_bgp:
     remote_as: '65042'
     description: INTERNET
     route_map_in: RM-BGP-192.168.42.1-IN
+    route_map_out: RM-BGP-192.168.42.1-OUT
   - ip_address: 192.168.44.1
     remote_as: '65044'
     description: PEER44_BGP

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-port-channels.yml
@@ -105,6 +105,16 @@ ethernet_interfaces:
     peer: peerDevice4
     peer_interface: Ethernet1/20
     peer_type: l3_port_channel_member
+- name: Ethernet1/21
+  description: peerDevice5_Ethernet1/21
+  shutdown: false
+  channel_group:
+    id: 21
+    mode: active
+  metadata:
+    peer: peerDevice5
+    peer_interface: Ethernet1/21
+    peer_type: l3_port_channel_member
 flow_tracking:
   hardware:
     trackers:
@@ -236,6 +246,12 @@ metadata:
         value: wan
       - name: Carrier
         value: BlizzardFast
+    - interface: Port-Channel21
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: BlizzardFast
   cv_pathfinder:
     role: edge
     region: AVD_Land_East
@@ -260,6 +276,9 @@ metadata:
       carrier: BlizzardFast
       pathgroup: INET
     - name: Port-Channel19
+      carrier: BlizzardFast
+      pathgroup: INET
+    - name: Port-Channel21
       carrier: BlizzardFast
       pathgroup: INET
 port_channel_interfaces:
@@ -356,12 +375,42 @@ port_channel_interfaces:
     peer_type: l3_port_channel
   switchport:
     enabled: false
+- name: Port-Channel21
+  description: BlizzardFast_peerDevice5_Port-Channel21
+  shutdown: false
+  ip_address: 192.168.21.21/31
+  metadata:
+    peer: peerDevice5
+    peer_interface: Port-Channel21
+    peer_type: l3_port_channel
+  switchport:
+    enabled: false
 prefix_lists:
+- name: ALLOW-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 0.0.0.0/0
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
   - sequence: 10
     action: permit 192.168.255.0/24 eq 32
 route_maps:
+- name: RM-BGP-192.168.21.20-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list ALLOW-DEFAULT
+    set:
+    - community no-advertise additive
+- name: RM-BGP-192.168.21.20-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list ALLOW-DEFAULT
+  - sequence: 20
+    type: deny
 - name: RM-CONN-2-BGP
   sequence_numbers:
   - sequence: 10
@@ -422,10 +471,20 @@ router_bgp:
   bgp:
     default:
       ipv4_unicast: false
+  neighbors:
+  - ip_address: 192.168.21.20
+    remote_as: '65021'
+    description: BlizzardFast_peerDevice5_Port-Channel21
+    route_map_in: RM-BGP-192.168.21.20-IN
+    route_map_out: RM-BGP-192.168.21.20-OUT
   redistribute:
     connected:
       enabled: true
       route_map: RM-CONN-2-BGP
+  address_family_ipv4:
+    neighbors:
+    - ip_address: 192.168.21.20
+      activate: true
   address_family_link_state:
     path_selection:
       roles:
@@ -459,6 +518,7 @@ router_path_selection:
     - name: Port-Channel5.100
     - name: Port-Channel8
     - name: Port-Channel19
+    - name: Port-Channel21
     dynamic_peers:
       enabled: true
   load_balance_policies:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -5,6 +5,10 @@ wan_mode: cv-pathfinder
 # the default is "none" for WAN routers"
 underlay_routing_protocol: ebgp
 
+avd_design_future:
+  # Opt-in so an empty `RM-BGP-<peer>-OUT deny 10` is not generated when `bgp.ipv4_prefix_list_out` is unset.
+  only_configure_outbound_route_map_when_prefix_list_out_defined: true
+
 ipv4_prefix_list_catalog:
   - name: ALLOW-DEFAULT
     sequence_numbers:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-interfaces-bgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-interfaces-bgp.yml
@@ -31,7 +31,7 @@ l3spine:
             peer_as: 65042
             ipv4_prefix_list_in: ALLOW-DEFAULT
         - # non-WAN BGP peer with ipv4_prefix_list_out defined.
-          # Verifies that the outbound route-map IS generated and attached when ipv4_prefix_list_out is configured.
+          # Verifies that the outbound route-map is generated and attached when ipv4_prefix_list_out is configured.
           name: Ethernet44
           description: PEER44_BGP
           enabled: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-interfaces-bgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-interfaces-bgp.yml
@@ -20,7 +20,8 @@ l3spine:
       bgp_as: 65000
       uplink_type: lan
       l3_interfaces:
-        - # triggering bgp
+        - # triggering bgp - WAN with only ipv4_prefix_list_in defined.
+          # Verifies that no outbound route-map is generated when ipv4_prefix_list_out is not configured.
           name: Ethernet43
           enabled: false
           ip_address: 192.168.42.42/24
@@ -29,3 +30,13 @@ l3spine:
           bgp:
             peer_as: 65042
             ipv4_prefix_list_in: ALLOW-DEFAULT
+        - # non-WAN BGP peer with ipv4_prefix_list_out defined.
+          # Verifies that the outbound route-map IS generated and attached when ipv4_prefix_list_out is configured.
+          name: Ethernet44
+          description: PEER44_BGP
+          enabled: false
+          ip_address: 192.168.44.44/24
+          peer_ip: 192.168.44.1
+          bgp:
+            peer_as: 65044
+            ipv4_prefix_list_out: ALLOW-DEFAULT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-interfaces-bgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-interfaces-bgp.yml
@@ -21,7 +21,8 @@ l3spine:
       uplink_type: lan
       l3_interfaces:
         - # triggering bgp - WAN with only ipv4_prefix_list_in defined.
-          # Verifies that no outbound route-map is generated when ipv4_prefix_list_out is not configured.
+          # Verifies legacy behavior: an empty `RM-BGP-<peer>-OUT deny 10` is generated when
+          # `avd_design_future.only_configure_outbound_route_map_when_prefix_list_out_defined` is unset.
           name: Ethernet43
           enabled: false
           ip_address: 192.168.42.42/24

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-port-channels.yml
@@ -19,6 +19,12 @@ bgp_peer_groups:
       - 192.168.142.0/24
       - 192.168.143.0/24
 
+ipv4_prefix_list_catalog:
+  - name: ALLOW-DEFAULT
+    sequence_numbers:
+      - sequence: 10
+        action: permit 0.0.0.0/0
+
 wan_ipsec_profiles:
   control_plane:
     shared_key: ABCDEF1234567890
@@ -154,6 +160,21 @@ wan_router:
               peer_port_channel: Port-Channel20
               peer_ip: 192.168.1.18
               wan_carrier: BlizzardFast
+            - # Port-Channel with BGP peering and both inbound + outbound prefix-lists defined.
+              # Verifies that the outbound route-map IS generated and attached when ipv4_prefix_list_out is configured on a port-channel.
+              name: Port-Channel21
+              ip_address: 192.168.21.21/31
+              member_interfaces:
+                - name: Ethernet1/21
+                  peer_interface: Ethernet1/21
+              peer: peerDevice5
+              peer_port_channel: Port-Channel21
+              peer_ip: 192.168.21.20
+              wan_carrier: BlizzardFast
+              bgp:
+                peer_as: 65021
+                ipv4_prefix_list_in: ALLOW-DEFAULT
+                ipv4_prefix_list_out: ALLOW-DEFAULT
 wan_carriers:
   - name: Cybercast
     path_group: INET

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-port-channels.yml
@@ -161,7 +161,7 @@ wan_router:
               peer_ip: 192.168.1.18
               wan_carrier: BlizzardFast
             - # Port-Channel with BGP peering and both inbound + outbound prefix-lists defined.
-              # Verifies that the outbound route-map IS generated and attached when ipv4_prefix_list_out is configured on a port-channel.
+              # Verifies that the outbound route-map is generated and attached when ipv4_prefix_list_out is configured on a port-channel.
               name: Port-Channel21
               ip_address: 192.168.21.21/31
               member_interfaces:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/avd-design-future.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/avd-design-future.md
@@ -15,6 +15,7 @@
     | [<samp>&nbsp;&nbsp;raise_for_underlay_router_with_uplink_type_port_channel</samp>](## "avd_design_future.raise_for_underlay_router_with_uplink_type_port_channel") | Boolean |  | `False` |  | Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,<br>since this combination is not supported. |
     | [<samp>&nbsp;&nbsp;configure_inband_mgmt_ipv6_vrf</samp>](## "avd_design_future.configure_inband_mgmt_ipv6_vrf") | Boolean |  | `False` |  | Configure `inband_mgmt_vrf` for IPv6 inband management. |
     | [<samp>&nbsp;&nbsp;only_configure_ipv6_inband_mgmt_prefix_list_when_used</samp>](## "avd_design_future.only_configure_ipv6_inband_mgmt_prefix_list_when_used") | Boolean |  | `False` |  | Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed. |
+    | [<samp>&nbsp;&nbsp;only_configure_outbound_route_map_when_prefix_list_out_defined</samp>](## "avd_design_future.only_configure_outbound_route_map_when_prefix_list_out_defined") | Boolean |  | `False` |  | Only generate the BGP outbound route-map for L3 interface and L3 port-channel BGP peerings when<br>`bgp.ipv4_prefix_list_out` is defined. By default an empty `deny` route-map is always created and<br>attached to the neighbor, even when no outbound prefix list is configured. |
 
 === "YAML"
 
@@ -43,4 +44,9 @@
 
       # Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
       only_configure_ipv6_inband_mgmt_prefix_list_when_used: <bool; default=False>
+
+      # Only generate the BGP outbound route-map for L3 interface and L3 port-channel BGP peerings when
+      # `bgp.ipv4_prefix_list_out` is defined. By default an empty `deny` route-map is always created and
+      # attached to the neighbor, even when no outbound prefix list is configured.
+      only_configure_outbound_route_map_when_prefix_list_out_defined: <bool; default=False>
     ```

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -933,6 +933,7 @@ class EosDesigns(EosDesignsRootModel):
             "raise_for_underlay_router_with_uplink_type_port_channel": {"type": bool, "default": False},
             "configure_inband_mgmt_ipv6_vrf": {"type": bool, "default": False},
             "only_configure_ipv6_inband_mgmt_prefix_list_when_used": {"type": bool, "default": False},
+            "only_configure_outbound_route_map_when_prefix_list_out_defined": {"type": bool, "default": False},
         }
         accept_dhcp_default_route_for_mgmt_ip_dhcp: bool
         """
@@ -979,6 +980,14 @@ class EosDesigns(EosDesignsRootModel):
 
         Default value: `False`
         """
+        only_configure_outbound_route_map_when_prefix_list_out_defined: bool
+        """
+        Only generate the BGP outbound route-map for L3 interface and L3 port-channel BGP peerings when
+        `bgp.ipv4_prefix_list_out` is defined. By default an empty `deny` route-map is always created and
+        attached to the neighbor, even when no outbound prefix list is configured.
+
+        Default value: `False`
+        """
 
         if TYPE_CHECKING:
 
@@ -992,6 +1001,7 @@ class EosDesigns(EosDesignsRootModel):
                 raise_for_underlay_router_with_uplink_type_port_channel: bool | UndefinedType = Undefined,
                 configure_inband_mgmt_ipv6_vrf: bool | UndefinedType = Undefined,
                 only_configure_ipv6_inband_mgmt_prefix_list_when_used: bool | UndefinedType = Undefined,
+                only_configure_outbound_route_map_when_prefix_list_out_defined: bool | UndefinedType = Undefined,
             ) -> None:
                 """
                 AvdDesignFuture.
@@ -1012,6 +1022,10 @@ class EosDesigns(EosDesignsRootModel):
                        this combination is not supported.
                     configure_inband_mgmt_ipv6_vrf: Configure `inband_mgmt_vrf` for IPv6 inband management.
                     only_configure_ipv6_inband_mgmt_prefix_list_when_used: Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
+                    only_configure_outbound_route_map_when_prefix_list_out_defined:
+                       Only generate the BGP outbound route-map for L3 interface and L3 port-channel BGP peerings when
+                       `bgp.ipv4_prefix_list_out` is defined. By default an empty `deny` route-map is always created and
+                       attached to the neighbor, even when no outbound prefix list is configured.
 
                 """
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -368,6 +368,16 @@ keys:
         description: Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when
           it is needed.
         default: false
+      only_configure_outbound_route_map_when_prefix_list_out_defined:
+        type: bool
+        description: 'Only generate the BGP outbound route-map for L3 interface and
+          L3 port-channel BGP peerings when
+
+          `bgp.ipv4_prefix_list_out` is defined. By default an empty `deny` route-map
+          is always created and
+
+          attached to the neighbor, even when no outbound prefix list is configured.'
+        default: false
   avd_digital_twin_mode:
     documentation_options:
       table: role-settings

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_design_future.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_design_future.schema.yml
@@ -45,3 +45,10 @@ keys:
         type: bool
         description: Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
         default: false
+      only_configure_outbound_route_map_when_prefix_list_out_defined:
+        type: bool
+        description: |-
+          Only generate the BGP outbound route-map for L3 interface and L3 port-channel BGP peerings when
+          `bgp.ipv4_prefix_list_out` is defined. By default an empty `deny` route-map is always created and
+          attached to the neighbor, even when no outbound prefix list is configured.
+        default: false

--- a/python-avd/pyavd/_eos_designs/shared_utils/misc.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/misc.py
@@ -405,6 +405,10 @@ class MiscMixin(Protocol):
             rm_out_name = f"RM-BGP-{neighbor.ip_address}-OUT"
             neighbor.route_map_out = rm_out_name
             route_maps.append(self.get_l3_bgp_route_map_out(rm_out_name, interface.bgp.ipv4_prefix_list_out))
+        elif not self.inputs.avd_design_future.only_configure_outbound_route_map_when_prefix_list_out_defined:
+            rm_out_name = f"RM-BGP-{neighbor.ip_address}-OUT"
+            neighbor.route_map_out = rm_out_name
+            route_maps.append(self.get_l3_bgp_route_map_out(rm_out_name, interface.bgp.ipv4_prefix_list_out))
 
         neighbors.append(neighbor)
 

--- a/python-avd/pyavd/_eos_designs/shared_utils/misc.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/misc.py
@@ -399,13 +399,9 @@ class MiscMixin(Protocol):
             neighbor.route_map_in = rm_in_name
             route_maps.append(self.get_l3_bgp_route_map_in(rm_in_name, interface.bgp.ipv4_prefix_list_in, no_advertise=is_wan_interface))
 
-        if interface.bgp.ipv4_prefix_list_out:
-            if interface.bgp.ipv4_prefix_list_out not in prefix_lists:
-                prefix_lists.append(self.get_prefix_list(interface.bgp.ipv4_prefix_list_out))
-            rm_out_name = f"RM-BGP-{neighbor.ip_address}-OUT"
-            neighbor.route_map_out = rm_out_name
-            route_maps.append(self.get_l3_bgp_route_map_out(rm_out_name, interface.bgp.ipv4_prefix_list_out))
-        elif not self.inputs.avd_design_future.only_configure_outbound_route_map_when_prefix_list_out_defined:
+        if interface.bgp.ipv4_prefix_list_out and interface.bgp.ipv4_prefix_list_out not in prefix_lists:
+            prefix_lists.append(self.get_prefix_list(interface.bgp.ipv4_prefix_list_out))
+        if not self.inputs.avd_design_future.only_configure_outbound_route_map_when_prefix_list_out_defined or interface.bgp.ipv4_prefix_list_out:
             rm_out_name = f"RM-BGP-{neighbor.ip_address}-OUT"
             neighbor.route_map_out = rm_out_name
             route_maps.append(self.get_l3_bgp_route_map_out(rm_out_name, interface.bgp.ipv4_prefix_list_out))

--- a/python-avd/pyavd/_eos_designs/shared_utils/misc.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/misc.py
@@ -399,12 +399,12 @@ class MiscMixin(Protocol):
             neighbor.route_map_in = rm_in_name
             route_maps.append(self.get_l3_bgp_route_map_in(rm_in_name, interface.bgp.ipv4_prefix_list_in, no_advertise=is_wan_interface))
 
-        if interface.bgp.ipv4_prefix_list_out and interface.bgp.ipv4_prefix_list_out not in prefix_lists:
-            prefix_lists.append(self.get_prefix_list(interface.bgp.ipv4_prefix_list_out))
-
-        rm_out_name = f"RM-BGP-{neighbor.ip_address}-OUT"
-        neighbor.route_map_out = rm_out_name
-        route_maps.append(self.get_l3_bgp_route_map_out(rm_out_name, interface.bgp.ipv4_prefix_list_out))
+        if interface.bgp.ipv4_prefix_list_out:
+            if interface.bgp.ipv4_prefix_list_out not in prefix_lists:
+                prefix_lists.append(self.get_prefix_list(interface.bgp.ipv4_prefix_list_out))
+            rm_out_name = f"RM-BGP-{neighbor.ip_address}-OUT"
+            neighbor.route_map_out = rm_out_name
+            route_maps.append(self.get_l3_bgp_route_map_out(rm_out_name, interface.bgp.ipv4_prefix_list_out))
 
         neighbors.append(neighbor)
 


### PR DESCRIPTION
## Change Summary

Only generate BGP outbound route-map when ipv4_prefix_list_out is defined

## Related Issue(s)

Fixes #6941 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
