### PR TITLE
Fix(eos_cli_config_gen)!: Correct valid values for Sand multicast replication

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1618,6 +1618,12 @@ dot1x dynamic-authorization
 | -------- | ----- |
 | MMU Headroom-pool Limit | 557 bytes |
 
+#### Platform Sand Summary
+
+| Settings | Value |
+| -------- | ----- |
+| Default Multicast Replication | fabric-egress |
+
 #### Platform FAP Summary
 
 | Settings | Value |
@@ -1630,6 +1636,8 @@ dot1x dynamic-authorization
 ```eos
 !
 platform fap buffering egress profile balanced
+!
+platform sand multicast replication default fabric-egress
 !
 platform trident mmu headroom-pool limit 557
 ```

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host2.cfg
@@ -111,6 +111,8 @@ router path-selection
 !
 platform fap buffering egress profile balanced
 !
+platform sand multicast replication default fabric-egress
+!
 sflow source 1.1.1.1
 sflow interface egress enable default
 !

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host2/platform.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host2/platform.yml
@@ -10,3 +10,6 @@ platform:
       profile: balanced
     voq:
       credit_rates_unified: false
+  sand:
+    multicast_replication:
+      default: fabric-egress

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
@@ -59,7 +59,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "platform.sand.lag.mode") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;forwarding_mode</samp>](## "platform.sand.forwarding_mode") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multicast_replication</samp>](## "platform.sand.multicast_replication") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "platform.sand.multicast_replication.default") | String |  |  | Valid Values:<br>- <code>ingress</code><br>- <code>egress</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "platform.sand.multicast_replication.default") | String |  |  | Valid Values:<br>- <code>ingress</code><br>- <code>fabric-egress</code><br>- <code>ingress-egress</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mdb_profile</samp>](## "platform.sand.mdb_profile") | String |  |  | Valid Values:<br>- <code>balanced</code><br>- <code>balanced-xl</code><br>- <code>l3</code><br>- <code>l3-xl</code><br>- <code>l3-xxl</code><br>- <code>l3-xxxl</code> | Sand platforms MDB Profile configuration. Note: l3-xxxl does not support MLAG. |
     | [<samp>&nbsp;&nbsp;sfe</samp>](## "platform.sfe") | Dictionary |  |  |  | Sfe (Software Forwarding Engine) settings. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;data_plane_cpu_allocation_max</samp>](## "platform.sfe.data_plane_cpu_allocation_max") | Integer |  |  | Min: 1<br>Max: 128 | Maximum number of CPUs used for data plane traffic forwarding. |
@@ -193,7 +193,7 @@
           mode: <str>
         forwarding_mode: <str>
         multicast_replication:
-          default: <str; "ingress" | "egress">
+          default: <str; "ingress" | "fabric-egress" | "ingress-egress">
 
         # Sand platforms MDB Profile configuration. Note: l3-xxxl does not support MLAG.
         mdb_profile: <str; "balanced" | "balanced-xl" | "l3" | "l3-xl" | "l3-xxl" | "l3-xxxl">

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
@@ -59,7 +59,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "platform.sand.lag.mode") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;forwarding_mode</samp>](## "platform.sand.forwarding_mode") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;multicast_replication</samp>](## "platform.sand.multicast_replication") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "platform.sand.multicast_replication.default") | String |  |  | Valid Values:<br>- <code>ingress</code><br>- <code>fabric-egress</code><br>- <code>ingress-egress</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default</samp>](## "platform.sand.multicast_replication.default") | String |  |  | Valid Values:<br>- <code>ingress</code><br>- <code>fabric-egress</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mdb_profile</samp>](## "platform.sand.mdb_profile") | String |  |  | Valid Values:<br>- <code>balanced</code><br>- <code>balanced-xl</code><br>- <code>l3</code><br>- <code>l3-xl</code><br>- <code>l3-xxl</code><br>- <code>l3-xxxl</code> | Sand platforms MDB Profile configuration. Note: l3-xxxl does not support MLAG. |
     | [<samp>&nbsp;&nbsp;sfe</samp>](## "platform.sfe") | Dictionary |  |  |  | Sfe (Software Forwarding Engine) settings. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;data_plane_cpu_allocation_max</samp>](## "platform.sfe.data_plane_cpu_allocation_max") | Integer |  |  | Min: 1<br>Max: 128 | Maximum number of CPUs used for data plane traffic forwarding. |
@@ -193,7 +193,7 @@
           mode: <str>
         forwarding_mode: <str>
         multicast_replication:
-          default: <str; "ingress" | "fabric-egress" | "ingress-egress">
+          default: <str; "ingress" | "fabric-egress">
 
         # Sand platforms MDB Profile configuration. Note: l3-xxxl does not support MLAG.
         mdb_profile: <str; "balanced" | "balanced-xl" | "l3" | "l3-xl" | "l3-xxl" | "l3-xxxl">

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -31717,7 +31717,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             class MulticastReplication(AvdModel):
                 """Subclass of AvdModel."""
 
-                Default: TypeAlias = Literal["ingress", "egress"]
+                Default: TypeAlias = Literal["ingress", "fabric-egress", "ingress-egress"]
                 _fields: ClassVar[dict] = {"default": {"type": str}}
                 default: Default | None
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -31717,7 +31717,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             class MulticastReplication(AvdModel):
                 """Subclass of AvdModel."""
 
-                Default: TypeAlias = Literal["ingress", "fabric-egress", "ingress-egress"]
+                Default: TypeAlias = Literal["ingress", "fabric-egress"]
                 _fields: ClassVar[dict] = {"default": {"type": str}}
                 default: Default | None
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -12309,7 +12309,8 @@ keys:
                 type: str
                 valid_values:
                 - ingress
-                - egress
+                - fabric-egress
+                - ingress-egress
           mdb_profile:
             type: str
             description: 'Sand platforms MDB Profile configuration. Note: l3-xxxl

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -12310,7 +12310,6 @@ keys:
                 valid_values:
                 - ingress
                 - fabric-egress
-                - ingress-egress
           mdb_profile:
             type: str
             description: 'Sand platforms MDB Profile configuration. Note: l3-xxxl

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/platform.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/platform.schema.yml
@@ -302,7 +302,7 @@ keys:
             keys:
               default:
                 type: str
-                valid_values: ["ingress", "fabric-egress", "ingress-egress"]
+                valid_values: ["ingress", "fabric-egress"]
           mdb_profile:
             type: str
             description: "Sand platforms MDB Profile configuration. Note: l3-xxxl does not support MLAG."

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/platform.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/platform.schema.yml
@@ -302,7 +302,7 @@ keys:
             keys:
               default:
                 type: str
-                valid_values: ["ingress", "egress"]
+                valid_values: ["ingress", "fabric-egress", "ingress-egress"]
           mdb_profile:
             type: str
             description: "Sand platforms MDB Profile configuration. Note: l3-xxxl does not support MLAG."


### PR DESCRIPTION
## Change Summary

Schema for multicast replication is wrong

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Valid values, depending on fixed or modular are;

- ingress
- ~~ingress-egress~~
- fabric-egress  

## How to test
Updated molecule tests for the egress scenario

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
