### PR TITLE
Feat(eos_cli_config_gen): Add support for 'spanning-tree guard loop default' on global spanning tree config

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -4302,6 +4302,8 @@ no lacp rate-limit default
 
 STP mode: **rapid-pvst**
 
+STP Loop Guard: **True**
+
 #### Rapid-PVST Instance and Priority
 
 | Instance(s) | Priority |

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -4331,6 +4331,7 @@ spanning-tree port-id allocation port-channel range 201 2001
 spanning-tree vlan-id 1,2,3,4,5,10-15 priority 4096
 spanning-tree vlan-id 3 priority 8192
 spanning-tree vlan-id 100-500 priority 16384
+spanning-tree guard loop default
 ```
 
 ### Synchronous Ethernet (SyncE) Settings

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1485,6 +1485,7 @@ spanning-tree port-id allocation port-channel range 201 2001
 spanning-tree vlan-id 1,2,3,4,5,10-15 priority 4096
 spanning-tree vlan-id 3 priority 8192
 spanning-tree vlan-id 100-500 priority 16384
+spanning-tree guard loop default
 !
 sync-e
    network option 2

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/spanning-tree.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/spanning-tree.yml
@@ -20,3 +20,4 @@ spanning_tree:
   port_id_allocation_port_channel_range:
     minimum: 201
     maximum: 2001
+  loop_guard_default: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/spanning-tree.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/spanning-tree.md
@@ -35,6 +35,7 @@
     | [<samp>&nbsp;&nbsp;port_id_allocation_port_channel_range</samp>](## "spanning_tree.port_id_allocation_port_channel_range") | Dictionary |  |  |  | Specify range of port-ids to reserve for port-channels. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;minimum</samp>](## "spanning_tree.port_id_allocation_port_channel_range.minimum") | Integer | Required |  | Min: 1<br>Max: 2048 | Specify minimum value for reserved range. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum</samp>](## "spanning_tree.port_id_allocation_port_channel_range.maximum") | Integer | Required |  | Min: 1<br>Max: 2048 | Specify maximum value for reserved range. |
+    | [<samp>&nbsp;&nbsp;loop_guard_default</samp>](## "spanning_tree.loop_guard_default") | Boolean |  |  |  | Enable loopguard by default on all ports. |
 
 === "YAML"
 
@@ -90,4 +91,7 @@
 
         # Specify maximum value for reserved range.
         maximum: <int; 1-2048; required>
+
+      # Enable loopguard by default on all ports.
+      loop_guard_default: <bool>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/spanning-tree.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/spanning-tree.j2
@@ -15,6 +15,10 @@ STP mode: **{{ spanning_tree.mode | arista.avd.default("mstp") }}**
 
 STP Root Super: **{{ spanning_tree.root_super }}**
 {%     endif %}
+{%     if spanning_tree.loop_guard_default is arista.avd.defined %}
+
+STP Loop Guard: **{{ spanning_tree.loop_guard_default }}**
+{%     endif %}
 {%     if spanning_tree.mst_instances is arista.avd.defined %}
 
 #### MSTP Instance and Priority

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/spanning-tree.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/spanning-tree.j2
@@ -60,6 +60,9 @@ spanning-tree vlan-id {{ vlan_id.id }} priority {{ vlan_id.priority }}
 spanning-tree priority {{ spanning_tree.rstp_priority }}
 {%         endif %}
 {%     endif %}
+{%     if spanning_tree.loop_guard_default is arista.avd.defined(true) %}
+spanning-tree guard loop default
+{%     endif %}
 {%     if spanning_tree.mst.configuration is arista.avd.defined %}
 !
 spanning-tree mst configuration

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -66637,6 +66637,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "no_spanning_tree_vlan": {"type": str},
             "rapid_pvst_instances": {"type": RapidPvstInstances},
             "port_id_allocation_port_channel_range": {"type": PortIdAllocationPortChannelRange},
+            "loop_guard_default": {"type": bool},
         }
         root_super: bool | None
         edge_port: EdgePort
@@ -66662,6 +66663,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
         Subclass of AvdModel.
         """
+        loop_guard_default: bool | None
+        """Enable loopguard by default on all ports."""
 
         if TYPE_CHECKING:
 
@@ -66678,6 +66681,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 no_spanning_tree_vlan: str | None | UndefinedType = Undefined,
                 rapid_pvst_instances: RapidPvstInstances | UndefinedType = Undefined,
                 port_id_allocation_port_channel_range: PortIdAllocationPortChannelRange | UndefinedType = Undefined,
+                loop_guard_default: bool | None | UndefinedType = Undefined,
             ) -> None:
                 """
                 SpanningTree.
@@ -66701,6 +66705,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        Specify range of port-ids to reserve for port-channels.
 
                        Subclass of AvdModel.
+                    loop_guard_default: Enable loopguard by default on all ports.
 
                 """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -24380,6 +24380,9 @@ keys:
             required: true
             convert_types:
             - str
+      loop_guard_default:
+        description: Enable loopguard by default on all ports.
+        type: bool
   standard_access_lists:
     type: list
     primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/spanning_tree.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/spanning_tree.schema.yml
@@ -127,3 +127,6 @@ keys:
             required: true
             convert_types:
               - str
+      loop_guard_default:
+        description: Enable loopguard by default on all ports.
+        type: bool


### PR DESCRIPTION
## Change Summary
Add support for 'spanning-tree guard loop default' on global spanning tree config

## Related Issue(s)

Part of #6581

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add support for 'spanning-tree guard loop default' on global spanning tree config

## How to test
Run Molecule

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
