### PR TITLE
Fix(cv_deploy): Fix workspace build error when deleting manifest configlets still assigned

### DIFF
--- a/ansible_collections/arista/avd/roles/cv_deploy/README.md
+++ b/ansible_collections/arista/avd/roles/cv_deploy/README.md
@@ -454,7 +454,7 @@ For each opted-in device, you are responsible for ensuring the manifest defines 
     When initially deploying or adding new root containers, the role places its managed root containers to the top of the Studio container tree. Please be aware that this automated ordering **may displace any containers you have manually arranged**.
 
 !!! warning "Manual configlet assignments"
-    Before you remove a configlet from the manifest, ensure it is not manually assigned to any non-manifest containers. If it is, you must manually remove it from those containers first.
+    Before you remove a configlet created by a cv_deploy manifest, ensure it is not manually assigned to any non-manifest containers. Otherwise you must manually unassign the configlet from such containers first.
 
 #### Example for AVD users
 

--- a/ansible_collections/arista/avd/roles/cv_deploy/README.md
+++ b/ansible_collections/arista/avd/roles/cv_deploy/README.md
@@ -453,6 +453,9 @@ For each opted-in device, you are responsible for ensuring the manifest defines 
 !!! note "Root Containers Order"
     When initially deploying or adding new root containers, the role places its managed root containers to the top of the Studio container tree. Please be aware that this automated ordering **may displace any containers you have manually arranged**.
 
+!!! warning "Manual configlet assignments"
+    If a configlet managed by the manifest is manually assigned to a container that the manifest does **not** control, it must be manually unassigned before it is removed from the manifest.
+
 #### Example for AVD users
 
 `eos_cli_config_gen` generates one configuration file per device in `eos_config_dir` (`intended/configs` by default). The example below puts those configurations into a custom hierarchy organized by fabric, DC, and POD.

--- a/ansible_collections/arista/avd/roles/cv_deploy/README.md
+++ b/ansible_collections/arista/avd/roles/cv_deploy/README.md
@@ -454,7 +454,7 @@ For each opted-in device, you are responsible for ensuring the manifest defines 
     When initially deploying or adding new root containers, the role places its managed root containers to the top of the Studio container tree. Please be aware that this automated ordering **may displace any containers you have manually arranged**.
 
 !!! warning "Manual configlet assignments"
-    If a configlet managed by the manifest is manually assigned to a container that the manifest does **not** control, it must be manually unassigned before it is removed from the manifest.
+    Before you remove a configlet from the manifest, ensure it is not manually assigned to any non-manifest containers. If it is, you must manually remove it from those containers first.
 
 #### Example for AVD users
 

--- a/python-avd/pyavd/_cv/workflows/deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/pyavd/_cv/workflows/deploy_static_config_studio_manifest_to_cv.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from asyncio import gather
+from collections import defaultdict
 from logging import getLogger
 from typing import TYPE_CHECKING, cast
 
@@ -29,6 +30,8 @@ async def deploy_static_config_studio_manifest_to_cv(manifest: AvdManifest, depl
 
     TODO: Implement strict mode to remove any containers/configlets not managed by AVD from the Studio.
     TODO: Implement configlet body diff - digest/checksum.
+    TODO: Replace the existing_containers / existing_managed_containers_by_id pair carried between sync functions with an
+          ExistingState dataclass holding pre-computed mappings (containers_by_id, parents_by_child_id, etc.).
     """
     workspace_id = deployment_result.workspace.id
     LOGGER.info("deploy_static_config_studio_manifest_to_cv: Starting manifest deployment for workspace '%s'.", workspace_id)
@@ -45,15 +48,25 @@ async def deploy_static_config_studio_manifest_to_cv(manifest: AvdManifest, depl
         return
 
     # Perform synchronization tasks.
-    await _sync_configlets(cv_manifest=cv_manifest, deployment_result=deployment_result, cv_client=cv_client)
-    await _sync_containers(cv_manifest=cv_manifest, deployment_result=deployment_result, cv_client=cv_client)
+    existing_containers, existing_managed_containers_by_id = await _sync_containers(
+        cv_manifest=cv_manifest, deployment_result=deployment_result, cv_client=cv_client
+    )
+    await _sync_configlets(
+        cv_manifest=cv_manifest,
+        existing_containers=existing_containers,
+        existing_managed_containers_by_id=existing_managed_containers_by_id,
+        deployment_result=deployment_result,
+        cv_client=cv_client,
+    )
     await _sync_studio_roots(cv_manifest=cv_manifest, deployment_result=deployment_result, cv_client=cv_client)
 
     # Done.
     LOGGER.info("deploy_static_config_studio_manifest_to_cv: Completed manifest deployment for workspace '%s'.", workspace_id)
 
 
-async def _sync_containers(cv_manifest: CVManifest, deployment_result: DeployToCvResult, cv_client: CVClient) -> dict[str, ConfigletAssignment]:
+async def _sync_containers(
+    cv_manifest: CVManifest, deployment_result: DeployToCvResult, cv_client: CVClient
+) -> tuple[list[ConfigletAssignment], dict[str, str]]:
     """Synchronize containers. Fetch existing ones and push any required creates or updates."""
     workspace_id = deployment_result.workspace.id
 
@@ -131,8 +144,16 @@ async def _sync_containers(cv_manifest: CVManifest, deployment_result: DeployToC
     else:
         LOGGER.info("deploy_static_config_studio_manifest_to_cv: No AVD-managed container deletions are needed.")
 
+    return existing_containers, existing_managed_containers_by_id
 
-async def _sync_configlets(cv_manifest: CVManifest, deployment_result: DeployToCvResult, cv_client: CVClient) -> None:
+
+async def _sync_configlets(
+    cv_manifest: CVManifest,
+    existing_containers: list[ConfigletAssignment],
+    existing_managed_containers_by_id: dict[str, str],
+    deployment_result: DeployToCvResult,
+    cv_client: CVClient,
+) -> None:
     """Synchronize configlets. Create/update new ones and delete unused AVD-managed ones."""
     workspace_id = deployment_result.workspace.id
 
@@ -155,6 +176,37 @@ async def _sync_configlets(cv_manifest: CVManifest, deployment_result: DeployToC
     }
 
     if configlets_to_delete:
+        # A configlet can be assigned to multiple containers (holders).
+        existing_holders_by_configlet_id: defaultdict[str, list[ConfigletAssignment]] = defaultdict(list)
+        for container in existing_containers:
+            for configlet_id in container.configlet_ids.values:
+                existing_holders_by_configlet_id[configlet_id].append(container)
+
+        # Validate that no managed configlet scheduled for deletion was assigned to containers this deploy will not touch.
+        violations: list[tuple[str, str, str, str]] = []
+        for configlet_id, configlet_name in configlets_to_delete.items():
+            for holder in existing_holders_by_configlet_id.get(configlet_id, []):
+                holder_id = cast("str", holder.key.configlet_assignment_id)
+                if holder_id in existing_managed_containers_by_id:
+                    # Holder is managed, it will be handled by this deploy.
+                    continue
+
+                # Holder is out of our control.
+                violations.append((cast("str", holder.display_name), holder_id, configlet_name, configlet_id))
+
+        if violations:
+            violations.sort()
+            violations_text = "; ".join(
+                f"'{configlet_name}' (id={configlet_id}) is still assigned to '{holder_name}' (id={holder_id})"
+                for holder_name, holder_id, configlet_name, configlet_id in violations
+            )
+            msg = (
+                "The following manifest-managed configlets are scheduled for deletion "
+                "but are still assigned to containers that this manifest does not control. "
+                f"Unassign the configlets manually (or keep them in the manifest) and re-run: {violations_text}"
+            )
+            raise CVManifestError(msg)
+
         LOGGER.info("deploy_static_config_studio_manifest_to_cv: Removing %d manifest-managed configlets which are no longer used.", len(configlets_to_delete))
         deployment_result.removed_static_config_configlets.extend(configlets_to_delete.values())
         await cv_client.delete_configlets(workspace_id=workspace_id, configlet_ids=list(configlets_to_delete.keys()))

--- a/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
@@ -1178,3 +1178,164 @@ class TestDeployStaticConfigStudio:
         )
 
         assert deployment_result.removed_static_config_containers == ["SOLO"]
+
+    async def test_fails_when_deleted_configlet_is_held_by_unmanaged_container(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that the deploy fails when a manifest configlet scheduled for deletion is still assigned to a container the manifest does not manage."""
+        manifest_root_id = generate_id("MANIFEST_ROOT")
+        stale_cfg_id = generate_id("STALE_CFG")
+        manual_holder_id = "manual-holder-001"
+
+        existing_containers = [
+            create_grpc_container(container_id=manifest_root_id, name="MANIFEST_ROOT", description="", query="device:*"),
+            create_grpc_container(container_id=manual_holder_id, name="MY_CUSTOM", description="", query="device:*", configlet_ids=[stale_cfg_id]),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=stale_cfg_id), display_name="STALE_CFG"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = [manifest_root_id, manual_holder_id]
+
+        # Manifest declares only the root container, no configlets — STALE_CFG is scheduled for deletion.
+        manifest_root = AvdContainer(name="MANIFEST_ROOT", tag_query="device:*")
+        manifest = AvdManifest(containers=(manifest_root,))
+
+        with pytest.raises(CVManifestError) as exc_info:
+            await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # Error message identifies both the offending holder and the configlet (name + id for each).
+        assert "MY_CUSTOM" in str(exc_info.value)
+        assert manual_holder_id in str(exc_info.value)
+        assert "STALE_CFG" in str(exc_info.value)
+        assert stale_cfg_id in str(exc_info.value)
+
+        # No updates on CV — workspace must be untouched.
+        mock_cv_client.set_configlets_from_files.assert_not_called()
+        mock_cv_client.set_configlet_containers.assert_not_called()
+        mock_cv_client.set_studio_inputs.assert_not_called()
+        mock_cv_client.delete_configlets.assert_not_called()
+        mock_cv_client.delete_configlet_container.assert_not_called()
+
+    async def test_passes_when_deleted_configlet_holder_is_also_scheduled_for_deletion(
+        self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult
+    ) -> None:
+        """Test that no violation is raised when both the deleted manifest configlet and its holder are scheduled for deletion by this deploy."""
+        manifest_root_id = generate_id("MANIFEST_ROOT")
+        stale_cfg_id = generate_id("STALE_CFG")
+        # Manifest-managed holder absent from this manifest is scheduled for deletion, so its reference to STALE_CFG disappears when the holder is deleted.
+        stale_holder_id = generate_id("STALE_HOLDER")
+
+        existing_containers = [
+            create_grpc_container(container_id=manifest_root_id, name="MANIFEST_ROOT", description="", query="device:*"),
+            create_grpc_container(container_id=stale_holder_id, name="STALE_HOLDER", description="", query="device:*", configlet_ids=[stale_cfg_id]),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=stale_cfg_id), display_name="STALE_CFG"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = [manifest_root_id, stale_holder_id]
+
+        # Manifest declares only MANIFEST_ROOT — STALE_HOLDER and STALE_CFG are both scheduled for deletion.
+        manifest_root = AvdContainer(name="MANIFEST_ROOT", tag_query="device:*")
+        manifest = AvdManifest(containers=(manifest_root,))
+
+        # Must not raise — STALE_HOLDER is managed (being deleted), so its stale reference goes away with it.
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # Both the configlet and the holder are deleted in the same deploy.
+        mock_cv_client.delete_configlets.assert_called_once_with(workspace_id=deployment_result.workspace.id, configlet_ids=[stale_cfg_id])
+        deleted_container_ids = {call.kwargs["assignment_id"] for call in mock_cv_client.delete_configlet_container.call_args_list}
+        assert stale_holder_id in deleted_container_ids
+
+    async def test_passes_when_deleted_configlet_is_only_held_by_managed_containers(
+        self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult
+    ) -> None:
+        """Test that a deleted manifest configlet held only by managed containers does not raise (the holders are themselves being rewritten or deleted)."""
+        root_id = generate_id("ROOT")
+        stale_cfg_id = generate_id("STALE_CFG")
+
+        # ROOT currently references STALE_CFG. Manifest will drop STALE_CFG from ROOT's configlets and from the manifest.
+        existing_containers = [
+            create_grpc_container(container_id=root_id, name="ROOT", description="Root", query="device:*", configlet_ids=[stale_cfg_id]),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=stale_cfg_id), display_name="STALE_CFG"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = [root_id]
+
+        # Manifest redeclares ROOT but without STALE_CFG, and drops STALE_CFG entirely.
+        root = AvdContainer(name="ROOT", tag_query="device:*", description="Root")
+        manifest = AvdManifest(containers=(root,))
+
+        # Must not raise — ROOT is being rewritten, so the stale reference disappears.
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # ROOT is re-pushed without STALE_CFG.
+        mock_cv_client.set_configlet_containers.assert_called_once()
+        pushed = mock_cv_client.set_configlet_containers.call_args[1]["containers"]
+        assert pushed[0][3] == []
+
+        # STALE_CFG is deleted.
+        mock_cv_client.delete_configlets.assert_called_once_with(workspace_id=deployment_result.workspace.id, configlet_ids=[stale_cfg_id])
+        assert deployment_result.removed_static_config_configlets == ["STALE_CFG"]
+
+    async def test_passes_when_deleted_configlet_has_no_holders(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that an orphan manifest configlet (not referenced by any container) is deleted cleanly without raising."""
+        root_id = generate_id("ROOT")
+        orphan_cfg_id = generate_id("ORPHAN_CFG")
+
+        existing_containers = [
+            create_grpc_container(container_id=root_id, name="ROOT", description="Root", query="device:*"),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=orphan_cfg_id), display_name="ORPHAN_CFG"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = [root_id]
+
+        root = AvdContainer(name="ROOT", tag_query="device:*", description="Root")
+        manifest = AvdManifest(containers=(root,))
+
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # Orphan configlet is deleted, no violation.
+        mock_cv_client.delete_configlets.assert_called_once_with(workspace_id=deployment_result.workspace.id, configlet_ids=[orphan_cfg_id])
+        assert deployment_result.removed_static_config_configlets == ["ORPHAN_CFG"]
+
+    async def test_fails_lists_multiple_holders_for_single_configlet(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that a single deleted manifest configlet referenced by multiple unmanaged holders produces one violation entry per holder."""
+        manifest_root_id = generate_id("MANIFEST_ROOT")
+        stale_cfg_id = generate_id("STALE_CFG")
+        holder_a_id = "manual-holder-a"
+        holder_b_id = "manual-holder-b"
+
+        existing_containers = [
+            create_grpc_container(container_id=manifest_root_id, name="MANIFEST_ROOT", description="", query="device:*"),
+            create_grpc_container(container_id=holder_a_id, name="HOLDER_A", description="", query="device:*", configlet_ids=[stale_cfg_id]),
+            create_grpc_container(container_id=holder_b_id, name="HOLDER_B", description="", query="device:*", configlet_ids=[stale_cfg_id]),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=stale_cfg_id), display_name="STALE_CFG"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = [manifest_root_id, holder_a_id, holder_b_id]
+
+        manifest_root = AvdContainer(name="MANIFEST_ROOT", tag_query="device:*")
+        manifest = AvdManifest(containers=(manifest_root,))
+
+        with pytest.raises(CVManifestError) as exc_info:
+            await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # Both holders appear in the message.
+        msg = str(exc_info.value)
+        assert "HOLDER_A" in msg
+        assert "HOLDER_B" in msg
+        assert holder_a_id in msg
+        assert holder_b_id in msg
+        # The configlet is named once per holder.
+        assert msg.count("STALE_CFG") == 2


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

Raise a proper error when a configlet managed by cv_deploy is scheduled for deletion but is still assigned to a container.

## Related Issue(s)

Fixes #6952

## Component(s) name

`arista.avd.cv_deploy`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Update the _sync_configlets function to fail early if configlets scheduled for deletion are still assigned to a container.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added unit tests to cover the fix.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
