### PR TITLE
Doc: Update eos_cli_config_gen contribution guide to add rule for empty dictionary input

### DIFF
--- a/docs/contribution/authoring_eos_cli_config_gen.md
+++ b/docs/contribution/authoring_eos_cli_config_gen.md
@@ -14,11 +14,11 @@ This document outlines the steps and checklist for contributing to the `eos_cli_
 2. Create the schema.
 3. Develop Jinja2 templates (eos and documentation).
 4. Run pre-commit to build schema and templates
-5. Validate With Molecule Tests
+5. Validate with molecule tests.
 6. Update documentation as needed.
 7. Run pre-commit checks to ensure compliance.
 8. Review all changes before submission.
-9. Raise a PR to the Arista AVD GitHub repository
+9. Raise a PR to the Arista AVD GitHub repository.
 
 ### Prepare development environment
 
@@ -70,7 +70,19 @@ When adding a top-level feature, add a new Jinja2 template following the naming 
 8. **Exclamation Marks:** Place exclamation marks `!` correctly as per the EOS running-config.
 9. Along with EOS config template, update the documentation template as well (if required).
 10. Implement only commands visible in `show running-config all` of the EOS device. We should not hide config if given by the user.
-11. Validate the template using j2lint tool, run `pre-commit run j2lint --all`.
+11. **Empty Dictionary Should Not Generate Config:** The presence of an empty dictionary alone must not be enough to generate configuration. Always check for a meaningful child key (e.g., `enabled: true`) rather than relying on the existence of the parent dictionary. This avoids producing unintended config when a user defines a parent key without providing any actual values.
+
+    For example, to render `neighbor some-neighbor default-originate`, the template should check for the explicit child key:
+
+    ```yaml
+    neighbors:
+      - name: some-neighbor
+        default_originate:
+          enabled: true
+    ```
+
+    An empty `default_originate:` block must not trigger config generation. The template should check `default_originate.enabled` rather than just the presence of `default_originate`.
+12. Validate the template using j2lint tool, run `pre-commit run j2lint --all`.
 
 ### Run pre-commit to build schemas and documentation
 

--- a/docs/contribution/authoring_eos_cli_config_gen.md
+++ b/docs/contribution/authoring_eos_cli_config_gen.md
@@ -70,7 +70,7 @@ When adding a top-level feature, add a new Jinja2 template following the naming 
 8. **Exclamation Marks:** Place exclamation marks `!` correctly as per the EOS running-config.
 9. Along with EOS config template, update the documentation template as well (if required).
 10. Implement only commands visible in `show running-config all` of the EOS device. We should not hide config if given by the user.
-11. **Empty Dictionary Should Not Generate Config:** The presence of an empty dictionary alone must not be enough to generate configuration. Always check for a meaningful child key (e.g., `enabled: true`) rather than relying on the existence of the parent dictionary. This avoids producing unintended config when a user defines a parent key without providing any actual values.
+11. **Empty Dictionary Should Not Generate Config:** The presence of an empty dictionary alone must not be enough to generate configuration. Always validate the presence of a meaningful child key (e.g., `enabled: true`) instead of relying solely on the existence of the parent dictionary. This prevents unintended configuration generation when a user defines a parent key without providing any actual values.
 
     For example, to render `neighbor some-neighbor default-originate`, the template should check for the explicit child key:
 
@@ -81,7 +81,7 @@ When adding a top-level feature, add a new Jinja2 template following the naming 
           enabled: true
     ```
 
-    An empty `default_originate:` block must not trigger config generation. The template should check `default_originate.enabled` rather than just the presence of `default_originate`.
+    An empty `default_originate:` block must not trigger configuration generation. The template should check `default_originate.enabled` rather than just the presence of `default_originate`.
 12. Validate the template using j2lint tool, run `pre-commit run j2lint --all`.
 
 ### Run pre-commit to build schemas and documentation


### PR DESCRIPTION
## Change Summary

Update doc **https://avd.arista.com/6.1/docs/contribution/authoring_eos_cli_config_gen.html?h=eos_cli_conf#schema-creation** to instruct the rule that presence of empty dictionary is not enough to generate config.
e.g.
To configure `neighbor some-neighbor default-originate`

Incorrect way:
```
neighbors:
  - name: some-neighbor
     default_originate:
```

Correct way: setting enabled: true
```
neighbors:
  - name : some-neighbor
    default_originate:
      enabled: true
```

## Related Issue(s)

Fixes #6925 

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
