### PR TITLE
Feat(eos_designs): Add support for dot1x_settings.radius_av_pairs.framed_mtu

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-2.cfg
@@ -30,6 +30,7 @@ aaa authorization dynamic dot1x additional-groups group coa-server-group
 aaa accounting dot1x default stop-only group agni-server-group multicast group backup-agni-server-group multicast logging
 dot1x
    radius av-pair service-type
+   radius av-pair framed-mtu 1500
    mac-based-auth radius av-pair user-name delimiter colon uppercase
 !
 interface Management1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-2.yml
@@ -46,6 +46,7 @@ dot1x:
     mac_string_case: uppercase
   radius_av_pair:
     service_type: true
+    framed_mtu: 1500
 enable_password:
   disabled: true
 hostname: dot1x-settings-2

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-2.yml
@@ -24,6 +24,7 @@ dot1x_settings:
       letter_case: uppercase
   radius_av_pairs:
     service_type: true
+    framed_mtu: 1500
 
 aaa_settings:
   radius:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/dot1x-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/dot1x-settings.md
@@ -31,6 +31,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;letter_case</samp>](## "dot1x_settings.mac_based_authentication.username_format.letter_case") | String | Required |  | Valid Values:<br>- <code>lowercase</code><br>- <code>uppercase</code> | RADIUS User-Name attribute letter case to use on the MAC address. |
     | [<samp>&nbsp;&nbsp;radius_av_pairs</samp>](## "dot1x_settings.radius_av_pairs") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_type</samp>](## "dot1x_settings.radius_av_pairs.service_type") | Boolean |  | `False` |  | Send RADIUS Service-Type attribute in Access-Request and Accounting messages. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;framed_mtu</samp>](## "dot1x_settings.radius_av_pairs.framed_mtu") | Integer |  |  | Min: 68<br>Max: 9236 |  |
     | [<samp>&nbsp;&nbsp;redistribute_in_evpn</samp>](## "dot1x_settings.redistribute_in_evpn") | Boolean |  | `True` |  | Globally enable the redistribution of static 802.1X-learned MAC addresses into EVPN under all configured MAC-VRFs. |
 
 === "YAML"
@@ -103,6 +104,7 @@
 
         # Send RADIUS Service-Type attribute in Access-Request and Accounting messages.
         service_type: <bool; default=False>
+        framed_mtu: <int; 68-9236>
 
       # Globally enable the redistribution of static 802.1X-learned MAC addresses into EVPN under all configured MAC-VRFs.
       redistribute_in_evpn: <bool; default=True>

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -18126,17 +18126,18 @@ class EosDesigns(EosDesignsRootModel):
         class RadiusAvPairs(AvdModel):
             """Subclass of AvdModel."""
 
-            _fields: ClassVar[dict] = {"service_type": {"type": bool, "default": False}}
+            _fields: ClassVar[dict] = {"service_type": {"type": bool, "default": False}, "framed_mtu": {"type": int}}
             service_type: bool
             """
             Send RADIUS Service-Type attribute in Access-Request and Accounting messages.
 
             Default value: `False`
             """
+            framed_mtu: int | None
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, service_type: bool | UndefinedType = Undefined) -> None:
+                def __init__(self, *, service_type: bool | UndefinedType = Undefined, framed_mtu: int | None | UndefinedType = Undefined) -> None:
                     """
                     RadiusAvPairs.
 
@@ -18145,6 +18146,7 @@ class EosDesigns(EosDesignsRootModel):
 
                     Args:
                         service_type: Send RADIUS Service-Type attribute in Access-Request and Accounting messages.
+                        framed_mtu: framed_mtu
 
                     """
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -2375,6 +2375,9 @@ keys:
             default: false
             description: Send RADIUS Service-Type attribute in Access-Request and
               Accounting messages.
+          framed_mtu:
+            type: int
+            $ref: eos_cli_config_gen#/keys/dot1x/keys/radius_av_pair/keys/framed_mtu
       redistribute_in_evpn:
         type: bool
         default: true

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/dot1x_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/dot1x_settings.schema.yml
@@ -117,6 +117,9 @@ keys:
             type: bool
             default: false
             description: Send RADIUS Service-Type attribute in Access-Request and Accounting messages.
+          framed_mtu:
+            type: int
+            $ref: eos_cli_config_gen#/keys/dot1x/keys/radius_av_pair/keys/framed_mtu
       redistribute_in_evpn:
         type: bool
         default: true

--- a/python-avd/pyavd/_eos_designs/structured_config/base/dot1x.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/dot1x.py
@@ -93,6 +93,8 @@ class Dot1xMixin(Protocol):
         )
         if dot1x_settings.radius_av_pairs.service_type is True:
             self.structured_config.dot1x.radius_av_pair.service_type = True
+        if dot1x_settings.radius_av_pairs.framed_mtu:
+            self.structured_config.dot1x.radius_av_pair.framed_mtu = dot1x_settings.radius_av_pairs.framed_mtu
         if dot1x_settings.mac_based_authentication.username_format:
             self.structured_config.dot1x.radius_av_pair_username_format = EosCliConfigGen.Dot1x.RadiusAvPairUsernameFormat(
                 delimiter=dot1x_settings.mac_based_authentication.username_format.delimiter,


### PR DESCRIPTION
## Change Summary

Add eos_designs support for:
```
dot1x_settings:
  radius_av_pairs:
    framed_mtu: <int>
```

This will map to existing eos_cli_config_gen data model:
```
dot1x:
  radius_av_pair:
    framed_mtu: <int; 68-9236>
```

## Related Issue(s)

Fixes #6963 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added new key

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
