### PR TITLE
Fix(cv_deploy): Delete unassigned containers

### DIFF
--- a/python-avd/pyavd/_cv/workflows/deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/pyavd/_cv/workflows/deploy_static_config_studio_manifest_to_cv.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from asyncio import gather
-from collections import defaultdict
+from collections import defaultdict, deque
 from logging import getLogger
 from typing import TYPE_CHECKING, cast
 
@@ -48,13 +48,14 @@ async def deploy_static_config_studio_manifest_to_cv(manifest: AvdManifest, depl
         return
 
     # Perform synchronization tasks.
-    existing_containers, existing_managed_containers_by_id = await _sync_containers(
+    existing_containers, existing_managed_containers_by_id, unmanaged_orphan_container_ids = await _sync_containers(
         cv_manifest=cv_manifest, deployment_result=deployment_result, cv_client=cv_client
     )
     await _sync_configlets(
         cv_manifest=cv_manifest,
         existing_containers=existing_containers,
         existing_managed_containers_by_id=existing_managed_containers_by_id,
+        unmanaged_orphan_container_ids=unmanaged_orphan_container_ids,
         deployment_result=deployment_result,
         cv_client=cv_client,
     )
@@ -66,8 +67,12 @@ async def deploy_static_config_studio_manifest_to_cv(manifest: AvdManifest, depl
 
 async def _sync_containers(
     cv_manifest: CVManifest, deployment_result: DeployToCvResult, cv_client: CVClient
-) -> tuple[list[ConfigletAssignment], dict[str, str]]:
-    """Synchronize containers. Fetch existing ones and push any required creates or updates."""
+) -> tuple[list[ConfigletAssignment], dict[str, str], set[str]]:
+    """
+    Synchronize containers. Fetch existing ones and push any required creates or updates.
+
+    TODO: Split into multiple functions.
+    """
     workspace_id = deployment_result.workspace.id
 
     LOGGER.info("deploy_static_config_studio_manifest_to_cv: Fetching all existing configlet containers from CloudVision...")
@@ -75,15 +80,67 @@ async def _sync_containers(
 
     existing_containers_by_id: dict[str, ConfigletAssignment] = {}
     existing_parents_by_child_id: dict[str, ConfigletAssignment] = {}
+    existing_children_by_parent_id: dict[str, list[str]] = {}
     existing_managed_containers_by_id: dict[str, str] = {}
 
     for container in existing_containers:
         container_id = cast("str", container.key.configlet_assignment_id)
         existing_containers_by_id[container_id] = container
+        existing_children_by_parent_id[container_id] = list(container.child_assignment_ids.values)
         if container_id.startswith(AVD_ENTITY_PREFIX):
             existing_managed_containers_by_id[container_id] = cast("str", container.display_name)
         for child_id in container.child_assignment_ids.values:
             existing_parents_by_child_id[child_id] = container
+
+    containers_to_push: list[CVContainer] = []
+    containers_to_skip: list[CVContainer] = []
+    containers_to_delete: dict[str, str] = {}
+    unmanaged_orphan_container_ids: set[str] = set()
+
+    for desired_container in cv_manifest.containers:
+        existing_container = existing_containers_by_id.get(desired_container.id)
+
+        if not existing_container:
+            # Container is new.
+            containers_to_push.append(desired_container)
+            continue
+
+        if not desired_container.matches_configlet_assignment(existing_container):
+            # Container has changed.
+            containers_to_push.append(desired_container)
+        else:
+            # Container is unchanged.
+            containers_to_skip.append(desired_container)
+
+        # Existing unmanaged children unassigned by the manifest become orphans.
+        existing_children = set(existing_container.child_assignment_ids.values)
+        desired_children = set(desired_container.child_ids)
+        unmanaged_orphan_container_ids.update(child_id for child_id in (existing_children - desired_children) if not child_id.startswith(AVD_ENTITY_PREFIX))
+
+    # Managed containers no longer in the manifest are deleted. Their unmanaged children also become orphans and are deleted.
+    desired_container_ids = {container.id for container in cv_manifest.containers}
+    for container_id, container_name in existing_managed_containers_by_id.items():
+        if container_id in desired_container_ids:
+            continue
+        containers_to_delete[container_id] = container_name
+        unmanaged_orphan_container_ids.update(
+            child_id for child_id in existing_children_by_parent_id.get(container_id, []) if not child_id.startswith(AVD_ENTITY_PREFIX)
+        )
+
+    # Walk the unmanaged orphans to pull in their descendants.
+    # Managed descendants are skipped because they are either re-parented by the push or already in containers_to_delete.
+    queue = deque(unmanaged_orphan_container_ids)
+    while queue:
+        container_id = queue.popleft()
+        for child_id in existing_children_by_parent_id.get(container_id, []):
+            if child_id.startswith(AVD_ENTITY_PREFIX) or child_id in unmanaged_orphan_container_ids:
+                continue
+            unmanaged_orphan_container_ids.add(child_id)
+            queue.append(child_id)
+
+    # Merge unmanaged orphan IDs into containers_to_delete with their CV display names.
+    for orphan_id in unmanaged_orphan_container_ids:
+        containers_to_delete[orphan_id] = cast("str", existing_containers_by_id[orphan_id].display_name)
 
     # Validate that no managed container was manually reassigned to a parent this deploy will not touch.
     violations: list[tuple[str, str, str, str]] = []
@@ -94,8 +151,8 @@ async def _sync_containers(
             # or it's an orphan which will get reassigned or deleted by this deploy.
             continue
         parent_id = cast("str", parent.key.configlet_assignment_id)
-        if parent_id in existing_managed_containers_by_id:
-            # Parent is managed, it will be handled by this deploy.
+        if parent_id in existing_managed_containers_by_id or parent_id in unmanaged_orphan_container_ids:
+            # Parent is managed and will be handled by this deploy, or is unmanaged and scheduled for orphan deletion.
             continue
 
         # Parent is out of our control.
@@ -113,16 +170,7 @@ async def _sync_containers(
         )
         raise CVManifestError(msg)
 
-    containers_to_push: list[CVContainer] = []
-    for desired_container in cv_manifest.containers:
-        existing_container = existing_containers_by_id.get(desired_container.id)
-
-        # Container is new or has changed, so it needs to be pushed.
-        if not existing_container or not desired_container.matches_configlet_assignment(existing_container):
-            containers_to_push.append(desired_container)
-        else:
-            # Container is unchanged.
-            deployment_result.skipped_static_config_containers.append(desired_container.avd_container)
+    deployment_result.skipped_static_config_containers.extend(container.avd_container for container in containers_to_skip)
 
     if containers_to_push:
         LOGGER.info("deploy_static_config_studio_manifest_to_cv: Applying changes for %d containers (create/update)...", len(containers_to_push))
@@ -132,25 +180,26 @@ async def _sync_containers(
     else:
         LOGGER.info("deploy_static_config_studio_manifest_to_cv: No container creations or updates are needed.")
 
-    # Delete unused AVD-managed containers.
-    desired_container_ids = {container.id for container in cv_manifest.containers}
-    containers_to_delete = {container_id: name for container_id, name in existing_managed_containers_by_id.items() if container_id not in desired_container_ids}
-
     if containers_to_delete:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: Removing %d AVD-managed containers which are no longer used.", len(containers_to_delete))
+        LOGGER.info(
+            "deploy_static_config_studio_manifest_to_cv: Removing %d manifest-managed and %d unmanaged orphan containers which are no longer used.",
+            len(containers_to_delete) - len(unmanaged_orphan_container_ids),
+            len(unmanaged_orphan_container_ids),
+        )
         deployment_result.removed_static_config_containers.extend(containers_to_delete.values())
         # TODO: Build a 'delete_configlet_containers' gRPC API
         await gather(*[cv_client.delete_configlet_container(workspace_id=workspace_id, assignment_id=container_id) for container_id in containers_to_delete])
     else:
-        LOGGER.info("deploy_static_config_studio_manifest_to_cv: No AVD-managed container deletions are needed.")
+        LOGGER.info("deploy_static_config_studio_manifest_to_cv: No container deletions are needed.")
 
-    return existing_containers, existing_managed_containers_by_id
+    return existing_containers, existing_managed_containers_by_id, unmanaged_orphan_container_ids
 
 
 async def _sync_configlets(
     cv_manifest: CVManifest,
     existing_containers: list[ConfigletAssignment],
     existing_managed_containers_by_id: dict[str, str],
+    unmanaged_orphan_container_ids: set[str],
     deployment_result: DeployToCvResult,
     cv_client: CVClient,
 ) -> None:
@@ -187,8 +236,8 @@ async def _sync_configlets(
         for configlet_id, configlet_name in configlets_to_delete.items():
             for holder in existing_holders_by_configlet_id.get(configlet_id, []):
                 holder_id = cast("str", holder.key.configlet_assignment_id)
-                if holder_id in existing_managed_containers_by_id:
-                    # Holder is managed, it will be handled by this deploy.
+                if holder_id in existing_managed_containers_by_id or holder_id in unmanaged_orphan_container_ids:
+                    # Holder is managed and will be handled by this deploy, or is unmanaged and scheduled for orphan deletion.
                     continue
 
                 # Holder is out of our control.

--- a/python-avd/pyavd/_cv/workflows/deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/pyavd/_cv/workflows/deploy_static_config_studio_manifest_to_cv.py
@@ -105,12 +105,13 @@ async def _sync_containers(
             containers_to_push.append(desired_container)
             continue
 
-        if not desired_container.matches_configlet_assignment(existing_container):
-            # Container has changed.
-            containers_to_push.append(desired_container)
-        else:
+        if desired_container.matches_configlet_assignment(existing_container):
             # Container is unchanged.
             containers_to_skip.append(desired_container)
+            continue
+
+        # Container has changed.
+        containers_to_push.append(desired_container)
 
         # Existing unmanaged children unassigned by the manifest become orphans.
         existing_children = set(existing_container.child_assignment_ids.values)

--- a/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
+++ b/python-avd/tests/pyavd/cv/workflows/test_deploy_static_config_studio_manifest_to_cv.py
@@ -678,7 +678,7 @@ class TestDeployStaticConfigStudio:
         )
 
     async def test_avd_parent_unassigns_non_avd_sub_container(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
-        """Test that a non-AVD sub-container under an AVD parent is unassigned (not deleted) when the parent is re-pushed."""
+        """Test that a non-AVD sub-container under an AVD parent is unassigned and removed as an orphan when the parent is re-pushed."""
         avd_parent_id = generate_id("PARENT")
         avd_child_id = generate_id("PARENT/AVD_CHILD")
         non_avd_child_id = "manually-added-child-xyz"
@@ -714,9 +714,9 @@ class TestDeployStaticConfigStudio:
         assert parent_push[5] == [avd_child_id]
         assert non_avd_child_id not in parent_push[5]
 
-        # The non-AVD sub-container itself must NOT be deleted (no AVD prefix).
-        mock_cv_client.delete_configlet_container.assert_not_called()
-        assert not deployment_result.removed_static_config_containers
+        # The non-AVD sub-container is removed as an orphan since it no longer has a parent in the tree.
+        mock_cv_client.delete_configlet_container.assert_called_once_with(workspace_id=deployment_result.workspace.id, assignment_id=non_avd_child_id)
+        assert deployment_result.removed_static_config_containers == ["MANUAL_CHILD"]
 
     async def test_sub_containers_excluded_from_studio_roots(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
         """Test that only top-level (root) containers are added to the Studio root list, not nested sub-containers."""
@@ -994,6 +994,39 @@ class TestDeployStaticConfigStudio:
         assert deployment_result.skipped_static_config_containers == []
         assert deployment_result.deployed_static_config_containers == []
 
+        mock_cv_client.set_configlets_from_files.assert_not_called()
+        mock_cv_client.set_configlet_containers.assert_not_called()
+        mock_cv_client.set_studio_inputs.assert_not_called()
+        mock_cv_client.delete_configlets.assert_not_called()
+        mock_cv_client.delete_configlet_container.assert_not_called()
+
+    async def test_fails_when_root_container_has_unmanaged_parent(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that the deploy fails when a manifest top-level container has been manually placed under an unmanaged parent in CV."""
+        root_id = generate_id("ROOT")
+        custom_parent_id = "custom-parent-003"
+
+        existing_containers = [
+            create_grpc_container(container_id=root_id, name="ROOT", description="", query="device:*"),
+            create_grpc_container(container_id=custom_parent_id, name="MY_CUSTOM", description="", query="device:*", child_ids=[root_id]),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = []
+        # ROOT is currently NOT in the Studio root list — it was reparented under MY_CUSTOM.
+        mock_cv_client.get_studio_inputs_with_path.return_value = [custom_parent_id]
+
+        root = AvdContainer(name="ROOT", tag_query="device:*")
+        manifest = AvdManifest(containers=(root,))
+
+        with pytest.raises(CVManifestError) as exc_info:
+            await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # Error message identifies both the offending parent and the root container.
+        assert "MY_CUSTOM" in str(exc_info.value)
+        assert custom_parent_id in str(exc_info.value)
+        assert "ROOT" in str(exc_info.value)
+        assert root_id in str(exc_info.value)
+
+        # No updates on CV — workspace must be untouched.
         mock_cv_client.set_configlets_from_files.assert_not_called()
         mock_cv_client.set_configlet_containers.assert_not_called()
         mock_cv_client.set_studio_inputs.assert_not_called()
@@ -1339,3 +1372,229 @@ class TestDeployStaticConfigStudio:
         assert holder_b_id in msg
         # The configlet is named once per holder.
         assert msg.count("STALE_CFG") == 2
+
+    async def test_orphan_unmanaged_subtree_deleted_when_managed_parent_updates(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that a multi-level unmanaged sub-tree is fully removed when its managed parent drops the top of the chain."""
+        managed_parent_id = generate_id("PARENT")
+        unmanaged_mid_id = "manual-mid-123"
+        unmanaged_leaf_id = "manual-leaf-456"
+
+        existing_containers = [
+            # Managed parent currently owns an unmanaged sub-tree mid -> leaf.
+            create_grpc_container(container_id=managed_parent_id, name="PARENT", description="Parent", query="device:*", child_ids=[unmanaged_mid_id]),
+            create_grpc_container(container_id=unmanaged_mid_id, name="UNMANAGED_MID", description="", query="device:*", child_ids=[unmanaged_leaf_id]),
+            create_grpc_container(container_id=unmanaged_leaf_id, name="UNMANAGED_LEAF", description="", query="device:LEAF"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = []
+        mock_cv_client.get_studio_inputs_with_path.return_value = [managed_parent_id]
+
+        # Manifest declares the managed parent with no children.
+        managed_parent = AvdContainer(name="PARENT", tag_query="device:*", description="Parent")
+        manifest = AvdManifest(containers=(managed_parent,))
+
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # Both unmanaged descendants are orphan-deleted.
+        assert mock_cv_client.delete_configlet_container.call_count == 2
+        deleted_ids = {call.kwargs["assignment_id"] for call in mock_cv_client.delete_configlet_container.call_args_list}
+        assert deleted_ids == {unmanaged_mid_id, unmanaged_leaf_id}
+        assert set(deployment_result.removed_static_config_containers) == {"UNMANAGED_MID", "UNMANAGED_LEAF"}
+
+    async def test_managed_container_reparented_by_manifest_is_not_orphan_deleted(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that a managed container reachable through an orphan path is reparented by the manifest instead of being deleted."""
+        managed_parent_id = generate_id("PARENT")
+        unmanaged_mid_id = "manual-mid-789"
+        managed_grand_id = generate_id("PARENT/MANAGED_GRAND")  # In the manifest as a child of PARENT.
+
+        # Existing layout: PARENT -> UNMANAGED_MID -> MANAGED_GRAND. Manifest wants PARENT -> MANAGED_GRAND directly.
+        existing_containers = [
+            create_grpc_container(container_id=managed_parent_id, name="PARENT", description="Parent", query="device:*", child_ids=[unmanaged_mid_id]),
+            create_grpc_container(container_id=unmanaged_mid_id, name="UNMANAGED_MID", description="", query="device:*", child_ids=[managed_grand_id]),
+            create_grpc_container(container_id=managed_grand_id, name="MANAGED_GRAND", description="", query="device:LEAF"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = []
+        mock_cv_client.get_studio_inputs_with_path.return_value = [managed_parent_id]
+
+        managed_grand = AvdContainer(name="MANAGED_GRAND", tag_query="device:LEAF")
+        managed_parent = AvdContainer(name="PARENT", tag_query="device:*", description="Parent", sub_containers=(managed_grand,))
+        manifest = AvdManifest(containers=(managed_parent,))
+
+        # Must not raise even though MANAGED_GRAND currently has an unmanaged parent that is about to be orphan-deleted.
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # Only UNMANAGED_MID is deleted. MANAGED_GRAND is reparented by the manifest, not deleted.
+        mock_cv_client.delete_configlet_container.assert_called_once_with(workspace_id=deployment_result.workspace.id, assignment_id=unmanaged_mid_id)
+        assert deployment_result.removed_static_config_containers == ["UNMANAGED_MID"]
+
+        # PARENT was updated to point directly at MANAGED_GRAND.
+        mock_cv_client.set_configlet_containers.assert_called_once()
+        pushed = mock_cv_client.set_configlet_containers.call_args[1]["containers"]
+        parent_push = next(c for c in pushed if c[1] == "PARENT")
+        assert parent_push[5] == [managed_grand_id]
+
+    async def test_subtree_under_deleted_managed_container_is_fully_removed(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that an entire unmanaged sub-tree hanging off a removed managed container is deleted together with the parent."""
+        stale_managed_root_id = generate_id("STALE_ROOT")  # Managed, NOT in this manifest -> deleted.
+        unmanaged_mid_id = "manual-mid-abc"
+        unmanaged_leaf_id = "manual-leaf-def"
+        new_root_id = generate_id("NEW_ROOT")
+
+        existing_containers = [
+            create_grpc_container(container_id=stale_managed_root_id, name="STALE_ROOT", description="", query="device:*", child_ids=[unmanaged_mid_id]),
+            create_grpc_container(container_id=unmanaged_mid_id, name="UNMANAGED_MID", description="", query="device:*", child_ids=[unmanaged_leaf_id]),
+            create_grpc_container(container_id=unmanaged_leaf_id, name="UNMANAGED_LEAF", description="", query="device:LEAF"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = []
+        mock_cv_client.get_studio_inputs_with_path.return_value = [stale_managed_root_id]
+
+        new_root = AvdContainer(name="NEW_ROOT", tag_query="device:*")
+        manifest = AvdManifest(containers=(new_root,))
+
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # All three (STALE_ROOT, UNMANAGED_MID, UNMANAGED_LEAF) are deleted in one go.
+        assert mock_cv_client.delete_configlet_container.call_count == 3
+        deleted_ids = {call.kwargs["assignment_id"] for call in mock_cv_client.delete_configlet_container.call_args_list}
+        assert deleted_ids == {stale_managed_root_id, unmanaged_mid_id, unmanaged_leaf_id}
+        assert set(deployment_result.removed_static_config_containers) == {"STALE_ROOT", "UNMANAGED_MID", "UNMANAGED_LEAF"}
+
+        # The new root container is pushed.
+        mock_cv_client.set_configlet_containers.assert_called_once()
+        pushed = mock_cv_client.set_configlet_containers.call_args[1]["containers"]
+        assert {c[0] for c in pushed} == {new_root_id}
+
+    async def test_deep_unmanaged_chain_is_fully_removed(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that every container of a long unmanaged chain below a managed parent is removed when the parent drops it."""
+        managed_parent_id = generate_id("PARENT")
+        m2, m3, m4, m5 = "manual-2", "manual-3", "manual-4", "manual-5"
+
+        existing_containers = [
+            create_grpc_container(container_id=managed_parent_id, name="PARENT", description="Parent", query="device:*", child_ids=[m2]),
+            create_grpc_container(container_id=m2, name="M2", description="", query="device:*", child_ids=[m3]),
+            create_grpc_container(container_id=m3, name="M3", description="", query="device:*", child_ids=[m4]),
+            create_grpc_container(container_id=m4, name="M4", description="", query="device:*", child_ids=[m5]),
+            create_grpc_container(container_id=m5, name="M5", description="", query="device:*"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = []
+        mock_cv_client.get_studio_inputs_with_path.return_value = [managed_parent_id]
+
+        managed_parent = AvdContainer(name="PARENT", tag_query="device:*", description="Parent")
+        manifest = AvdManifest(containers=(managed_parent,))
+
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        deleted_ids = {call.kwargs["assignment_id"] for call in mock_cv_client.delete_configlet_container.call_args_list}
+        assert deleted_ids == {m2, m3, m4, m5}
+        assert set(deployment_result.removed_static_config_containers) == {"M2", "M3", "M4", "M5"}
+
+    async def test_managed_parent_dropping_mixed_children_removes_both(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that when a managed parent drops both a managed and an unmanaged child at once, both are removed."""
+        managed_parent_id = generate_id("PARENT")
+        dropped_managed_child_id = generate_id("PARENT/DROPPED_CHILD")
+        dropped_unmanaged_child_id = "manual-dropped-child"
+
+        existing_containers = [
+            # Managed parent currently owns one managed child and one unmanaged child; the manifest drops both.
+            create_grpc_container(
+                container_id=managed_parent_id,
+                name="PARENT",
+                description="Parent",
+                query="device:*",
+                child_ids=[dropped_managed_child_id, dropped_unmanaged_child_id],
+            ),
+            create_grpc_container(container_id=dropped_managed_child_id, name="DROPPED_CHILD", description="", query="device:LEAF"),
+            create_grpc_container(container_id=dropped_unmanaged_child_id, name="UNMANAGED_DROPPED", description="", query="device:LEAF"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = []
+        mock_cv_client.get_studio_inputs_with_path.return_value = [managed_parent_id]
+
+        # Manifest declares only the parent with no children.
+        managed_parent = AvdContainer(name="PARENT", tag_query="device:*", description="Parent")
+        manifest = AvdManifest(containers=(managed_parent,))
+
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # Both children are removed (each via its own removal path) and the parent is updated to have no children.
+        assert mock_cv_client.delete_configlet_container.call_count == 2
+        deleted_ids = {call.kwargs["assignment_id"] for call in mock_cv_client.delete_configlet_container.call_args_list}
+        assert deleted_ids == {dropped_managed_child_id, dropped_unmanaged_child_id}
+        assert set(deployment_result.removed_static_config_containers) == {"DROPPED_CHILD", "UNMANAGED_DROPPED"}
+
+        mock_cv_client.set_configlet_containers.assert_called_once()
+        pushed = mock_cv_client.set_configlet_containers.call_args[1]["containers"]
+        parent_push = next(c for c in pushed if c[1] == "PARENT")
+        assert parent_push[5] == []
+
+    async def test_deleted_managed_container_with_mixed_children_is_fully_removed(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that a removed managed container together with its managed and unmanaged children are all deleted in one deploy."""
+        stale_managed_root_id = generate_id("STALE_ROOT")  # Managed, NOT in this manifest -> deleted.
+        stale_managed_child_id = generate_id("STALE_ROOT/MANAGED_CHILD")  # Managed and a child of the deleted root.
+        unmanaged_child_id = "manual-child-xyz"
+        new_root_id = generate_id("NEW_ROOT")
+
+        existing_containers = [
+            create_grpc_container(
+                container_id=stale_managed_root_id,
+                name="STALE_ROOT",
+                description="",
+                query="device:*",
+                child_ids=[stale_managed_child_id, unmanaged_child_id],
+            ),
+            create_grpc_container(container_id=stale_managed_child_id, name="MANAGED_CHILD", description="", query="device:LEAF"),
+            create_grpc_container(container_id=unmanaged_child_id, name="UNMANAGED_CHILD", description="", query="device:LEAF"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = []
+        mock_cv_client.get_studio_inputs_with_path.return_value = [stale_managed_root_id]
+
+        new_root = AvdContainer(name="NEW_ROOT", tag_query="device:*")
+        manifest = AvdManifest(containers=(new_root,))
+
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # The deleted root and both of its children are removed in one deploy.
+        assert mock_cv_client.delete_configlet_container.call_count == 3
+        deleted_ids = {call.kwargs["assignment_id"] for call in mock_cv_client.delete_configlet_container.call_args_list}
+        assert deleted_ids == {stale_managed_root_id, stale_managed_child_id, unmanaged_child_id}
+        assert set(deployment_result.removed_static_config_containers) == {"STALE_ROOT", "MANAGED_CHILD", "UNMANAGED_CHILD"}
+
+        # The new root container is pushed.
+        mock_cv_client.set_configlet_containers.assert_called_once()
+        pushed = mock_cv_client.set_configlet_containers.call_args[1]["containers"]
+        assert {c[0] for c in pushed} == {new_root_id}
+
+    async def test_deleted_configlet_with_only_orphan_holder_does_not_raise(self, mock_cv_client: MagicMock, deployment_result: DeployToCvResult) -> None:
+        """Test that removing a configlet still referenced only by a container scheduled for orphan deletion succeeds without raising."""
+        managed_parent_id = generate_id("PARENT")
+        unmanaged_holder_id = "manual-holder-xyz"
+        stale_cfg_id = generate_id("STALE_CFG")
+
+        existing_containers = [
+            # Managed parent currently owns an unmanaged sub-container that holds the manifest configlet.
+            create_grpc_container(container_id=managed_parent_id, name="PARENT", description="Parent", query="device:*", child_ids=[unmanaged_holder_id]),
+            create_grpc_container(container_id=unmanaged_holder_id, name="UNMANAGED_HOLDER", description="", query="device:*", configlet_ids=[stale_cfg_id]),
+        ]
+        existing_configlets = [
+            Configlet(key=ConfigletKey(configlet_id=stale_cfg_id), display_name="STALE_CFG"),
+        ]
+        mock_cv_client.get_configlet_containers.return_value = existing_containers
+        mock_cv_client.get_configlets.return_value = existing_configlets
+        mock_cv_client.get_studio_inputs_with_path.return_value = [managed_parent_id]
+
+        # Manifest drops the unmanaged holder (PARENT updated with no children) and the configlet.
+        managed_parent = AvdContainer(name="PARENT", tag_query="device:*", description="Parent")
+        manifest = AvdManifest(configlets=(), containers=(managed_parent,))
+
+        # Must not raise -- UNMANAGED_HOLDER is about to be orphan-deleted, taking its stale STALE_CFG reference with it.
+        await deploy_static_config_studio_manifest_to_cv(manifest, deployment_result, mock_cv_client)
+
+        # The configlet and its orphan holder are both deleted.
+        mock_cv_client.delete_configlets.assert_called_once_with(workspace_id=deployment_result.workspace.id, configlet_ids=[stale_cfg_id])
+        mock_cv_client.delete_configlet_container.assert_called_once_with(workspace_id=deployment_result.workspace.id, assignment_id=unmanaged_holder_id)
+        assert deployment_result.removed_static_config_configlets == ["STALE_CFG"]
+        assert deployment_result.removed_static_config_containers == ["UNMANAGED_HOLDER"]


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

Today, cv_deploy will automatically unassign any sub-containers manually assigned under a parent container managed by cv_deploy, leaving them as orphans in the CV database.

This PR adds a fix to also delete them from CV to avoid orphans.

## Related Issue(s)

Fixes aristanetworks/avd-internal/issues/543

## Component(s) name

`arista.avd.cv_deploy`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
Add unassigned sub-containers to the `containers_to_delete` mapping to delete them.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Added unit tests to cover the fix.

1- Push a manifest.
2- Add manual sub-containers under a manifest container.
3- Re-push the manifest.
4- Via CV API Explorer, make sure all sub-containers are deleted from CV.
5- Make sure all sub-containers are also part of Ansible result in `removed_static_config_containers`.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
