### PR TITLE
Fix(eos_cli_config_gen): dot1x documentation checks wrong path for DHCP hostname auth-only

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1625,6 +1625,11 @@ router pim sparse-mode
 | ---- | ----- | --------- |
 | Service Type | - | - |
 | Framed MTU | 1500 | - |
+| LLDP System-name | - | No |
+| LLDP System-description | - | No |
+| DHCP Hostname | - | No |
+| DHCP Parameter Request List | - | No |
+| DHCP Vendor Class ID | - | No |
 
 #### Dot1x Configuration
 
@@ -1634,6 +1639,11 @@ dot1x
    aaa unresponsive action traffic allow
    radius av-pair service-type
    radius av-pair framed-mtu 1500
+   radius av-pair lldp system-name
+   radius av-pair lldp system-description
+   radius av-pair dhcp hostname
+   radius av-pair dhcp parameter-request-list
+   radius av-pair dhcp vendor-class-id
 !
 dot1x system-auth-control
 dot1x protocol lldp bypass

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host2.cfg
@@ -207,6 +207,11 @@ dot1x
    aaa unresponsive action traffic allow
    radius av-pair service-type
    radius av-pair framed-mtu 1500
+   radius av-pair lldp system-name
+   radius av-pair lldp system-description
+   radius av-pair dhcp hostname
+   radius av-pair dhcp parameter-request-list
+   radius av-pair dhcp vendor-class-id
 !
 mac security
    fips restrictions

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host2/dot1x.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host2/dot1x.yml
@@ -10,6 +10,18 @@ dot1x:
   radius_av_pair:
     service_type: true
     framed_mtu: 1500
+    lldp:
+      system_name:
+        enabled: true
+      system_description:
+        enabled: true
+    dhcp:
+      hostname:
+        enabled: true
+      parameter_request_list:
+        enabled: true
+      vendor_class_id:
+        enabled: true
   aaa:
     unresponsive:
       action:

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
@@ -49,34 +49,19 @@
 | Framed MTU | {{ dot1x.radius_av_pair.framed_mtu }} | - |
 {%             endif %}
 {%             if dot1x.radius_av_pair.lldp.system_name.enabled is arista.avd.defined(true) %}
-{%                 if dot1x.radius_av_pair.lldp.system_name.auth_only is arista.avd.defined(true) %}
-{%                     set auth_only = "Yes" %}
-{%                 endif %}
-| LLDP System-name | - | {{ auth_only | arista.avd.default('No') }} |
+| LLDP System-name | - | {{ "Yes" if dot1x.radius_av_pair.lldp.system_name.auth_only is arista.avd.defined(true) else "No" }} |
 {%             endif %}
 {%             if dot1x.radius_av_pair.lldp.system_description.enabled is arista.avd.defined(true) %}
-{%                 if dot1x.radius_av_pair.lldp.system_description.auth_only is arista.avd.defined(true) %}
-{%                     set auth_only = "Yes" %}
-{%                 endif %}
-| LLDP System-description | - | {{ auth_only | arista.avd.default('No') }} |
+| LLDP System-description | - | {{ "Yes" if dot1x.radius_av_pair.lldp.system_description.auth_only is arista.avd.defined(true) else "No" }} |
 {%             endif %}
 {%             if dot1x.radius_av_pair.dhcp.hostname.enabled is arista.avd.defined(true) %}
-{%                 if dot1x.radius_av_pair.lldp.hostname.auth_only is arista.avd.defined(true) %}
-{%                     set auth_only = "Yes" %}
-{%                 endif %}
-| DHCP Hostname | - | {{ auth_only | arista.avd.default('No') }} |
+| DHCP Hostname | - | {{ "Yes" if dot1x.radius_av_pair.dhcp.hostname.auth_only is arista.avd.defined(true) else "No" }} |
 {%             endif %}
 {%             if dot1x.radius_av_pair.dhcp.parameter_request_list.enabled is arista.avd.defined(true) %}
-{%                 if dot1x.radius_av_pair.dhcp.parameter_request_list.auth_only is arista.avd.defined(true) %}
-{%                     set auth_only = "Yes" %}
-{%                 endif %}
-| DHCP Parameter Request List | - | {{ auth_only | arista.avd.default('No') }} |
+| DHCP Parameter Request List | - | {{ "Yes" if dot1x.radius_av_pair.dhcp.parameter_request_list.auth_only is arista.avd.defined(true) else "No" }} |
 {%             endif %}
 {%             if dot1x.radius_av_pair.dhcp.vendor_class_id.enabled is arista.avd.defined(true) %}
-{%                 if dot1x.radius_av_pair.dhcp.vendor_class_id.auth_only is arista.avd.defined(true) %}
-{%                     set auth_only = "Yes" %}
-{%                 endif %}
-| DHCP Vendor Class ID | - | {{ auth_only | arista.avd.default('No') }} |
+| DHCP Vendor Class ID | - | {{ "Yes" if dot1x.radius_av_pair.dhcp.vendor_class_id.auth_only is arista.avd.defined(true) else "No" }} |
 {%             endif %}
 {%             if dot1x.radius_av_pair.filter_id.delimiter_period is arista.avd.defined(true) %}
 | Filter ID Delimiter Period | - | - |


### PR DESCRIPTION
## Change Summary

The eos_cli_config_gen dot1x documentation template checks the wrong data path when rendering the Auth Only value for the DHCP Hostname RADIUS AV-pair row.

In python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2, the DHCP Hostname row is gated by:
```
dot1x.radius_av_pair.dhcp.hostname.enabled
```
but the auth_only check uses:
```
dot1x.radius_av_pair.lldp.hostname.auth_only
```
That path does not match the schema or EOS config template. The valid input path is:
```
dot1x.radius_av_pair.dhcp.hostname.auth_only
```

## Related Issue(s)

Fixes #7058 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
fixed the check and added TCs

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
