### PR TITLE
Doc: Add EOS Config and AVD Design future settings at the top of the release notes

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md
@@ -8,9 +8,9 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>eos_config_future</samp>](## "eos_config_future") | Dictionary |  |  |  | Opt-in to future EOS CLI behaviors which will become default behaviors in a future AVD major version. |
+    | [<samp>&nbsp;&nbsp;always_render_ip_routing_separator</samp>](## "eos_config_future.always_render_ip_routing_separator") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Always render a '!' before the '(no) ip routing' command section.<br>Without this the '!' is missing when only configuring routing for VRFs. |
     | [<samp>&nbsp;&nbsp;new_ip_radius_cli_order</samp>](## "eos_config_future.new_ip_radius_cli_order") | Boolean |  | `False` |  | Available from AVD 6.1.0.<br>When `true`, renders the new EOS CLI order using `ip_radius`, sorted by VRF name.<br>When `false` (default), renders the legacy CLI order using `ip_radius_source_interfaces`, sorted by source interface name. |
     | [<samp>&nbsp;&nbsp;new_ip_tacacs_cli_order</samp>](## "eos_config_future.new_ip_tacacs_cli_order") | Boolean |  | `False` |  | Available from AVD 6.1.0.<br>When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.<br>When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source interface name. |
-    | [<samp>&nbsp;&nbsp;always_render_ip_routing_separator</samp>](## "eos_config_future.always_render_ip_routing_separator") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Always render a '!' before the '(no) ip routing' command section.<br>Without this the '!' is missing when only configuring routing for VRFs. |
     | [<samp>&nbsp;&nbsp;only_render_mpls_rsvp_with_settings</samp>](## "eos_config_future.only_render_mpls_rsvp_with_settings") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is defined.<br>When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined, even if no sub-settings are set. |
 
 === "YAML"
@@ -18,6 +18,11 @@
     ```yaml
     # Opt-in to future EOS CLI behaviors which will become default behaviors in a future AVD major version.
     eos_config_future:
+
+      # Available from AVD 6.2.0.
+      # Always render a '!' before the '(no) ip routing' command section.
+      # Without this the '!' is missing when only configuring routing for VRFs.
+      always_render_ip_routing_separator: <bool; default=False>
 
       # Available from AVD 6.1.0.
       # When `true`, renders the new EOS CLI order using `ip_radius`, sorted by VRF name.
@@ -28,11 +33,6 @@
       # When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.
       # When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source interface name.
       new_ip_tacacs_cli_order: <bool; default=False>
-
-      # Available from AVD 6.2.0.
-      # Always render a '!' before the '(no) ip routing' command section.
-      # Without this the '!' is missing when only configuring routing for VRFs.
-      always_render_ip_routing_separator: <bool; default=False>
 
       # Available from AVD 6.2.0.
       # When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is defined.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md
@@ -8,10 +8,10 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>eos_config_future</samp>](## "eos_config_future") | Dictionary |  |  |  | Opt-in to future EOS CLI behaviors which will become default behaviors in a future AVD major version. |
-    | [<samp>&nbsp;&nbsp;new_ip_radius_cli_order</samp>](## "eos_config_future.new_ip_radius_cli_order") | Boolean |  | `False` |  | When `true`, renders the new EOS CLI order using `ip_radius`, sorted by VRF name.<br>When `false` (default), renders the legacy CLI order using `ip_radius_source_interfaces`, sorted by source interface name. |
-    | [<samp>&nbsp;&nbsp;new_ip_tacacs_cli_order</samp>](## "eos_config_future.new_ip_tacacs_cli_order") | Boolean |  | `False` |  | When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.<br>When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source interface name. |
-    | [<samp>&nbsp;&nbsp;always_render_ip_routing_separator</samp>](## "eos_config_future.always_render_ip_routing_separator") | Boolean |  | `False` |  | Always render a '!' before the '(no) ip routing' command section.<br>Without this the '!' is missing when only configuring routing for VRFs. |
-    | [<samp>&nbsp;&nbsp;only_render_mpls_rsvp_with_settings</samp>](## "eos_config_future.only_render_mpls_rsvp_with_settings") | Boolean |  | `False` |  | When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is defined.<br>When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined, even if no sub-settings are set. |
+    | [<samp>&nbsp;&nbsp;new_ip_radius_cli_order</samp>](## "eos_config_future.new_ip_radius_cli_order") | Boolean |  | `False` |  | Available from AVD 6.1.0.<br>When `true`, renders the new EOS CLI order using `ip_radius`, sorted by VRF name.<br>When `false` (default), renders the legacy CLI order using `ip_radius_source_interfaces`, sorted by source interface name. |
+    | [<samp>&nbsp;&nbsp;new_ip_tacacs_cli_order</samp>](## "eos_config_future.new_ip_tacacs_cli_order") | Boolean |  | `False` |  | Available from AVD 6.1.0.<br>When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.<br>When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source interface name. |
+    | [<samp>&nbsp;&nbsp;always_render_ip_routing_separator</samp>](## "eos_config_future.always_render_ip_routing_separator") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Always render a '!' before the '(no) ip routing' command section.<br>Without this the '!' is missing when only configuring routing for VRFs. |
+    | [<samp>&nbsp;&nbsp;only_render_mpls_rsvp_with_settings</samp>](## "eos_config_future.only_render_mpls_rsvp_with_settings") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is defined.<br>When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined, even if no sub-settings are set. |
 
 === "YAML"
 
@@ -19,18 +19,22 @@
     # Opt-in to future EOS CLI behaviors which will become default behaviors in a future AVD major version.
     eos_config_future:
 
+      # Available from AVD 6.1.0.
       # When `true`, renders the new EOS CLI order using `ip_radius`, sorted by VRF name.
       # When `false` (default), renders the legacy CLI order using `ip_radius_source_interfaces`, sorted by source interface name.
       new_ip_radius_cli_order: <bool; default=False>
 
+      # Available from AVD 6.1.0.
       # When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.
       # When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source interface name.
       new_ip_tacacs_cli_order: <bool; default=False>
 
+      # Available from AVD 6.2.0.
       # Always render a '!' before the '(no) ip routing' command section.
       # Without this the '!' is missing when only configuring routing for VRFs.
       always_render_ip_routing_separator: <bool; default=False>
 
+      # Available from AVD 6.2.0.
       # When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is defined.
       # When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined, even if no sub-settings are set.
       only_render_mpls_rsvp_with_settings: <bool; default=False>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/avd-design-future.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/avd-design-future.md
@@ -9,14 +9,14 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>avd_design_future</samp>](## "avd_design_future") | Dictionary |  |  |  | Opt-in to future AVD behaviors which will become default behaviors in a future AVD major version. |
     | [<samp>&nbsp;&nbsp;accept_dhcp_default_route_for_mgmt_ip_dhcp</samp>](## "avd_design_future.accept_dhcp_default_route_for_mgmt_ip_dhcp") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Configure management interface to accept DHCP default route when the management IP is set to 'dhcp'. |
-    | [<samp>&nbsp;&nbsp;remove_redundant_ipv4_unicast_for_peer_groups</samp>](## "avd_design_future.remove_redundant_ipv4_unicast_for_peer_groups") | Boolean |  | `False` |  | Available from AVD 6.1.0.<br>Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it. |
-    | [<samp>&nbsp;&nbsp;raise_for_port_channels_without_members</samp>](## "avd_design_future.raise_for_port_channels_without_members") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Raise an error if an L3 Port-Channel is configured without any member interfaces. |
-    | [<samp>&nbsp;&nbsp;only_configure_mlag_vrfs_peer_group_when_used</samp>](## "avd_design_future.only_configure_mlag_vrfs_peer_group_when_used") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed. |
-    | [<samp>&nbsp;&nbsp;raise_for_underlay_router_with_uplink_type_port_channel</samp>](## "avd_design_future.raise_for_underlay_router_with_uplink_type_port_channel") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,<br>since this combination is not supported. |
     | [<samp>&nbsp;&nbsp;configure_inband_mgmt_ipv6_vrf</samp>](## "avd_design_future.configure_inband_mgmt_ipv6_vrf") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Configure `inband_mgmt_vrf` for IPv6 inband management. |
-    | [<samp>&nbsp;&nbsp;only_configure_ipv6_inband_mgmt_prefix_list_when_used</samp>](## "avd_design_future.only_configure_ipv6_inband_mgmt_prefix_list_when_used") | Boolean |  | `False` |  | Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed. |
     | [<samp>&nbsp;&nbsp;consistent_uplink_vlans</samp>](## "avd_design_future.consistent_uplink_vlans") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Always configure Port-Channel uplinks with consistent 'switchport trunk allowed' on both ends<br>and on all 'uplink_switches' even when available VLANs differ between the 'uplink_switches'. |
     | [<samp>&nbsp;&nbsp;fix_radius_server_group_tls</samp>](## "avd_design_future.fix_radius_server_group_tls") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Fix to configure TLS on RADIUS server group members to match their global RADIUS server configurations. |
+    | [<samp>&nbsp;&nbsp;only_configure_ipv6_inband_mgmt_prefix_list_when_used</samp>](## "avd_design_future.only_configure_ipv6_inband_mgmt_prefix_list_when_used") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed. |
+    | [<samp>&nbsp;&nbsp;only_configure_mlag_vrfs_peer_group_when_used</samp>](## "avd_design_future.only_configure_mlag_vrfs_peer_group_when_used") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed. |
+    | [<samp>&nbsp;&nbsp;raise_for_port_channels_without_members</samp>](## "avd_design_future.raise_for_port_channels_without_members") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Raise an error if an L3 Port-Channel is configured without any member interfaces. |
+    | [<samp>&nbsp;&nbsp;raise_for_underlay_router_with_uplink_type_port_channel</samp>](## "avd_design_future.raise_for_underlay_router_with_uplink_type_port_channel") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,<br>since this combination is not supported. |
+    | [<samp>&nbsp;&nbsp;remove_redundant_ipv4_unicast_for_peer_groups</samp>](## "avd_design_future.remove_redundant_ipv4_unicast_for_peer_groups") | Boolean |  | `False` |  | Available from AVD 6.1.0.<br>Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it. |
 
 === "YAML"
 
@@ -28,29 +28,9 @@
       # Configure management interface to accept DHCP default route when the management IP is set to 'dhcp'.
       accept_dhcp_default_route_for_mgmt_ip_dhcp: <bool; default=False>
 
-      # Available from AVD 6.1.0.
-      # Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it.
-      remove_redundant_ipv4_unicast_for_peer_groups: <bool; default=False>
-
-      # Available from AVD 6.2.0.
-      # Raise an error if an L3 Port-Channel is configured without any member interfaces.
-      raise_for_port_channels_without_members: <bool; default=False>
-
-      # Available from AVD 6.2.0.
-      # Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
-      only_configure_mlag_vrfs_peer_group_when_used: <bool; default=False>
-
-      # Available from AVD 6.2.0.
-      # Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,
-      # since this combination is not supported.
-      raise_for_underlay_router_with_uplink_type_port_channel: <bool; default=False>
-
       # Available from AVD 6.2.0.
       # Configure `inband_mgmt_vrf` for IPv6 inband management.
       configure_inband_mgmt_ipv6_vrf: <bool; default=False>
-
-      # Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
-      only_configure_ipv6_inband_mgmt_prefix_list_when_used: <bool; default=False>
 
       # Available from AVD 6.2.0.
       # Always configure Port-Channel uplinks with consistent 'switchport trunk allowed' on both ends
@@ -60,4 +40,25 @@
       # Available from AVD 6.2.0.
       # Fix to configure TLS on RADIUS server group members to match their global RADIUS server configurations.
       fix_radius_server_group_tls: <bool; default=False>
+
+      # Available from AVD 6.2.0.
+      # Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
+      only_configure_ipv6_inband_mgmt_prefix_list_when_used: <bool; default=False>
+
+      # Available from AVD 6.2.0.
+      # Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
+      only_configure_mlag_vrfs_peer_group_when_used: <bool; default=False>
+
+      # Available from AVD 6.2.0.
+      # Raise an error if an L3 Port-Channel is configured without any member interfaces.
+      raise_for_port_channels_without_members: <bool; default=False>
+
+      # Available from AVD 6.2.0.
+      # Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,
+      # since this combination is not supported.
+      raise_for_underlay_router_with_uplink_type_port_channel: <bool; default=False>
+
+      # Available from AVD 6.1.0.
+      # Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it.
+      remove_redundant_ipv4_unicast_for_peer_groups: <bool; default=False>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/avd-design-future.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/avd-design-future.md
@@ -8,15 +8,15 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>avd_design_future</samp>](## "avd_design_future") | Dictionary |  |  |  | Opt-in to future AVD behaviors which will become default behaviors in a future AVD major version. |
-    | [<samp>&nbsp;&nbsp;accept_dhcp_default_route_for_mgmt_ip_dhcp</samp>](## "avd_design_future.accept_dhcp_default_route_for_mgmt_ip_dhcp") | Boolean |  | `False` |  | Configure management interface to accept DHCP default route when the management IP is set to 'dhcp'. |
-    | [<samp>&nbsp;&nbsp;remove_redundant_ipv4_unicast_for_peer_groups</samp>](## "avd_design_future.remove_redundant_ipv4_unicast_for_peer_groups") | Boolean |  | `False` |  | Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it. |
-    | [<samp>&nbsp;&nbsp;raise_for_port_channels_without_members</samp>](## "avd_design_future.raise_for_port_channels_without_members") | Boolean |  | `False` |  | Raise an error if an L3 Port-Channel is configured without any member interfaces. |
-    | [<samp>&nbsp;&nbsp;only_configure_mlag_vrfs_peer_group_when_used</samp>](## "avd_design_future.only_configure_mlag_vrfs_peer_group_when_used") | Boolean |  | `False` |  | Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed. |
-    | [<samp>&nbsp;&nbsp;raise_for_underlay_router_with_uplink_type_port_channel</samp>](## "avd_design_future.raise_for_underlay_router_with_uplink_type_port_channel") | Boolean |  | `False` |  | Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,<br>since this combination is not supported. |
-    | [<samp>&nbsp;&nbsp;configure_inband_mgmt_ipv6_vrf</samp>](## "avd_design_future.configure_inband_mgmt_ipv6_vrf") | Boolean |  | `False` |  | Configure `inband_mgmt_vrf` for IPv6 inband management. |
+    | [<samp>&nbsp;&nbsp;accept_dhcp_default_route_for_mgmt_ip_dhcp</samp>](## "avd_design_future.accept_dhcp_default_route_for_mgmt_ip_dhcp") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Configure management interface to accept DHCP default route when the management IP is set to 'dhcp'. |
+    | [<samp>&nbsp;&nbsp;remove_redundant_ipv4_unicast_for_peer_groups</samp>](## "avd_design_future.remove_redundant_ipv4_unicast_for_peer_groups") | Boolean |  | `False` |  | Available from AVD 6.1.0.<br>Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it. |
+    | [<samp>&nbsp;&nbsp;raise_for_port_channels_without_members</samp>](## "avd_design_future.raise_for_port_channels_without_members") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Raise an error if an L3 Port-Channel is configured without any member interfaces. |
+    | [<samp>&nbsp;&nbsp;only_configure_mlag_vrfs_peer_group_when_used</samp>](## "avd_design_future.only_configure_mlag_vrfs_peer_group_when_used") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed. |
+    | [<samp>&nbsp;&nbsp;raise_for_underlay_router_with_uplink_type_port_channel</samp>](## "avd_design_future.raise_for_underlay_router_with_uplink_type_port_channel") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,<br>since this combination is not supported. |
+    | [<samp>&nbsp;&nbsp;configure_inband_mgmt_ipv6_vrf</samp>](## "avd_design_future.configure_inband_mgmt_ipv6_vrf") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Configure `inband_mgmt_vrf` for IPv6 inband management. |
     | [<samp>&nbsp;&nbsp;only_configure_ipv6_inband_mgmt_prefix_list_when_used</samp>](## "avd_design_future.only_configure_ipv6_inband_mgmt_prefix_list_when_used") | Boolean |  | `False` |  | Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed. |
-    | [<samp>&nbsp;&nbsp;consistent_uplink_vlans</samp>](## "avd_design_future.consistent_uplink_vlans") | Boolean |  | `False` |  | Always configure Port-Channel uplinks with consistent 'switchport trunk allowed' on both ends<br>and on all 'uplink_switches' even when available VLANs differ between the 'uplink_switches'. |
-    | [<samp>&nbsp;&nbsp;fix_radius_server_group_tls</samp>](## "avd_design_future.fix_radius_server_group_tls") | Boolean |  | `False` |  | Fix to configure TLS on RADIUS server group members to match their global RADIUS server configurations. |
+    | [<samp>&nbsp;&nbsp;consistent_uplink_vlans</samp>](## "avd_design_future.consistent_uplink_vlans") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Always configure Port-Channel uplinks with consistent 'switchport trunk allowed' on both ends<br>and on all 'uplink_switches' even when available VLANs differ between the 'uplink_switches'. |
+    | [<samp>&nbsp;&nbsp;fix_radius_server_group_tls</samp>](## "avd_design_future.fix_radius_server_group_tls") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>Fix to configure TLS on RADIUS server group members to match their global RADIUS server configurations. |
 
 === "YAML"
 
@@ -24,32 +24,40 @@
     # Opt-in to future AVD behaviors which will become default behaviors in a future AVD major version.
     avd_design_future:
 
+      # Available from AVD 6.2.0.
       # Configure management interface to accept DHCP default route when the management IP is set to 'dhcp'.
       accept_dhcp_default_route_for_mgmt_ip_dhcp: <bool; default=False>
 
+      # Available from AVD 6.1.0.
       # Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it.
       remove_redundant_ipv4_unicast_for_peer_groups: <bool; default=False>
 
+      # Available from AVD 6.2.0.
       # Raise an error if an L3 Port-Channel is configured without any member interfaces.
       raise_for_port_channels_without_members: <bool; default=False>
 
+      # Available from AVD 6.2.0.
       # Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
       only_configure_mlag_vrfs_peer_group_when_used: <bool; default=False>
 
+      # Available from AVD 6.2.0.
       # Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,
       # since this combination is not supported.
       raise_for_underlay_router_with_uplink_type_port_channel: <bool; default=False>
 
+      # Available from AVD 6.2.0.
       # Configure `inband_mgmt_vrf` for IPv6 inband management.
       configure_inband_mgmt_ipv6_vrf: <bool; default=False>
 
       # Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
       only_configure_ipv6_inband_mgmt_prefix_list_when_used: <bool; default=False>
 
+      # Available from AVD 6.2.0.
       # Always configure Port-Channel uplinks with consistent 'switchport trunk allowed' on both ends
       # and on all 'uplink_switches' even when available VLANs differ between the 'uplink_switches'.
       consistent_uplink_vlans: <bool; default=False>
 
+      # Available from AVD 6.2.0.
       # Fix to configure TLS on RADIUS server group members to match their global RADIUS server configurations.
       fix_radius_server_group_tls: <bool; default=False>
     ```

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -35,7 +35,7 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/avd-design-future.m
 
 #### EOS Config Future
 
-The `eos_config_future` settings are part of the EOS Config schema used by `eos_cli_config_gen`.
+The `eos_config_future` settings are part of the EOS Config schema used by the `eos_cli_config_gen` Ansible role.
 
 --8<--
 ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -23,7 +23,8 @@ For additional information, please see [versioning](../versioning/semantic-versi
 !!! info "AVD future behavior settings"
 
     AVD 6.x includes opt-in settings for AVD Design and EOS Config behaviors planned as defaults in a later major release.
-    These behaviors are kept behind explicit knobs because AVD follows Semantic Versioning and they are breaking changes.
+    These behaviors are kept behind explicit knobs because AVD follows Semantic Versioning and they are breaking changes,
+    meaning the new behaviors can lead to changes in the generated EOS configurations for the same AVD inputs.
 
 #### AVD Design Future
 

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -18,6 +18,29 @@ The AVD project follows Semantic Versioning. For the best user experience, we re
 
 For additional information, please see [versioning](../versioning/semantic-versioning.md).
 
+### AVD Future Behavior Opt-In
+
+!!! info "AVD future behavior settings"
+
+    AVD 6.x includes opt-in settings for AVD Design and EOS Config behaviors planned as defaults in a later major release.
+    These behaviors are kept behind explicit knobs because AVD follows Semantic Versioning and they are breaking changes.
+
+#### AVD Design Future
+
+The `avd_design_future` settings are part of the AVD Design schema used by `eos_designs`.
+
+--8<--
+ansible_collections/arista/avd/roles/eos_designs/docs/tables/avd-design-future.md
+--8<--
+
+#### EOS Config Future
+
+The `eos_config_future` settings are part of the EOS Config schema used by `eos_cli_config_gen`.
+
+--8<--
+ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md
+--8<--
+
 ## Release 6.2.0
 
 ### Changes to requirements

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -27,7 +27,7 @@ For additional information, please see [versioning](../versioning/semantic-versi
 
 #### AVD Design Future
 
-The `avd_design_future` settings are part of the AVD Design schema used by `eos_designs`.
+The `avd_design_future` settings are part of the AVD Design schema used by the `eos_designs` Ansible role.
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/avd-design-future.md

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -27,7 +27,7 @@ For additional information, please see [versioning](../versioning/semantic-versi
     meaning the new behaviors can lead to changes in the generated EOS configurations for the same AVD inputs.
 
 !!! tip
-     
+
      For new deployments, we recommend setting all `avd_design_future` and `eos_config_future` keys to true.
 
 #### AVD Design Future

--- a/docs/release-notes/6.x.x.md
+++ b/docs/release-notes/6.x.x.md
@@ -26,6 +26,10 @@ For additional information, please see [versioning](../versioning/semantic-versi
     These behaviors are kept behind explicit knobs because AVD follows Semantic Versioning and they are breaking changes,
     meaning the new behaviors can lead to changes in the generated EOS configurations for the same AVD inputs.
 
+!!! tip
+     
+     For new deployments, we recommend setting all `avd_design_future` and `eos_config_future` keys to true.
+
 #### AVD Design Future
 
 The `avd_design_future` settings are part of the AVD Design schema used by the `eos_designs` Ansible role.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -6334,11 +6334,20 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Subclass of AvdModel."""
 
         _fields: ClassVar[dict] = {
+            "always_render_ip_routing_separator": {"type": bool, "default": False},
             "new_ip_radius_cli_order": {"type": bool, "default": False},
             "new_ip_tacacs_cli_order": {"type": bool, "default": False},
-            "always_render_ip_routing_separator": {"type": bool, "default": False},
             "only_render_mpls_rsvp_with_settings": {"type": bool, "default": False},
         }
+        always_render_ip_routing_separator: bool
+        """
+        Available from AVD 6.2.0.
+        Always render a '!' before the '(no) ip routing' command section.
+        Without
+        this the '!' is missing when only configuring routing for VRFs.
+
+        Default value: `False`
+        """
         new_ip_radius_cli_order: bool
         """
         Available from AVD 6.1.0.
@@ -6359,15 +6368,6 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
         Default value: `False`
         """
-        always_render_ip_routing_separator: bool
-        """
-        Available from AVD 6.2.0.
-        Always render a '!' before the '(no) ip routing' command section.
-        Without
-        this the '!' is missing when only configuring routing for VRFs.
-
-        Default value: `False`
-        """
         only_render_mpls_rsvp_with_settings: bool
         """
         Available from AVD 6.2.0.
@@ -6384,9 +6384,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             def __init__(
                 self,
                 *,
+                always_render_ip_routing_separator: bool | UndefinedType = Undefined,
                 new_ip_radius_cli_order: bool | UndefinedType = Undefined,
                 new_ip_tacacs_cli_order: bool | UndefinedType = Undefined,
-                always_render_ip_routing_separator: bool | UndefinedType = Undefined,
                 only_render_mpls_rsvp_with_settings: bool | UndefinedType = Undefined,
             ) -> None:
                 """
@@ -6396,6 +6396,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 Subclass of AvdModel.
 
                 Args:
+                    always_render_ip_routing_separator:
+                       Available from AVD 6.2.0.
+                       Always render a '!' before the '(no) ip routing' command section.
+                       Without
+                       this the '!' is missing when only configuring routing for VRFs.
                     new_ip_radius_cli_order:
                        Available from AVD 6.1.0.
                        When `true`, renders the new EOS CLI order using `ip_radius`, sorted by
@@ -6408,11 +6413,6 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        VRF name.
                        When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`,
                        sorted by source interface name.
-                    always_render_ip_routing_separator:
-                       Available from AVD 6.2.0.
-                       Always render a '!' before the '(no) ip routing' command section.
-                       Without
-                       this the '!' is missing when only configuring routing for VRFs.
                     only_render_mpls_rsvp_with_settings:
                        Available from AVD 6.2.0.
                        When `true`, only renders the `mpls rsvp` CLI block when at least one

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -6341,36 +6341,40 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         }
         new_ip_radius_cli_order: bool
         """
-        When `true`, renders the new EOS CLI order using `ip_radius`, sorted by VRF name.
-        When `false`
-        (default), renders the legacy CLI order using `ip_radius_source_interfaces`, sorted by source
-        interface name.
+        Available from AVD 6.1.0.
+        When `true`, renders the new EOS CLI order using `ip_radius`, sorted by
+        VRF name.
+        When `false` (default), renders the legacy CLI order using `ip_radius_source_interfaces`,
+        sorted by source interface name.
 
         Default value: `False`
         """
         new_ip_tacacs_cli_order: bool
         """
-        When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.
-        When `false`
-        (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source
-        interface name.
+        Available from AVD 6.1.0.
+        When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by
+        VRF name.
+        When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`,
+        sorted by source interface name.
 
         Default value: `False`
         """
         always_render_ip_routing_separator: bool
         """
+        Available from AVD 6.2.0.
         Always render a '!' before the '(no) ip routing' command section.
-        Without this the '!' is missing
-        when only configuring routing for VRFs.
+        Without
+        this the '!' is missing when only configuring routing for VRFs.
 
         Default value: `False`
         """
         only_render_mpls_rsvp_with_settings: bool
         """
-        When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is
-        defined.
-        When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined, even if no
-        sub-settings are set.
+        Available from AVD 6.2.0.
+        When `true`, only renders the `mpls rsvp` CLI block when at least one
+        `mpls.rsvp.*` setting is defined.
+        When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp`
+        is defined, even if no sub-settings are set.
 
         Default value: `False`
         """
@@ -6393,24 +6397,28 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 Args:
                     new_ip_radius_cli_order:
-                       When `true`, renders the new EOS CLI order using `ip_radius`, sorted by VRF name.
-                       When `false`
-                       (default), renders the legacy CLI order using `ip_radius_source_interfaces`, sorted by source
-                       interface name.
+                       Available from AVD 6.1.0.
+                       When `true`, renders the new EOS CLI order using `ip_radius`, sorted by
+                       VRF name.
+                       When `false` (default), renders the legacy CLI order using `ip_radius_source_interfaces`,
+                       sorted by source interface name.
                     new_ip_tacacs_cli_order:
-                       When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.
-                       When `false`
-                       (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source
-                       interface name.
+                       Available from AVD 6.1.0.
+                       When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by
+                       VRF name.
+                       When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`,
+                       sorted by source interface name.
                     always_render_ip_routing_separator:
+                       Available from AVD 6.2.0.
                        Always render a '!' before the '(no) ip routing' command section.
-                       Without this the '!' is missing
-                       when only configuring routing for VRFs.
+                       Without
+                       this the '!' is missing when only configuring routing for VRFs.
                     only_render_mpls_rsvp_with_settings:
-                       When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is
-                       defined.
-                       When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined, even if no
-                       sub-settings are set.
+                       Available from AVD 6.2.0.
+                       When `true`, only renders the `mpls rsvp` CLI block when at least one
+                       `mpls.rsvp.*` setting is defined.
+                       When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp`
+                       is defined, even if no sub-settings are set.
 
                 """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -2511,6 +2511,14 @@ keys:
     description: Opt-in to future EOS CLI behaviors which will become default behaviors
       in a future AVD major version.
     keys:
+      always_render_ip_routing_separator:
+        type: bool
+        default: false
+        description: 'Available from AVD 6.2.0.
+
+          Always render a ''!'' before the ''(no) ip routing'' command section.
+
+          Without this the ''!'' is missing when only configuring routing for VRFs.'
       new_ip_radius_cli_order:
         type: bool
         default: false
@@ -2531,14 +2539,6 @@ keys:
 
           When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`,
           sorted by source interface name.'
-      always_render_ip_routing_separator:
-        type: bool
-        default: false
-        description: 'Available from AVD 6.2.0.
-
-          Always render a ''!'' before the ''(no) ip routing'' command section.
-
-          Without this the ''!'' is missing when only configuring routing for VRFs.'
       only_render_mpls_rsvp_with_settings:
         type: bool
         default: false

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -2514,31 +2514,38 @@ keys:
       new_ip_radius_cli_order:
         type: bool
         default: false
-        description: 'When `true`, renders the new EOS CLI order using `ip_radius`,
-          sorted by VRF name.
+        description: 'Available from AVD 6.1.0.
+
+          When `true`, renders the new EOS CLI order using `ip_radius`, sorted by
+          VRF name.
 
           When `false` (default), renders the legacy CLI order using `ip_radius_source_interfaces`,
           sorted by source interface name.'
       new_ip_tacacs_cli_order:
         type: bool
         default: false
-        description: 'When `true`, renders the new EOS CLI order using `ip_tacacs`,
-          sorted by VRF name.
+        description: 'Available from AVD 6.1.0.
+
+          When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by
+          VRF name.
 
           When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`,
           sorted by source interface name.'
       always_render_ip_routing_separator:
         type: bool
         default: false
-        description: 'Always render a ''!'' before the ''(no) ip routing'' command
-          section.
+        description: 'Available from AVD 6.2.0.
+
+          Always render a ''!'' before the ''(no) ip routing'' command section.
 
           Without this the ''!'' is missing when only configuring routing for VRFs.'
       only_render_mpls_rsvp_with_settings:
         type: bool
         default: false
-        description: 'When `true`, only renders the `mpls rsvp` CLI block when at
-          least one `mpls.rsvp.*` setting is defined.
+        description: 'Available from AVD 6.2.0.
+
+          When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*`
+          setting is defined.
 
           When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined,
           even if no sub-settings are set.'

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_config_future.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_config_future.schema.yml
@@ -15,23 +15,27 @@ keys:
         type: bool
         default: false
         description: |-
+          Available from AVD 6.1.0.
           When `true`, renders the new EOS CLI order using `ip_radius`, sorted by VRF name.
           When `false` (default), renders the legacy CLI order using `ip_radius_source_interfaces`, sorted by source interface name.
       new_ip_tacacs_cli_order:
         type: bool
         default: false
         description: |-
+          Available from AVD 6.1.0.
           When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.
           When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source interface name.
       always_render_ip_routing_separator:
         type: bool
         default: false
         description: |-
+          Available from AVD 6.2.0.
           Always render a '!' before the '(no) ip routing' command section.
           Without this the '!' is missing when only configuring routing for VRFs.
       only_render_mpls_rsvp_with_settings:
         type: bool
         default: false
         description: |-
+          Available from AVD 6.2.0.
           When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is defined.
           When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined, even if no sub-settings are set.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_config_future.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_config_future.schema.yml
@@ -11,6 +11,13 @@ keys:
     description: |-
       Opt-in to future EOS CLI behaviors which will become default behaviors in a future AVD major version.
     keys:
+      always_render_ip_routing_separator:
+        type: bool
+        default: false
+        description: |-
+          Available from AVD 6.2.0.
+          Always render a '!' before the '(no) ip routing' command section.
+          Without this the '!' is missing when only configuring routing for VRFs.
       new_ip_radius_cli_order:
         type: bool
         default: false
@@ -25,13 +32,6 @@ keys:
           Available from AVD 6.1.0.
           When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.
           When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source interface name.
-      always_render_ip_routing_separator:
-        type: bool
-        default: false
-        description: |-
-          Available from AVD 6.2.0.
-          Always render a '!' before the '(no) ip routing' command section.
-          Without this the '!' is missing when only configuring routing for VRFs.
       only_render_mpls_rsvp_with_settings:
         type: bool
         default: false

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -981,14 +981,14 @@ class EosDesigns(EosDesignsRootModel):
 
         _fields: ClassVar[dict] = {
             "accept_dhcp_default_route_for_mgmt_ip_dhcp": {"type": bool, "default": False},
-            "remove_redundant_ipv4_unicast_for_peer_groups": {"type": bool, "default": False},
-            "raise_for_port_channels_without_members": {"type": bool, "default": False},
-            "only_configure_mlag_vrfs_peer_group_when_used": {"type": bool, "default": False},
-            "raise_for_underlay_router_with_uplink_type_port_channel": {"type": bool, "default": False},
             "configure_inband_mgmt_ipv6_vrf": {"type": bool, "default": False},
-            "only_configure_ipv6_inband_mgmt_prefix_list_when_used": {"type": bool, "default": False},
             "consistent_uplink_vlans": {"type": bool, "default": False},
             "fix_radius_server_group_tls": {"type": bool, "default": False},
+            "only_configure_ipv6_inband_mgmt_prefix_list_when_used": {"type": bool, "default": False},
+            "only_configure_mlag_vrfs_peer_group_when_used": {"type": bool, "default": False},
+            "raise_for_port_channels_without_members": {"type": bool, "default": False},
+            "raise_for_underlay_router_with_uplink_type_port_channel": {"type": bool, "default": False},
+            "remove_redundant_ipv4_unicast_for_peer_groups": {"type": bool, "default": False},
         }
         accept_dhcp_default_route_for_mgmt_ip_dhcp: bool
         """
@@ -998,48 +998,10 @@ class EosDesigns(EosDesignsRootModel):
 
         Default value: `False`
         """
-        remove_redundant_ipv4_unicast_for_peer_groups: bool
-        """
-        Available from AVD 6.1.0.
-        Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when
-        IPv4 is activated by default instead of always deactivating it.
-
-        Default value: `False`
-        """
-        raise_for_port_channels_without_members: bool
-        """
-        Available from AVD 6.2.0.
-        Raise an error if an L3 Port-Channel is configured without any member
-        interfaces.
-
-        Default value: `False`
-        """
-        only_configure_mlag_vrfs_peer_group_when_used: bool
-        """
-        Available from AVD 6.2.0.
-        Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
-
-        Default value: `False`
-        """
-        raise_for_underlay_router_with_uplink_type_port_channel: bool
-        """
-        Available from AVD 6.2.0.
-        Raise an error if a node has both 'underlay_router: true' and
-        'uplink_type: port-channel' set,
-        since this combination is not supported.
-
-        Default value: `False`
-        """
         configure_inband_mgmt_ipv6_vrf: bool
         """
         Available from AVD 6.2.0.
         Configure `inband_mgmt_vrf` for IPv6 inband management.
-
-        Default value: `False`
-        """
-        only_configure_ipv6_inband_mgmt_prefix_list_when_used: bool
-        """
-        Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
 
         Default value: `False`
         """
@@ -1061,6 +1023,45 @@ class EosDesigns(EosDesignsRootModel):
 
         Default value: `False`
         """
+        only_configure_ipv6_inband_mgmt_prefix_list_when_used: bool
+        """
+        Available from AVD 6.2.0.
+        Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
+
+        Default value: `False`
+        """
+        only_configure_mlag_vrfs_peer_group_when_used: bool
+        """
+        Available from AVD 6.2.0.
+        Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
+
+        Default value: `False`
+        """
+        raise_for_port_channels_without_members: bool
+        """
+        Available from AVD 6.2.0.
+        Raise an error if an L3 Port-Channel is configured without any member
+        interfaces.
+
+        Default value: `False`
+        """
+        raise_for_underlay_router_with_uplink_type_port_channel: bool
+        """
+        Available from AVD 6.2.0.
+        Raise an error if a node has both 'underlay_router: true' and
+        'uplink_type: port-channel' set,
+        since this combination is not supported.
+
+        Default value: `False`
+        """
+        remove_redundant_ipv4_unicast_for_peer_groups: bool
+        """
+        Available from AVD 6.1.0.
+        Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when
+        IPv4 is activated by default instead of always deactivating it.
+
+        Default value: `False`
+        """
 
         if TYPE_CHECKING:
 
@@ -1068,14 +1069,14 @@ class EosDesigns(EosDesignsRootModel):
                 self,
                 *,
                 accept_dhcp_default_route_for_mgmt_ip_dhcp: bool | UndefinedType = Undefined,
-                remove_redundant_ipv4_unicast_for_peer_groups: bool | UndefinedType = Undefined,
-                raise_for_port_channels_without_members: bool | UndefinedType = Undefined,
-                only_configure_mlag_vrfs_peer_group_when_used: bool | UndefinedType = Undefined,
-                raise_for_underlay_router_with_uplink_type_port_channel: bool | UndefinedType = Undefined,
                 configure_inband_mgmt_ipv6_vrf: bool | UndefinedType = Undefined,
-                only_configure_ipv6_inband_mgmt_prefix_list_when_used: bool | UndefinedType = Undefined,
                 consistent_uplink_vlans: bool | UndefinedType = Undefined,
                 fix_radius_server_group_tls: bool | UndefinedType = Undefined,
+                only_configure_ipv6_inband_mgmt_prefix_list_when_used: bool | UndefinedType = Undefined,
+                only_configure_mlag_vrfs_peer_group_when_used: bool | UndefinedType = Undefined,
+                raise_for_port_channels_without_members: bool | UndefinedType = Undefined,
+                raise_for_underlay_router_with_uplink_type_port_channel: bool | UndefinedType = Undefined,
+                remove_redundant_ipv4_unicast_for_peer_groups: bool | UndefinedType = Undefined,
             ) -> None:
                 """
                 AvdDesignFuture.
@@ -1088,26 +1089,9 @@ class EosDesigns(EosDesignsRootModel):
                        Available from AVD 6.2.0.
                        Configure management interface to accept DHCP default route when the
                        management IP is set to 'dhcp'.
-                    remove_redundant_ipv4_unicast_for_peer_groups:
-                       Available from AVD 6.1.0.
-                       Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when
-                       IPv4 is activated by default instead of always deactivating it.
-                    raise_for_port_channels_without_members:
-                       Available from AVD 6.2.0.
-                       Raise an error if an L3 Port-Channel is configured without any member
-                       interfaces.
-                    only_configure_mlag_vrfs_peer_group_when_used:
-                       Available from AVD 6.2.0.
-                       Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
-                    raise_for_underlay_router_with_uplink_type_port_channel:
-                       Available from AVD 6.2.0.
-                       Raise an error if a node has both 'underlay_router: true' and
-                       'uplink_type: port-channel' set,
-                       since this combination is not supported.
                     configure_inband_mgmt_ipv6_vrf:
                        Available from AVD 6.2.0.
                        Configure `inband_mgmt_vrf` for IPv6 inband management.
-                    only_configure_ipv6_inband_mgmt_prefix_list_when_used: Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
                     consistent_uplink_vlans:
                        Available from AVD 6.2.0.
                        Always configure Port-Channel uplinks with consistent 'switchport trunk
@@ -1118,6 +1102,25 @@ class EosDesigns(EosDesignsRootModel):
                        Available from AVD 6.2.0.
                        Fix to configure TLS on RADIUS server group members to match their global
                        RADIUS server configurations.
+                    only_configure_ipv6_inband_mgmt_prefix_list_when_used:
+                       Available from AVD 6.2.0.
+                       Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
+                    only_configure_mlag_vrfs_peer_group_when_used:
+                       Available from AVD 6.2.0.
+                       Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
+                    raise_for_port_channels_without_members:
+                       Available from AVD 6.2.0.
+                       Raise an error if an L3 Port-Channel is configured without any member
+                       interfaces.
+                    raise_for_underlay_router_with_uplink_type_port_channel:
+                       Available from AVD 6.2.0.
+                       Raise an error if a node has both 'underlay_router: true' and
+                       'uplink_type: port-channel' set,
+                       since this combination is not supported.
+                    remove_redundant_ipv4_unicast_for_peer_groups:
+                       Available from AVD 6.1.0.
+                       Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when
+                       IPv4 is activated by default instead of always deactivating it.
 
                 """
 

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -992,39 +992,47 @@ class EosDesigns(EosDesignsRootModel):
         }
         accept_dhcp_default_route_for_mgmt_ip_dhcp: bool
         """
-        Configure management interface to accept DHCP default route when the management IP is set to 'dhcp'.
+        Available from AVD 6.2.0.
+        Configure management interface to accept DHCP default route when the
+        management IP is set to 'dhcp'.
 
         Default value: `False`
         """
         remove_redundant_ipv4_unicast_for_peer_groups: bool
         """
-        Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by
-        default instead of always deactivating it.
+        Available from AVD 6.1.0.
+        Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when
+        IPv4 is activated by default instead of always deactivating it.
 
         Default value: `False`
         """
         raise_for_port_channels_without_members: bool
         """
-        Raise an error if an L3 Port-Channel is configured without any member interfaces.
+        Available from AVD 6.2.0.
+        Raise an error if an L3 Port-Channel is configured without any member
+        interfaces.
 
         Default value: `False`
         """
         only_configure_mlag_vrfs_peer_group_when_used: bool
         """
+        Available from AVD 6.2.0.
         Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
 
         Default value: `False`
         """
         raise_for_underlay_router_with_uplink_type_port_channel: bool
         """
-        Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,
-        since
-        this combination is not supported.
+        Available from AVD 6.2.0.
+        Raise an error if a node has both 'underlay_router: true' and
+        'uplink_type: port-channel' set,
+        since this combination is not supported.
 
         Default value: `False`
         """
         configure_inband_mgmt_ipv6_vrf: bool
         """
+        Available from AVD 6.2.0.
         Configure `inband_mgmt_vrf` for IPv6 inband management.
 
         Default value: `False`
@@ -1037,16 +1045,19 @@ class EosDesigns(EosDesignsRootModel):
         """
         consistent_uplink_vlans: bool
         """
-        Always configure Port-Channel uplinks with consistent 'switchport trunk allowed' on both ends
-        and on
-        all 'uplink_switches' even when available VLANs differ between the 'uplink_switches'.
+        Available from AVD 6.2.0.
+        Always configure Port-Channel uplinks with consistent 'switchport trunk
+        allowed' on both ends
+        and on all 'uplink_switches' even when available VLANs differ between the
+        'uplink_switches'.
 
         Default value: `False`
         """
         fix_radius_server_group_tls: bool
         """
-        Fix to configure TLS on RADIUS server group members to match their global RADIUS server
-        configurations.
+        Available from AVD 6.2.0.
+        Fix to configure TLS on RADIUS server group members to match their global
+        RADIUS server configurations.
 
         Default value: `False`
         """
@@ -1073,25 +1084,40 @@ class EosDesigns(EosDesignsRootModel):
                 Subclass of AvdModel.
 
                 Args:
-                    accept_dhcp_default_route_for_mgmt_ip_dhcp: Configure management interface to accept DHCP default route when the management IP is set to 'dhcp'.
+                    accept_dhcp_default_route_for_mgmt_ip_dhcp:
+                       Available from AVD 6.2.0.
+                       Configure management interface to accept DHCP default route when the
+                       management IP is set to 'dhcp'.
                     remove_redundant_ipv4_unicast_for_peer_groups:
-                       Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by
-                       default instead of always deactivating it.
-                    raise_for_port_channels_without_members: Raise an error if an L3 Port-Channel is configured without any member interfaces.
-                    only_configure_mlag_vrfs_peer_group_when_used: Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
+                       Available from AVD 6.1.0.
+                       Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when
+                       IPv4 is activated by default instead of always deactivating it.
+                    raise_for_port_channels_without_members:
+                       Available from AVD 6.2.0.
+                       Raise an error if an L3 Port-Channel is configured without any member
+                       interfaces.
+                    only_configure_mlag_vrfs_peer_group_when_used:
+                       Available from AVD 6.2.0.
+                       Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
                     raise_for_underlay_router_with_uplink_type_port_channel:
-                       Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,
-                       since
-                       this combination is not supported.
-                    configure_inband_mgmt_ipv6_vrf: Configure `inband_mgmt_vrf` for IPv6 inband management.
+                       Available from AVD 6.2.0.
+                       Raise an error if a node has both 'underlay_router: true' and
+                       'uplink_type: port-channel' set,
+                       since this combination is not supported.
+                    configure_inband_mgmt_ipv6_vrf:
+                       Available from AVD 6.2.0.
+                       Configure `inband_mgmt_vrf` for IPv6 inband management.
                     only_configure_ipv6_inband_mgmt_prefix_list_when_used: Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
                     consistent_uplink_vlans:
-                       Always configure Port-Channel uplinks with consistent 'switchport trunk allowed' on both ends
-                       and on
-                       all 'uplink_switches' even when available VLANs differ between the 'uplink_switches'.
+                       Available from AVD 6.2.0.
+                       Always configure Port-Channel uplinks with consistent 'switchport trunk
+                       allowed' on both ends
+                       and on all 'uplink_switches' even when available VLANs differ between the
+                       'uplink_switches'.
                     fix_radius_server_group_tls:
-                       Fix to configure TLS on RADIUS server group members to match their global RADIUS server
-                       configurations.
+                       Available from AVD 6.2.0.
+                       Fix to configure TLS on RADIUS server group members to match their global
+                       RADIUS server configurations.
 
                 """
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -350,33 +350,43 @@ keys:
       accept_dhcp_default_route_for_mgmt_ip_dhcp:
         type: bool
         default: false
-        description: Configure management interface to accept DHCP default route when
-          the management IP is set to 'dhcp'.
+        description: 'Available from AVD 6.2.0.
+
+          Configure management interface to accept DHCP default route when the management
+          IP is set to ''dhcp''.'
       remove_redundant_ipv4_unicast_for_peer_groups:
         type: bool
-        description: Deactivate the IPv4 unicast Address Family for BGP Peer Groups
-          only when IPv4 is activated by default instead of always deactivating it.
+        description: 'Available from AVD 6.1.0.
+
+          Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when
+          IPv4 is activated by default instead of always deactivating it.'
         default: false
       raise_for_port_channels_without_members:
         type: bool
-        description: Raise an error if an L3 Port-Channel is configured without any
-          member interfaces.
+        description: 'Available from AVD 6.2.0.
+
+          Raise an error if an L3 Port-Channel is configured without any member interfaces.'
         default: false
       only_configure_mlag_vrfs_peer_group_when_used:
         type: bool
-        description: Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when
-          needed.
+        description: 'Available from AVD 6.2.0.
+
+          Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.'
         default: false
       raise_for_underlay_router_with_uplink_type_port_channel:
         type: bool
-        description: 'Raise an error if a node has both ''underlay_router: true''
-          and ''uplink_type: port-channel'' set,
+        description: 'Available from AVD 6.2.0.
+
+          Raise an error if a node has both ''underlay_router: true'' and ''uplink_type:
+          port-channel'' set,
 
           since this combination is not supported.'
         default: false
       configure_inband_mgmt_ipv6_vrf:
         type: bool
-        description: Configure `inband_mgmt_vrf` for IPv6 inband management.
+        description: 'Available from AVD 6.2.0.
+
+          Configure `inband_mgmt_vrf` for IPv6 inband management.'
         default: false
       only_configure_ipv6_inband_mgmt_prefix_list_when_used:
         type: bool
@@ -385,8 +395,10 @@ keys:
         default: false
       consistent_uplink_vlans:
         type: bool
-        description: 'Always configure Port-Channel uplinks with consistent ''switchport
-          trunk allowed'' on both ends
+        description: 'Available from AVD 6.2.0.
+
+          Always configure Port-Channel uplinks with consistent ''switchport trunk
+          allowed'' on both ends
 
           and on all ''uplink_switches'' even when available VLANs differ between
           the ''uplink_switches''.'
@@ -394,8 +406,10 @@ keys:
       fix_radius_server_group_tls:
         type: bool
         default: false
-        description: Fix to configure TLS on RADIUS server group members to match
-          their global RADIUS server configurations.
+        description: 'Available from AVD 6.2.0.
+
+          Fix to configure TLS on RADIUS server group members to match their global
+          RADIUS server configurations.'
   avd_digital_twin_mode:
     documentation_options:
       table: role-settings

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -354,44 +354,11 @@ keys:
 
           Configure management interface to accept DHCP default route when the management
           IP is set to ''dhcp''.'
-      remove_redundant_ipv4_unicast_for_peer_groups:
-        type: bool
-        description: 'Available from AVD 6.1.0.
-
-          Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when
-          IPv4 is activated by default instead of always deactivating it.'
-        default: false
-      raise_for_port_channels_without_members:
-        type: bool
-        description: 'Available from AVD 6.2.0.
-
-          Raise an error if an L3 Port-Channel is configured without any member interfaces.'
-        default: false
-      only_configure_mlag_vrfs_peer_group_when_used:
-        type: bool
-        description: 'Available from AVD 6.2.0.
-
-          Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.'
-        default: false
-      raise_for_underlay_router_with_uplink_type_port_channel:
-        type: bool
-        description: 'Available from AVD 6.2.0.
-
-          Raise an error if a node has both ''underlay_router: true'' and ''uplink_type:
-          port-channel'' set,
-
-          since this combination is not supported.'
-        default: false
       configure_inband_mgmt_ipv6_vrf:
         type: bool
         description: 'Available from AVD 6.2.0.
 
           Configure `inband_mgmt_vrf` for IPv6 inband management.'
-        default: false
-      only_configure_ipv6_inband_mgmt_prefix_list_when_used:
-        type: bool
-        description: Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when
-          it is needed.
         default: false
       consistent_uplink_vlans:
         type: bool
@@ -410,6 +377,40 @@ keys:
 
           Fix to configure TLS on RADIUS server group members to match their global
           RADIUS server configurations.'
+      only_configure_ipv6_inband_mgmt_prefix_list_when_used:
+        type: bool
+        description: 'Available from AVD 6.2.0.
+
+          Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.'
+        default: false
+      only_configure_mlag_vrfs_peer_group_when_used:
+        type: bool
+        description: 'Available from AVD 6.2.0.
+
+          Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.'
+        default: false
+      raise_for_port_channels_without_members:
+        type: bool
+        description: 'Available from AVD 6.2.0.
+
+          Raise an error if an L3 Port-Channel is configured without any member interfaces.'
+        default: false
+      raise_for_underlay_router_with_uplink_type_port_channel:
+        type: bool
+        description: 'Available from AVD 6.2.0.
+
+          Raise an error if a node has both ''underlay_router: true'' and ''uplink_type:
+          port-channel'' set,
+
+          since this combination is not supported.'
+        default: false
+      remove_redundant_ipv4_unicast_for_peer_groups:
+        type: bool
+        description: 'Available from AVD 6.1.0.
+
+          Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when
+          IPv4 is activated by default instead of always deactivating it.'
+        default: false
   avd_digital_twin_mode:
     documentation_options:
       table: role-settings

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_design_future.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_design_future.schema.yml
@@ -17,40 +17,11 @@ keys:
         description: |-
           Available from AVD 6.2.0.
           Configure management interface to accept DHCP default route when the management IP is set to 'dhcp'.
-      remove_redundant_ipv4_unicast_for_peer_groups:
-        type: bool
-        description: |-
-          Available from AVD 6.1.0.
-          Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it.
-        default: false
-      raise_for_port_channels_without_members:
-        type: bool
-        description: |-
-          Available from AVD 6.2.0.
-          Raise an error if an L3 Port-Channel is configured without any member interfaces.
-        default: false
-      only_configure_mlag_vrfs_peer_group_when_used:
-        type: bool
-        description: |-
-          Available from AVD 6.2.0.
-          Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
-        default: false
-      raise_for_underlay_router_with_uplink_type_port_channel:
-        type: bool
-        description: |-
-          Available from AVD 6.2.0.
-          Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,
-          since this combination is not supported.
-        default: false
       configure_inband_mgmt_ipv6_vrf:
         type: bool
         description: |-
           Available from AVD 6.2.0.
           Configure `inband_mgmt_vrf` for IPv6 inband management.
-        default: false
-      only_configure_ipv6_inband_mgmt_prefix_list_when_used:
-        type: bool
-        description: Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
         default: false
       consistent_uplink_vlans:
         type: bool
@@ -65,3 +36,34 @@ keys:
         description: |-
           Available from AVD 6.2.0.
           Fix to configure TLS on RADIUS server group members to match their global RADIUS server configurations.
+      only_configure_ipv6_inband_mgmt_prefix_list_when_used:
+        type: bool
+        description: |-
+          Available from AVD 6.2.0.
+          Configure `IPv6-PL-L2LEAF-INBAND-MGMT` prefix list only when it is needed.
+        default: false
+      only_configure_mlag_vrfs_peer_group_when_used:
+        type: bool
+        description: |-
+          Available from AVD 6.2.0.
+          Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
+        default: false
+      raise_for_port_channels_without_members:
+        type: bool
+        description: |-
+          Available from AVD 6.2.0.
+          Raise an error if an L3 Port-Channel is configured without any member interfaces.
+        default: false
+      raise_for_underlay_router_with_uplink_type_port_channel:
+        type: bool
+        description: |-
+          Available from AVD 6.2.0.
+          Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,
+          since this combination is not supported.
+        default: false
+      remove_redundant_ipv4_unicast_for_peer_groups:
+        type: bool
+        description: |-
+          Available from AVD 6.1.0.
+          Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it.
+        default: false

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_design_future.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_design_future.schema.yml
@@ -15,31 +15,38 @@ keys:
         type: bool
         default: false
         description: |-
+          Available from AVD 6.2.0.
           Configure management interface to accept DHCP default route when the management IP is set to 'dhcp'.
       remove_redundant_ipv4_unicast_for_peer_groups:
         type: bool
         description: |-
+          Available from AVD 6.1.0.
           Deactivate the IPv4 unicast Address Family for BGP Peer Groups only when IPv4 is activated by default instead of always deactivating it.
         default: false
       raise_for_port_channels_without_members:
         type: bool
         description: |-
+          Available from AVD 6.2.0.
           Raise an error if an L3 Port-Channel is configured without any member interfaces.
         default: false
       only_configure_mlag_vrfs_peer_group_when_used:
         type: bool
         description: |-
+          Available from AVD 6.2.0.
           Configure the `mlag_ipv4_vrfs_peer` BGP peer group only when needed.
         default: false
       raise_for_underlay_router_with_uplink_type_port_channel:
         type: bool
         description: |-
+          Available from AVD 6.2.0.
           Raise an error if a node has both 'underlay_router: true' and 'uplink_type: port-channel' set,
           since this combination is not supported.
         default: false
       configure_inband_mgmt_ipv6_vrf:
         type: bool
-        description: Configure `inband_mgmt_vrf` for IPv6 inband management.
+        description: |-
+          Available from AVD 6.2.0.
+          Configure `inband_mgmt_vrf` for IPv6 inband management.
         default: false
       only_configure_ipv6_inband_mgmt_prefix_list_when_used:
         type: bool
@@ -48,6 +55,7 @@ keys:
       consistent_uplink_vlans:
         type: bool
         description: |-
+          Available from AVD 6.2.0.
           Always configure Port-Channel uplinks with consistent 'switchport trunk allowed' on both ends
           and on all 'uplink_switches' even when available VLANs differ between the 'uplink_switches'.
         default: false
@@ -55,4 +63,5 @@ keys:
         type: bool
         default: false
         description: |-
+          Available from AVD 6.2.0.
           Fix to configure TLS on RADIUS server group members to match their global RADIUS server configurations.


### PR DESCRIPTION
## Change Summary

Add EOS Config and AVD Design future settings at the top of the release notes

## Related Issue(s)

Fixes #7043 

## Component(s) name

`documentation`

## Proposed changes

Insert the two tables

## How to test

Look at readthedocs output

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
