### PR TITLE
Doc(eos_designs): Fix wrong indentation for MAC ACLs Catalog

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
@@ -879,16 +879,16 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/ipv4-acls.md
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/ipv6-acls.md
 --8<--
 
-## MAC ACLs Catalog
-
---8<--
-ansible_collections/arista/avd/roles/eos_designs/docs/tables/mac-acls.md
---8<--
-
 ### IPv4 Prefix-List Catalog
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/ipv4-prefix-list-catalog.md
+--8<--
+
+### MAC ACLs Catalog
+
+--8<--
+ansible_collections/arista/avd/roles/eos_designs/docs/tables/mac-acls.md
 --8<--
 
 ## OSPF settings


### PR DESCRIPTION
## Change Summary

Cf title

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

correct indentation

## How to test

readthedoc

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
