### PR TITLE
Test(plugins): Bump pytest to 9.1.0 and fix failing tests

### DIFF
--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
@@ -350,7 +350,7 @@ class TestAVDActionPlugin:
             logger.addHandler(sticky_handler)
             # pytest 9.1.0 can attach multiple capture/live-log handlers to non-propagating loggers.
             # The plugin should restore all existing handlers, including pytest-owned handlers.
-            expected_handlers = original_handlers + [sticky_handler]
+            expected_handlers = [*original_handlers, sticky_handler]
 
             plugin = self._plugin_factory(ActionModule)
             plugin.run()

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
@@ -342,14 +342,22 @@ class TestAVDActionPlugin:
         # Create a "sticky" handler and add it to the AVD logger BEFORE the test
         logger = logging.getLogger("ansible_collections.arista.avd")
         sticky_handler = logging.StreamHandler()
-        logger.addHandler(sticky_handler)
+        original_handlers = logger.handlers[:]
+        original_level = logger.level
+        original_propagate = logger.propagate
 
-        plugin = self._plugin_factory(ActionModule)
-        plugin.run()
+        try:
+            logger.addHandler(sticky_handler)
+            # pytest 9.1.0 can attach multiple capture/live-log handlers to non-propagating loggers.
+            # The plugin should restore all existing handlers, including pytest-owned handlers.
+            expected_handlers = original_handlers + [sticky_handler]
 
-        # Assert that ONLY the sticky handler has been restored after execution
-        assert len(logger.handlers) == 1
-        assert logger.handlers[0] is sticky_handler
+            plugin = self._plugin_factory(ActionModule)
+            plugin.run()
 
-        # Final cleanup for other tests
-        logger.removeHandler(sticky_handler)
+            assert logger.handlers == expected_handlers
+            assert logger.level == original_level
+            assert logger.propagate == original_propagate
+        finally:
+            logger.removeHandler(sticky_handler)
+            sticky_handler.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ molecule = [
 pytest = [
     "ansible-core>=2.16.0,<2.22.0",
     "anta==1.8.0",
-    "pytest>=9.0.3",
+    "pytest>=9.1.0",
     "pytest-asyncio>=1.3.0",
     "pydantic>=2.11.10",
     "referencing>=0.37.0",


### PR DESCRIPTION
## Change Summary

* pytest 9.1.0 changed how it behaves on non propagating root loggers and showed that one of our tests was making bad assumptions 🗡️ 

## Related Issue(s)

Fixes Monday morning CI failure blues

## Component(s) name

`plugins`

## Proposed changes

* bump pytest to the latest and greatest 
* make the test more robust

## How to test

CI is 🍏 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
