### PR TITLE
CI: Update CI workflow using zizmor

### DIFF
--- a/.github/actions/rn-pr-labeler-action/action.yml
+++ b/.github/actions/rn-pr-labeler-action/action.yml
@@ -9,33 +9,31 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: 'Looking up existing "rn:" label'
+    - name: Label PR for release notes
+      env:
+        AUTO_CREATE_LABEL: ${{ inputs.auto_create_label }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
       run: |
-        echo "OLD_LABEL=$(gh pr view ${{ github.event.pull_request.number }} --json labels -q .labels[].name | grep 'rn: ')" >> $GITHUB_ENV
-      shell: bash
-    - name: 'Delete existing "rn:" label if found'
-      run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "${{ env.OLD_LABEL }}"
-      shell: bash
-      if: ${{ env.OLD_LABEL }}
-    - name: Set Label
-      # Using toJSON to support ' and " in commit messages
-      # https://stackoverflow.com/questions/73363167/github-actions-how-to-escape-characters-in-commit-message
-      run: echo "LABEL=$(echo ${{ toJSON(github.event.pull_request.title) }} | cut -d ':' -f 1 | tr -d ' ' | tr ',' '|')" >> $GITHUB_ENV
-      shell: bash
-      # an alternative to verifying if the target label already exist is to
-      # create the label with --force in the next step, it will keep on changing
-      # the color of the label though so it may not be desirable.
-    - name: Check if label exist
-      run: |
-        EXIST=$(gh label list -L 100 --search "rn:" --json name -q '.[] | select(.name=="rn: ${{ env.LABEL }}").name')
-        echo "EXIST=$EXIST" >> $GITHUB_ENV
-      shell: bash
-    - name: Create Label if auto-create and label does not exist already
-      run: |
-        gh label create "rn: ${{ env.LABEL }}"
-      shell: bash
-      if: ${{ inputs.auto_create_label  && ! env.EXIST }}
-    - name: Labelling PR
-      run: |
-        gh pr edit ${{ github.event.pull_request.number }} --add-label "rn: ${{ env.LABEL }}"
+        set -euo pipefail
+
+        old_label="$(gh pr view "$PR_NUMBER" --json labels -q '.labels[].name' | grep 'rn: ' || true)"
+        if [[ -n "$old_label" ]]; then
+          while IFS= read -r label; do
+            gh pr edit "$PR_NUMBER" --remove-label "$label"
+          done <<< "$old_label"
+        fi
+
+        label="$(printf '%s' "$PR_TITLE" | cut -d ':' -f 1 | tr -d ' ' | tr ',' '|')"
+        if [[ "$AUTO_CREATE_LABEL" == "true" ]]; then
+          existing_label="$(
+            gh label list -L 100 --search "rn:" --json name -q '.[] | select(.name | startswith("rn: ")) | .name' |
+              grep -Fx "rn: $label" || true
+          )"
+          if [[ -z "$existing_label" ]]; then
+            gh label create "rn: $label"
+          fi
+        fi
+
+        gh pr edit "$PR_NUMBER" --add-label "rn: $label"
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
     commit-message:
       prefix: "Bump(requirements): "
       prefix-development: "CI(requirements):"
+    cooldown:
+      default-days: 7
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -28,3 +30,5 @@ updates:
       day: "monday"
     commit-message:
       prefix: "CI: "
+    cooldown:
+      default-days: 7

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,28 +14,30 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Download coverage from pytest
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pytest-coverage
 
       - name: Download coverage from ansible-test units
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ansible-test-units-coverage
 
       - name: Download coverage from ansible-test integration
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ansible-test-integration-coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
           fail_ci_if_error: false

--- a/.github/workflows/container_build_base.yml
+++ b/.github/workflows/container_build_base.yml
@@ -17,6 +17,9 @@ name: Build base container
 jobs:
   build_base:
     if: github.repository == 'aristanetworks/avd'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:

--- a/.github/workflows/container_build_dev.yml
+++ b/.github/workflows/container_build_dev.yml
@@ -16,6 +16,9 @@ name: Build dev container
 jobs:
   build_dev_container:
     if: github.repository == 'aristanetworks/avd'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:

--- a/.github/workflows/container_build_fix.yml
+++ b/.github/workflows/container_build_fix.yml
@@ -28,6 +28,9 @@ name: Manual container build
 
 jobs:
   manual_container_build:
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/container_build_template.yml
     with:
       container_name: ${{ inputs.container_name }}

--- a/.github/workflows/container_build_template.yml
+++ b/.github/workflows/container_build_template.yml
@@ -6,7 +6,7 @@ name: Reusable build container workflow
 
 env:
   # BUILDX_NO_DEFAULT_ATTESTATIONS must be set to build only arm64 and amd64 images.
-  # The devcontainers/ci@v0.3 build will fail if this env variable is not set.
+  # The devcontainers/ci build will fail if this env variable is not set.
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
 
 "on":
@@ -63,51 +63,61 @@ env:
 jobs:
   build_image:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Starting container build
         run: echo "Starting container build. Be patient. 🐢"
       - name: Checkout code ✅
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       # Build image tags based on Python version and AVD version (if defined).
       # If container_tags is not defined, then image_tags will be auto-generated.
       # If container_tags is latest, it will be added to auto-generated image_tags.
       # If container_tags is defined and not latest, it will be used as-is.
       - name: Build image tags 🏷️
         id: build-tags
+        env:
+          CONTAINER_NAME: ${{ inputs.container_name }}
+          CONTAINER_TAGS: ${{ inputs.container_tags }}
+          PYTHON_VERSION: ${{ inputs.python_version }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ -z "${{ inputs.container_tags }}" ]; then
-            case ${{ inputs.container_name }} in
+          if [ -z "$CONTAINER_TAGS" ]; then
+            case "$CONTAINER_NAME" in
               base)
-                echo "image_tags=python${{ inputs.python_version }}" >> $GITHUB_OUTPUT
-                echo "image_version=python${{ inputs.python_version }}" >> $GITHUB_OUTPUT
+                echo "image_tags=python$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
+                echo "image_version=python$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
                 ;;
               dev)
-                echo "image_tags=python${{ inputs.python_version }}" >> $GITHUB_OUTPUT
-                echo "image_version=python${{ inputs.python_version }}" >> $GITHUB_OUTPUT
+                echo "image_tags=python$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
+                echo "image_version=python$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
                 ;;
               *)
-                echo "image_tags=python${{ inputs.python_version }}-avd-${{ github.ref_name }}" >> $GITHUB_OUTPUT
-                echo "image_version=python${{ inputs.python_version }}-avd-${{ github.ref_name }}" >> $GITHUB_OUTPUT
+                echo "image_tags=python$PYTHON_VERSION-avd-$REF_NAME" >> "$GITHUB_OUTPUT"
+                echo "image_version=python$PYTHON_VERSION-avd-$REF_NAME" >> "$GITHUB_OUTPUT"
                 ;;
             esac
           else
-            if [ "${{ inputs.container_tags }}" == "latest" ]; then
-              case ${{ inputs.container_name }} in
+            if [ "$CONTAINER_TAGS" == "latest" ]; then
+              case "$CONTAINER_NAME" in
                 base)
-                  echo "image_tags=latest,python${{ inputs.python_version }}" >> $GITHUB_OUTPUT
-                  echo "image_version=python${{ inputs.python_version }}" >> $GITHUB_OUTPUT
+                  echo "image_tags=latest,python$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "image_version=python$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
                   ;;
                 dev)
-                  echo "image_tags=latest,python${{ inputs.python_version }}" >> $GITHUB_OUTPUT
-                  echo "image_version=python${{ inputs.python_version }}" >> $GITHUB_OUTPUT
+                  echo "image_tags=latest,python$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
+                  echo "image_version=python$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
                   ;;
                 *)
-                  echo "image_tags=latest,python${{ inputs.python_version }}-avd-${{ github.ref_name }}" >> $GITHUB_OUTPUT
-                  echo "image_version=python${{ inputs.python_version }}-avd-${{ github.ref_name }}" >> $GITHUB_OUTPUT
+                  echo "image_tags=latest,python$PYTHON_VERSION-avd-$REF_NAME" >> "$GITHUB_OUTPUT"
+                  echo "image_version=python$PYTHON_VERSION-avd-$REF_NAME" >> "$GITHUB_OUTPUT"
                   ;;
               esac
             else
-              echo "image_tags=${{ inputs.container_tags }}" >> $GITHUB_OUTPUT
+              echo "image_tags=$CONTAINER_TAGS" >> "$GITHUB_OUTPUT"
             fi
           fi
 
@@ -119,14 +129,19 @@ jobs:
         # 3) All other images will be built from the base image.
         # 4) "from_image" and "from_variant" can be passed transparently to the build step,
         #    but that is not implemented currently.
+        env:
+          CONTAINER_NAME: ${{ inputs.container_name }}
+          FROM_IMAGE: ${{ inputs.from_image }}
+          PYTHON_VERSION: ${{ inputs.python_version }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if [ "${{ inputs.from_image }}" == "python" ]; then
-            if [ "${{ inputs.container_name }}" == "base" ]; then
-              echo "from_image=${{ inputs.from_image }}" >> $GITHUB_OUTPUT
-              echo "from_variant=${{ inputs.python_version }}-slim-bookworm" >> $GITHUB_OUTPUT
+          if [ "$FROM_IMAGE" == "python" ]; then
+            if [ "$CONTAINER_NAME" == "base" ]; then
+              echo "from_image=$FROM_IMAGE" >> "$GITHUB_OUTPUT"
+              echo "from_variant=$PYTHON_VERSION-slim-bookworm" >> "$GITHUB_OUTPUT"
             else
-              echo "from_image=ghcr.io/${{ github.repository }}/base" >> $GITHUB_OUTPUT
-              echo "from_variant=python${{ inputs.python_version }}" >> $GITHUB_OUTPUT
+              echo "from_image=ghcr.io/$REPOSITORY/base" >> "$GITHUB_OUTPUT"
+              echo "from_variant=python$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
             fi
           else
             echo "Only python-slim images are supported at the moment. Exiting."
@@ -135,17 +150,21 @@ jobs:
 
       - name: Find ansible and pyavd install location
         id: find-install-locations
+        env:
+          GITHUB_TAG: ${{ inputs.github_tag }}
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          if [ -z "${{ inputs.github_tag }}" ]; then
-            PYAVD_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git@${{ github.ref_name }}#subdirectory=python-avd"
-            ANSIBLE_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git#/ansible_collections/arista/avd/,${{ github.ref_name }}"
-            echo "ansible_install_location=$ANSIBLE_INSTALL_LOCATION" >> $GITHUB_OUTPUT
-            echo "pyavd_install_location=$PYAVD_INSTALL_LOCATION" >> $GITHUB_OUTPUT
+          if [ -z "$GITHUB_TAG" ]; then
+            PYAVD_INSTALL_LOCATION="git+https://github.com/$REPOSITORY.git@$REF_NAME#subdirectory=python-avd"
+            ANSIBLE_INSTALL_LOCATION="git+https://github.com/$REPOSITORY.git#/ansible_collections/arista/avd/,$REF_NAME"
+            echo "ansible_install_location=$ANSIBLE_INSTALL_LOCATION" >> "$GITHUB_OUTPUT"
+            echo "pyavd_install_location=$PYAVD_INSTALL_LOCATION" >> "$GITHUB_OUTPUT"
           else
-            PYAVD_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git@${{ inputs.github_tag }}#subdirectory=python-avd"
-            ANSIBLE_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git#/ansible_collections/arista/avd/,${{ inputs.github_tag }}"
-            echo "ansible_install_location=$ANSIBLE_INSTALL_LOCATION" >> $GITHUB_OUTPUT
-            echo "pyavd_install_location=$PYAVD_INSTALL_LOCATION" >> $GITHUB_OUTPUT
+            PYAVD_INSTALL_LOCATION="git+https://github.com/$REPOSITORY.git@$GITHUB_TAG#subdirectory=python-avd"
+            ANSIBLE_INSTALL_LOCATION="git+https://github.com/$REPOSITORY.git#/ansible_collections/arista/avd/,$GITHUB_TAG"
+            echo "ansible_install_location=$ANSIBLE_INSTALL_LOCATION" >> "$GITHUB_OUTPUT"
+            echo "pyavd_install_location=$PYAVD_INSTALL_LOCATION" >> "$GITHUB_OUTPUT"
           fi
 
       # This check is temporarily deactivated, will be rewised in later PRs
@@ -168,7 +187,7 @@ jobs:
 
       - name: Setup QEMU for multi-arch builds 🏗️
         # if: ${{ steps.check-image-presence.outputs.not_present == '1' }}
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         with:
           platforms: ${{ inputs.platform }}
           image: tonistiigi/binfmt:qemu-v9.2.2-52
@@ -177,11 +196,11 @@ jobs:
 
       - name: Setup Docker buildX for multi-arch builds 🏗️
         # if: ${{ steps.check-image-presence.outputs.not_present == '1' }}
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to Docker Hub 🗝️
         # if: ${{ steps.check-image-presence.outputs.not_present == '1' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -193,7 +212,7 @@ jobs:
 
       - name: Pre-build dev container image 🔨
         # if: ${{ steps.check-image-presence.outputs.not_present == '1' }}
-        uses: devcontainers/ci@v0.3
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3.1900000450
         env:
           FROM_IMAGE: ${{ steps.generate-from-parameters.outputs.from_image }}
           FROM_VARIANT: ${{ steps.generate-from-parameters.outputs.from_variant }}

--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -19,6 +19,9 @@ name: Build universal container
 jobs:
   build_universal_container:
     if: github.repository == 'aristanetworks/avd'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:

--- a/.github/workflows/new-cvp-integration.yml
+++ b/.github/workflows/new-cvp-integration.yml
@@ -4,6 +4,9 @@ name: "CV integration testing"
 # "on": pull_request
 "on": workflow_dispatch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
 
@@ -25,8 +28,10 @@ jobs:
     outputs:
       wheel_file: ${{ steps.build_step.outputs.wheel_file }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
             3.12
@@ -39,7 +44,7 @@ jobs:
           WHEEL_FILE=$(find ./dist/*.whl -print0 -type f | xargs -0 -n 1 basename)
           echo "wheel_file=/tmp/pyavd/$WHEEL_FILE" >> "$GITHUB_OUTPUT"
       - name: Upload pyavd artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pyavd
           path: ./python-avd/dist/*.whl
@@ -59,15 +64,19 @@ jobs:
         ansible_version:
           - "ansible-core<2.22.0 --upgrade"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: Install pyavd and Ansible requirements
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
-          python -m pip install "${{ matrix.ansible_version}}" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]" --group molecule
+          python -m pip install "${{ matrix.ansible_version}}" "$WHEEL_FILE[ansible-collection]" --group molecule
           ansible-galaxy install -r "ansible_collections/arista/avd/collections.yml"
       - name: Run molecule test
         working-directory: ansible_collections/arista/avd
@@ -92,15 +101,19 @@ jobs:
         ansible_version:
           - "ansible-core<2.22.0 --upgrade"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: Install pyavd and Ansible requirements
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
-          python -m pip install "${{ matrix.ansible_version}}" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]" --group molecule
+          python -m pip install "${{ matrix.ansible_version}}" "$WHEEL_FILE[ansible-collection]" --group molecule
           ansible-galaxy install -r "ansible_collections/arista/avd/collections.yml"
       - name: Run molecule test
         working-directory: ansible_collections/arista/avd

--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -1,7 +1,7 @@
 ---
 name: "Pull Request Comment"
 
-"on":
+"on": # zizmor: ignore[dangerous-triggers] Uses pull_request_target only to create a static reviewer help comment from PR metadata, not to check out or execute PR code.
   pull_request_target:
     types:
       - opened
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           BODY: |
             Review docs on [Read the Docs](https://ansible-avd--${{ github.event.pull_request.number }}.org.readthedocs.build/en/${{ github.event.pull_request.number }}/)
@@ -62,5 +62,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `${{ env.BODY }}`
+              body: process.env.BODY
             })

--- a/.github/workflows/pull-request-conflict.yml
+++ b/.github/workflows/pull-request-conflict.yml
@@ -1,5 +1,5 @@
 name: "PR Conflicts checker"
-"on":
+"on": # zizmor: ignore[dangerous-triggers] Uses pull_request_target only to label/comment on PR metadata, not to check out or execute PR code.
   pull_request_target:
     types: [synchronize]
 
@@ -7,9 +7,13 @@ jobs:
   Conflict_Check:
     name: "Check PR status: conflicts and resolution"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Check if PRs are dirty
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
         with:
           dirtyLabel: "state: conflict"
           removeOnDirtyLabel: "state: conflict resolved"

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -10,6 +10,9 @@ name: "Collection code testing"
     branches:
       - devel
 
+permissions:
+  contents: read
+
 concurrency:
   # For PRs the head_ref will be used. For Merge Queues (merge_group) we fallback to run_id.
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -45,8 +48,12 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: echo "$NEEDS_JSON" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'
 
   file-changes:
     runs-on: ubuntu-latest
@@ -57,8 +64,10 @@ jobs:
       requirements: ${{ steps.filter.outputs.requirements }}
       anta_runner: ${{ steps.filter.outputs.anta_runner }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -110,8 +119,10 @@ jobs:
     outputs:
       wheel_file: ${{ steps.build_step.outputs.wheel_file }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
             3.12
@@ -124,7 +135,7 @@ jobs:
           WHEEL_FILE=$(find ./dist/*.whl -print0 -type f | xargs -0 -n 1 basename)
           echo "wheel_file=/tmp/pyavd/$WHEEL_FILE" >> "$GITHUB_OUTPUT"
       - name: Upload pyavd artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pyavd
           path: ./python-avd/dist/*.whl
@@ -136,8 +147,10 @@ jobs:
     name: Python Linting not covered in pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install pyavd and Ansible requirements
@@ -145,7 +158,7 @@ jobs:
           pip install --group dev --group coverage --upgrade
       - name: PyRight static type checker
         # Specific SHA as allowed by github org admins
-        uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef
+        uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3.0.2
 
   # ----------------------------------- #
   # Test Requirements
@@ -165,19 +178,23 @@ jobs:
           - "3.13"
           - "3.14"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python_version }}
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: "Install Python requirements"
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
-          pip install "${{ needs.build_pyavd.outputs.wheel_file }}" --group dev --upgrade
+          pip install "$WHEEL_FILE" --group dev --upgrade
 
   # ----------------------------------- #
   # EOS CLI CONFIG GEN MOLECULE
@@ -207,19 +224,23 @@ jobs:
             ansible_version: "ansible-core==2.16.0"
             python_version: "3.11"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python_version }}
       - name: Install pyavd and Ansible requirements
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
-          python -m pip install "${{ matrix.ansible_version}}" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]" --group molecule
+          python -m pip install "${{ matrix.ansible_version}}" "$WHEEL_FILE[ansible-collection]" --group molecule
       - name: Run molecule test
         working-directory: ansible_collections/arista/avd
         run: |
@@ -302,19 +323,23 @@ jobs:
             python_version: "3.14"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python_version }}
       - name: Install pyavd and Ansible requirements
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
-          python -m pip install "${{ matrix.ansible_version}}" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]" --group molecule
+          python -m pip install "${{ matrix.ansible_version}}" "$WHEEL_FILE[ansible-collection]" --group molecule
       - name: Run molecule test
         working-directory: ansible_collections/arista/avd
         env:
@@ -333,14 +358,16 @@ jobs:
       needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true' || needs.file-changes.outputs.requirements == 'true' ||
       github.event_name == 'merge_group'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: Use Python 3.10 for minimum requirements
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
             3.10
@@ -349,13 +376,15 @@ jobs:
         # with jsonschema>=4.9.1 in molecule when using pip compile with lowest
         # Need to delete min_requirements afterwards otherwise git status is sad
         # pip upgrade to get dependency groups
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
           pip install uv
           uv pip compile python-avd/pyproject.toml --extra ansible-collection --resolution lowest-direct > /tmp/pyavd/min_requirements.txt
           cat /tmp/pyavd/min_requirements.txt
           pip install pip --upgrade
           python -m pip install --group molecule
-          python -m pip install "ansible-core==2.16.0" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]" -r /tmp/pyavd/min_requirements.txt
+          python -m pip install "ansible-core==2.16.0" "$WHEEL_FILE[ansible-collection]" -r /tmp/pyavd/min_requirements.txt
       - name: Run molecule test
         working-directory: ansible_collections/arista/avd
         run: |
@@ -390,19 +419,23 @@ jobs:
             ansible_version: "ansible-core==2.16.0"
             python_version: "3.11"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python_version }}
       - name: Install pyavd and Ansible requirements
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
-          python -m pip install "${{ matrix.ansible_version}}" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]" --group molecule
+          python -m pip install "${{ matrix.ansible_version}}" "$WHEEL_FILE[ansible-collection]" --group molecule
       - name: Run molecule test
         working-directory: ansible_collections/arista/avd
         run: |
@@ -441,20 +474,24 @@ jobs:
             python_version: |
               3.14
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
             ${{ matrix.python_version }}
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: Install pyavd and Ansible requirements
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
-          pip install "${{ matrix.pip_installation }}" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]"
+          pip install "${{ matrix.pip_installation }}" "$WHEEL_FILE[ansible-collection]"
       - name: Run ansible-test sanity
         working-directory: ansible_collections/arista/avd
         run: |
@@ -465,20 +502,24 @@ jobs:
     runs-on: ubuntu-latest
     needs: [file-changes, build_pyavd]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
             3.12
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: Install pyavd and ansible requirements
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
-          pip install "ansible-core<2.22.0" "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]"
+          pip install "ansible-core<2.22.0" "$WHEEL_FILE[ansible-collection]"
       - name: Run ansible-test units
         working-directory: ansible_collections/arista/avd
         run: |
@@ -486,7 +527,7 @@ jobs:
           ansible-test coverage xml
           mv tests/output/reports/coverage.xml ./units-coverage.xml
       - name: Upload coverage from ansible-test units
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ansible-test-units-coverage
           path: ansible_collections/arista/avd/units-coverage.xml
@@ -496,9 +537,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [file-changes]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           # Testing 3.10 to ensure ansible-core < 2.19 still works.
           python-version: |
@@ -516,7 +559,7 @@ jobs:
           ansible-test coverage xml
           mv tests/output/reports/coverage.xml ./integration-coverage.xml
       - name: Upload coverage from ansible-test integration
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ansible-test-integration-coverage
           path: ansible_collections/arista/avd/integration-coverage.xml
@@ -528,11 +571,13 @@ jobs:
     name: Build Ansible collection
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
             3.12
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Python & Ansible requirements
         run: |
           # distlib is required when using manifest
@@ -541,7 +586,7 @@ jobs:
         run: |
           ansible-galaxy collection build -vvv --force ansible_collections/arista/avd
       - name: Upload collection
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: avd-collection
           path: ./arista-avd-*.tar.gz
@@ -554,16 +599,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_collection]
     steps:
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
             3.11
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Python & Ansible requirements
         run: |
           pip install "ansible-core==2.16.0"
       - name: Download collection
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: avd-collection
       - name: Install galaxy-importer
@@ -574,7 +621,7 @@ jobs:
           pip install "galaxy-importer==0.4.31"
       - name: Run galaxy-importer checks
         run: python -m galaxy_importer.main *.tar.gz
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: importer-logs
           path: ./importer_result.json
@@ -590,9 +637,11 @@ jobs:
     env:
       ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: |
             3.10
@@ -601,15 +650,17 @@ jobs:
             3.13
             3.14
       - name: Download pyavd Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pyavd
           path: /tmp/pyavd/
       - name: Install Python & Ansible requirements
+        env:
+          WHEEL_FILE: ${{ needs.build_pyavd.outputs.wheel_file }}
         run: |
-          pip install "${{ needs.build_pyavd.outputs.wheel_file }}[ansible-collection]" --group dev --upgrade
+          pip install "$WHEEL_FILE[ansible-collection]" --group dev --upgrade
       - name: Download collection
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: avd-collection
       - name: Extract collection
@@ -628,8 +679,10 @@ jobs:
     name: Check for common misspellings in text files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install codespell
@@ -644,8 +697,10 @@ jobs:
     name: Check for linting errors on Jinja2 files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Install j2lint
@@ -660,7 +715,9 @@ jobs:
     name: Check for linting errors on Markdown files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install markdownlint-cli2
         run: npm install markdownlint-cli2 --global
       - name: Run markdownlint-cli2
@@ -676,8 +733,10 @@ jobs:
     name: Check for schema tables in documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
       - name: Check for schema tables in documentation
@@ -717,9 +776,11 @@ jobs:
             pytest_args: >-
               python-avd/tests/pyavd/molecule_scenarios/test_negative_eos_designs.py
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox
@@ -734,7 +795,7 @@ jobs:
           mv .coverage coverage-${{ matrix.suite.id }}.dat
       - name: Upload pytest coverage data
         if: matrix.python == '3.11'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-data-${{ matrix.suite.id }}
           path: coverage-${{ matrix.suite.id }}.dat
@@ -744,15 +805,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test_pyavd]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
       - name: Install coverage
         run: pip install --group coverage -e development/coverage_plugins
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -763,7 +826,7 @@ jobs:
           coverage report
           coverage xml
       - name: Upload pytest coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-coverage
           path: coverage.xml
@@ -775,4 +838,7 @@ jobs:
       - ansible_test_integration
       - generate_pyavd_coverage_report
     if: github.repository == 'aristanetworks/avd'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/codecov.yml

--- a/.github/workflows/pull-request-rn-labeler.yml
+++ b/.github/workflows/pull-request-rn-labeler.yml
@@ -2,7 +2,7 @@
 # changed post merge
 name: "Label for Release Notes"
 
-"on":
+"on": # zizmor: ignore[dangerous-triggers] Runs after merge or title edits and only uses trusted base-branch action code to maintain release-note labels.
   pull_request_target:
     types:
       - closed
@@ -19,8 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/rn-pr-labeler-action
         with:
           auto_create_label: true

--- a/.github/workflows/pull-request-rn-labeler.yml
+++ b/.github/workflows/pull-request-rn-labeler.yml
@@ -21,8 +21,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -1,7 +1,7 @@
 ---
 name: "Pull Request Triage"
 
-"on":
+"on": # zizmor: ignore[dangerous-triggers] Uses pull_request_target only for PR metadata assignment and title validation, not to check out or execute PR code.
   pull_request_target:
     types:
       - opened
@@ -21,7 +21,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v6
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: '.github/labeler.yml'
@@ -30,8 +30,11 @@ jobs:
     name: "Assign Author to PR"
     # https://github.com/marketplace/actions/auto-author-assign
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: toshimaru/auto-author-assign@v3.0.3
+      - uses: toshimaru/auto-author-assign@bdd7688cbf9e6d5683f02f8c7d8ae4062a254b6d # v3.0.2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
@@ -40,10 +43,12 @@ jobs:
   ###################################################
   Check_PR_semantic:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pull-request-triage.yml
+++ b/.github/workflows/pull-request-triage.yml
@@ -34,7 +34,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: toshimaru/auto-author-assign@bdd7688cbf9e6d5683f02f8c7d8ae4062a254b6d # v3.0.2
+      - uses: toshimaru/auto-author-assign@3e19bfc990cb1cf0589dce95e9f75289bb1e22de # v3.0.3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release-schema.yml
+++ b/.github/workflows/release-schema.yml
@@ -16,12 +16,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: refs/tags/${{ inputs.tag || github.event.release.tag_name }}
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -33,6 +34,7 @@ jobs:
         working-directory: python-avd
 
       - name: Upload schemas.json.gz to release
-        run: gh release upload ${{ inputs.tag || github.event.release.tag_name }} python-avd/pyavd/_schema/schemas.json.gz
+        run: gh release upload "$RELEASE_TAG" python-avd/pyavd/_schema/schemas.json.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,9 +1,13 @@
 ---
 name: Analysis with Sonarlint and publish to SonarCloud
-"on":
+"on": # zizmor: ignore[dangerous-triggers] Runs only after the collection test workflow completes successfully and checks out the triggering SHA for Sonar analysis.
   workflow_run:
     workflows: ["Collection code testing"]
     types: [completed]
+
+permissions:
+  actions: read
+  contents: read
 
 jobs:
   sonarcloud:
@@ -11,14 +15,15 @@ jobs:
     if: github.repository == 'aristanetworks/avd' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Download coverage from ansible-test units
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ansible-test-units-coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +33,7 @@ jobs:
 
       - name: Download coverage from ansible-test integration
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ansible-test-integration-coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -38,7 +43,7 @@ jobs:
 
       - name: Download coverage from pytest
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pytest-coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,7 +74,7 @@ jobs:
           echo "pr_branch=${PR_BRANCH}" >> "${GITHUB_OUTPUT}"
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v8.2.0
+        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -74,7 +74,7 @@ jobs:
           echo "pr_branch=${PR_BRANCH}" >> "${GITHUB_OUTPUT}"
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995 # v8.1.0
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,13 +3,17 @@ name: "Issue and PR stale management"
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     if: github.repository == 'aristanetworks/avd'
     steps:
       # Issue stale management
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 90

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -182,6 +182,15 @@ repos:
         name: Check for common misspellings in text files.
         args: [--config, .codespellrc]
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 9257c6050c0261b8c57e712f632dc4a8010109a9  # frozen: v1.25.2
+    hooks:
+      - id: zizmor
+        name: Check GitHub Actions with zizmor
+        files: ^\.github/
+        pass_filenames: false
+        args: [".github"]
+
   - repo: https://github.com/pdm-project/pdm
     rev: "0d939146d20336fda803dee0637253d8d3ea9bac"  # frozen: 2.27.0
     hooks:


### PR DESCRIPTION
## Component(s) name

`ci`

## Proposed changes

- Add zizmor pre-commit hook for GitHub Actions auditing
- Pin external GitHub Actions to verified latest-in-train SHAs
- Add explicit workflow permissions and disable checkout credential persistence
- Fix zizmor findings in CI workflows and release-note labeling action
- Add Dependabot cooldowns for dependency update scheduling


## How to test

CI is 🍏 
pre-commit.ci passes with zizmor

## Checklist

### Repository Checklist
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
