### PR TITLE
Doc(cv_deploy): Clarify limitation of the device replacement procedure

### DIFF
--- a/ansible_collections/arista/avd/roles/cv_deploy/README.md
+++ b/ansible_collections/arista/avd/roles/cv_deploy/README.md
@@ -58,6 +58,24 @@ The API to CloudVision is using gRPC over encrypted HTTP/2.
 
     ![Figure 1: Ansible Role arista.avd.cv_deploy](../../../../../docs/_media/studios_end_to_end_provisioning.png)
 
+- **CloudVision device replacement** is not fully supported when using the default flat-layout configuration deployment.
+  When CloudVision replaces a device using the
+  [Replace](https://www.arista.io/help/articles/provisioning-studios-built-in-inventory#cHJvdmlzaW9uaW5nLnN0dWRpby9UT1BPTE9HWQ==-replacing-devices)
+  workflow in the [Inventory & Topology Studio](https://www.arista.io/help/articles/provisioning-studios-built-in-inventory#inventory-and-topology-studio), it updates the serial number reference inside the existing Static Configuration Studio container.
+  On the next `cv_deploy` run, AVD creates a **new** container and configlet keyed to the new serial number. While the original container and
+  configlet become orphaned (from `cv_deploy` point of view), they are still associated with the replacement device through the updated query.
+
+  Choose one of the following approaches to avoid duplicate configlet assignment:
+
+  - **After replacement**: Manually delete (using CloudVision UI) the orphaned container and configlet from the Static Configuration Studio in CloudVision after
+    the replacement is complete but before running `cv_deploy` again.
+  - **Instead of replacement**: Use the CloudVision
+    [Decommission](https://www.arista.io/help/articles/provisioning-studios-built-in-inventory#cHJvdmlzaW9uaW5nLnN0dWRpby9UT1BPTE9HWQ==-decommissioning-devices-from-cloud-vision)
+    workflow to remove the old device first, then run `cv_deploy` again to onboard and apply the configuration to the replacement device.
+
+  The manifest-based deployment is **not affected** by this limitation, as it automatically removes unused/orphaned manifest-created containers and
+  configlets on each run.
+
 ## Roadmap
 
 This feature is still under development, so several planned features are not implemented yet.


### PR DESCRIPTION
## Change Summary

Clarify existing limitation of the original flat-layout `cv_deploy` workflow when dealing with CloudVision device replacement procedure (studio-oriented analogue of the network provisioning's ZTR)

## Related Issue(s)

Related to #7079

## Component(s) name

`arista.avd.cv_deploy`

## Proposed changes
Update documentation to list existing limitation of the flat-layout approach

## How to test
N/A

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
