### PR TITLE
CI: Fix BODY of comments after zizmor was merged

### DIFF
--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -25,7 +25,7 @@ jobs:
 
             To test this pull request:
 
-            \`\`\`sh
+            ```sh
             # Create virtual environment for this testing below the current directory
             python -m venv test-avd-pr-${{ github.event.pull_request.number }}
             # Activate the virtual environment
@@ -37,8 +37,8 @@ jobs:
             # Install Ansible collection
             python -m ansible.cli.galaxy collection install git+${{ github.event.pull_request.head.repo.clone_url }}#/ansible_collections/arista/avd/,${{ github.event.pull_request.head.ref }} --force
             cd test-avd-pr-${{ github.event.pull_request.number }}
-            # Run your playbook using \`python -m ansible.cli.playbook path/to/playbook.yml ...\`
-            \`\`\`
+            # Run your playbook using `python -m ansible.cli.playbook path/to/playbook.yml ...`
+            ```
 
             You can also test this PR using AVD playground:
             - Rebase your branch to makes sure it is up-to-date and has latest lab topologies for example inventories
@@ -47,14 +47,14 @@ jobs:
             - In the lab selector UI pick "I want to use a specific AVD fork"
             - Enter following parameters:
 
-            \`\`\`text
+            ```text
             GitHub org: ${{ github.event.pull_request.head.repo.owner.login }}
             Repository name: ${{ github.event.pull_request.head.repo.name }}
             Branch: ${{ github.event.pull_request.head.ref }}
-            \`\`\`
+            ```
 
             - Select an example inventory to test the PR
-            - Once the AVD Playground setup will be finished, type \`make start\` and test anything once the lab is up
+            - Once the AVD Playground setup will be finished, type `make start` and test anything once the lab is up
 
         with:
           script: |-


### PR DESCRIPTION
Help save the comments.

After moving to zizmor security the body of the comment don't need the wesape character no more or it renders badly (see latest PRs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved formatting of auto-generated pull-request comments with better code-fence rendering for code examples and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->