### PR TITLE
CI: migrate Codecov from flags to components

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,21 +17,24 @@ coverage:
         threshold: 0%
 
 comment:
-  layout: "reach,diff,flags,files"
+  layout: "reach,diff,components,files"
   behavior: default
   require_changes: true
 
-flags:
-  pyavd:
-    paths:
-      - python-avd/pyavd/
-      - python-avd/schema_tools/
-  ansible-test-units:
-    paths:
-      - ansible_collections/arista/avd/plugins/
-  ansible-test-integration:
-    paths:
-      - ansible_collections/arista/avd/plugins/
+component_management:
+  individual_components:
+    - component_id: pyavd
+      name: pyavd
+      paths:
+        - "python-avd/pyavd/"
+    - component_id: schema_tools
+      name: schema_tools
+      paths:
+        - "python-avd/schema_tools/"
+    - component_id: ansible_plugins
+      name: Ansible plugins
+      paths:
+        - "ansible_collections/arista/avd/plugins/"
 
 ignore:
   # Test directories


### PR DESCRIPTION
Codecov recommends using components instead of flags for new repository setups, and components match AVD's source-area coverage grouping better than upload-time flags.

Recommendation: https://docs.codecov.com/docs/components

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to use a new layout structure and component-based organization for improved coverage reporting and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->