### PR TITLE
Doc: Fix broken link and update galaxy.yml as recommended by RedHat

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AVD Documentation:
 
 ### Examples
 
-- [Getting started](https://avd.arista.com/stable/docs/getting-started/intro-to-ansible-and-avd.html)
+- [Getting started](https://avd.arista.com/stable/docs/user-manual/intro-to-ansible-and-avd.html)
 - [Examples](https://avd.arista.com/stable/ansible_collections/arista/avd/examples/single-dc-l3ls/index.html)
 
 ## Additional resources

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -71,7 +71,7 @@ pip3 install "pyavd[ansible-collection]==$ARISTA_AVD_VERSION"
 
 Please see the documentation for examples in data center, campus, and wide area network environments.
 
-- [Getting started](https://avd.arista.com/stable/docs/getting-started/intro-to-ansible-and-avd.html)
+- [Getting started](https://avd.arista.com/stable/docs/user-manual/intro-to-ansible-and-avd.html)
 - [Examples](https://avd.arista.com/stable/ansible_collections/arista/avd/examples/single-dc-l3ls/index.html)
 
 ### Testing

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -23,9 +23,8 @@ authors:
 # A short summary description of the collection
 description: Ansible Roles & Modules to support Arista AVD
 
-# The path to the license file for the collection. This path is relative to the root of the collection. This key is
-# mutually exclusive with 'license'
-license_file: "LICENSE"
+# The license of the collection
+license: ["Apache-2.0"]
 
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'


### PR DESCRIPTION
## Change Summary

feedback we received

During the review I noted one minor item for your awareness:

1. Broken link in README (advisory — not blocking)
   The "Getting started" link in the README points to:
   https://avd.arista.com/stable/docs/getting-started/intro-to-ansible-and-avd.html
   This URL currently returns HTTP 404. Please update this link to the correct
   location in a future version.

Additionally, a small suggestion: the `license` field in `galaxy.yml` is currently
empty (`license: []`), with the license instead declared via `license_file`. While
this is valid, setting `license: ["Apache-2.0"]` directly in `galaxy.yml` would
surface the license information in the Automation Hub UI for better visibility to
customers.

## Related Issue(s)

Reported by RedHat

## Component(s) name

`documentation`

## Proposed changes

cf title

## How to test

CI is green, links work

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](htxps://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Getting started" links in the main README and Ansible collection README to direct to stable documentation URL paths under the user manual section, replacing previous URL structures.

* **Chores**
  * Updated collection license metadata declaration in galaxy.yml, replacing the file reference approach with explicit Apache-2.0 license specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->