### PR TITLE
Fix(plugins): Report metadata version for installed AVD collections

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -330,26 +330,33 @@ def _get_collection_version(collection_path: str) -> str:
     return version
 
 
+def _get_git_command_output(command: list[str], collection_path: str) -> str | None:
+    """Return the output of a git command or None if git is unavailable or the command failed."""
+    try:
+        with Popen(command, stdout=PIPE, stderr=PIPE, cwd=collection_path) as process:  # noqa: S603
+            output, err = process.communicate()
+    except FileNotFoundError:
+        LOGGER.debug("Could not find 'git' executable, returning collection version")
+        return None
+
+    if process.returncode or err:
+        return None
+
+    return output.decode("UTF-8").strip()
+
+
 def _get_running_collection_version(running_collection_name: str, result: dict[str, Any]) -> None:
     """Stores the version collection in result."""
     collection_path = _get_collection_path(running_collection_name)
     version = _get_collection_version(collection_path)
 
-    try:
-        # Try to detect a git tag
-        # Using subprocess for now
-        with Popen(["git", "describe", "--tags"], stdout=PIPE, stderr=PIPE, cwd=collection_path) as process:  # noqa: S607
-            output, err = process.communicate()
-            if err:
-                # Not that when molecule runs, it runs in a copy of the directory that is not a git repo
-                # so only the latest tag is being returned
-                LOGGER.debug("Not a git repository")
-            else:
-                LOGGER.debug("This is a git repository, overwriting version with 'git describe --tags output'")
-                version = output.decode("UTF-8").strip()
-    except FileNotFoundError:
-        # Handle the case where `git` is not installed or not in the PATH
-        LOGGER.debug("Could not find 'git' executable, returning collection version")
+    if Path(collection_path, "MANIFEST.json").exists():
+        LOGGER.debug("Published collection detected, returning collection version")
+    elif not RUNNING_FROM_SOURCE:
+        LOGGER.debug("AVD is not running from source, returning collection version")
+    elif git_version := _get_git_command_output(["git", "describe", "--tags"], collection_path):
+        LOGGER.debug("Overwriting version with 'git describe --tags output'")
+        version = git_version
 
     result["collection"] = {
         "name": running_collection_name,

--- a/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
@@ -3,7 +3,6 @@
 # that can be found in the LICENSE file.
 
 import logging
-import os
 from importlib.metadata import PackageNotFoundError
 from itertools import repeat
 from pathlib import Path
@@ -269,27 +268,93 @@ def test__validate_ansible_collections(n_reqs: int, mocked_version: str | None, 
         assert ret == expected_return
 
 
-def test__get_running_collection_version_git_not_installed(caplog: pytest.LogCaptureFixture) -> None:
-    """Verify that when git is not found in PATH the function returns properly."""
-    # setting PATH to empty string to make sure git is not present
-    os.environ["PATH"] = ""
-    # setting ANSIBLE_VERBOSITY to trigger the log message when raising the exception
-    os.environ["ANSIBLE_VERBOSITY"] = "3"
+def test__get_running_collection_version_published_install_skips_git(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Verify that when MANIFEST.json is present the collection metadata version is returned."""
+    collection_path = tmp_path / "ansible_collections/arista/avd"
+    collection_path.mkdir(parents=True)
+    (collection_path / "MANIFEST.json").touch()
     result = {}
     with (
-        patch("ansible_collections.arista.avd.plugins.action.verify_requirements.Path") as patched_path,
         patch("ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_path") as patched__get_collection_path,
         patch(
             "ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_version",
         ) as patched__get_collection_version,
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements._get_git_command_output") as patched__get_git_command_output,
     ):
-        patched__get_collection_path.return_value = "."
+        patched__get_collection_path.return_value = str(collection_path)
         patched__get_collection_version.return_value = "42.0.0"
-        # TODO: Path is less kind than os.path was
-        patched_path.return_value = Path("/collections/foo/bar/__synthetic__/blah")
 
         with caplog.at_level(logging.DEBUG):
             _get_running_collection_version("dummy", result)
 
-    assert result == {"collection": {"name": "dummy", "path": "/collections/foo/bar", "version": "42.0.0"}}
+    assert result == {"collection": {"name": "dummy", "path": str(tmp_path / "ansible_collections"), "version": "42.0.0"}}
+    patched__get_git_command_output.assert_not_called()
+    assert "Published collection detected, returning collection version" in caplog.text
+
+
+def test__get_running_collection_version_git_not_installed(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Verify that when git is not found in PATH the function returns the collection metadata version."""
+    collection_path = tmp_path / "ansible_collections/arista/avd"
+    result = {}
+    with (
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements.RUNNING_FROM_SOURCE", new=True),
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_path") as patched__get_collection_path,
+        patch(
+            "ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_version",
+        ) as patched__get_collection_version,
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements.Popen", side_effect=FileNotFoundError),
+    ):
+        patched__get_collection_path.return_value = str(collection_path)
+        patched__get_collection_version.return_value = "42.0.0"
+
+        with caplog.at_level(logging.DEBUG):
+            _get_running_collection_version("dummy", result)
+
+    assert result == {"collection": {"name": "dummy", "path": str(tmp_path / "ansible_collections"), "version": "42.0.0"}}
     assert "Could not find 'git' executable, returning collection version" in caplog.text
+
+
+def test__get_running_collection_version_source_checkout_uses_git(tmp_path: Path) -> None:
+    """Verify that an AVD source checkout uses git describe for the running collection version."""
+    collection_path = tmp_path / "ansible_collections/arista/avd"
+    result = {}
+    with (
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements.RUNNING_FROM_SOURCE", new=True),
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_path") as patched__get_collection_path,
+        patch(
+            "ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_version",
+        ) as patched__get_collection_version,
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements._get_git_command_output") as patched__get_git_command_output,
+    ):
+        patched__get_collection_path.return_value = str(collection_path)
+        patched__get_collection_version.return_value = "42.0.0"
+        patched__get_git_command_output.return_value = "v42.0.1-1-gabcdef"
+
+        _get_running_collection_version("dummy", result)
+
+    assert result == {"collection": {"name": "dummy", "path": str(tmp_path / "ansible_collections"), "version": "v42.0.1-1-gabcdef"}}
+    patched__get_git_command_output.assert_called_once_with(["git", "describe", "--tags"], str(collection_path))
+
+
+def test__get_running_collection_version_not_running_from_source_skips_git(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Verify that non-source collections use the collection metadata version."""
+    customer_repo_path = tmp_path / "customer"
+    collection_path = customer_repo_path / "collections/ansible_collections/arista/avd"
+    result = {}
+    with (
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements.RUNNING_FROM_SOURCE", new=False),
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_path") as patched__get_collection_path,
+        patch(
+            "ansible_collections.arista.avd.plugins.action.verify_requirements._get_collection_version",
+        ) as patched__get_collection_version,
+        patch("ansible_collections.arista.avd.plugins.action.verify_requirements._get_git_command_output") as patched__get_git_command_output,
+    ):
+        patched__get_collection_path.return_value = str(collection_path)
+        patched__get_collection_version.return_value = "42.0.0"
+
+        with caplog.at_level(logging.DEBUG):
+            _get_running_collection_version("dummy", result)
+
+    assert result == {"collection": {"name": "dummy", "path": str(customer_repo_path / "collections/ansible_collections"), "version": "42.0.0"}}
+    patched__get_git_command_output.assert_not_called()
+    assert "AVD is not running from source, returning collection version" in caplog.text


### PR DESCRIPTION
## Change Summary

The verify_requirements action plugin used git describe --tags whenever the collection path was inside a Git repository. For collections installed from Galaxy, Automation Hub, or ansible-galaxy git sources, the installed collection contains MANIFEST.json and may live under a customer repository. In that layout git describe can report the enclosing repository tag instead of the AVD collection version.

Keep the collection metadata version for built or non-source installs, and only use git describe when AVD is explicitly running from source. This preserves useful source checkout version reporting while avoiding customer repository tags in the displayed AVD version.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

Reported by the field

## Proposed changes

In Manifest.json we trust. When this is present then we just render the version and don't even try git to avoid false positive

## How to test

These commands create a parent Git repository with a tag, install `arista.avd` inside it, and run `arista.avd.verify_requirements`.

  ```shell
  cd /tmp
  rm -rf avd-verify-requirements-repro
  mkdir avd-verify-requirements-repro
  cd avd-verify-requirements-repro

  # Create a parent/customer Git repository with a tag.
  git init
  git config user.name "AVD Test"
  git config user.email "avd-test@example.com"
  touch parent-repo-file
  git add parent-repo-file
  git commit -m "Initial parent repo commit"
  git tag v0.0.0-parent-repo-tag

  # Create a Python virtual environment with ansible-core.
  python3 -m venv .venv
  . .venv/bin/activate
  python -m pip install --upgrade pip
  python -m pip install ansible-core

  # Minimal playbook invoking verify_requirements directly.
  cat > verify.yml <<'EOF'
  ---
  - name: Verify AVD requirements
    hosts: localhost
    gather_facts: false
    tasks:
      - name: Run verify_requirements
        arista.avd.verify_requirements:
          requirements: []
        check_mode: false
        run_once: true
  EOF

  # Helper to run the playbook with collections installed below this parent repo.
  cat > run-verify.sh <<'EOF'
  #!/usr/bin/env bash
  set -euo pipefail

  ANSIBLE_COLLECTIONS_PATH="$PWD/collections" \
  ansible-playbook -i localhost, -c local verify.yml -v
  EOF
  chmod +x run-verify.sh
  ```

  ### 1. Install AVD from `devel` in the tagged parent repository

  On an unpatched version, this can show the parent repository tag from `git describe --tags`.

  ```shell
  rm -rf collections
  ansible-galaxy collection install arista.eos -p collections
  ansible-galaxy collection install \
    'git+https://github.com/aristanetworks/avd.git#/ansible_collections/arista/avd/,devel' \
    -p collections

  ./run-verify.sh
  ```

  Expected bad behavior before this PR: output may show the parent repo tag, for example:

  ```text
  AVD version v0.0.0-parent-repo-tag
  ```

  ### 2. Install AVD from Galaxy in the tagged parent repository

  On an unpatched version, this can also show the parent repository tag if the collection is installed below the tagged parent repo.

  ```shell
  rm -rf collections
  ansible-galaxy collection install arista.eos -p collections
  ansible-galaxy collection install arista.avd -p collections

  ./run-verify.sh
  ```

  Expected bad behavior before this PR: output may show the parent repo tag instead of the installed collection version.

  ### 3. Install AVD with this PR and verify the fix

  Replace `<PR_REF>` with the PR branch, commit SHA, or reviewer checkout ref.

  ```shell
  rm -rf collections
  ansible-galaxy collection install arista.eos -p collections
  ansible-galaxy collection install \
    'git+https://github.com/aristanetworks/avd.git#/ansible_collections/arista/avd/,<PR_REF>' \
    -p collections

  ./run-verify.sh
  ```

  Expected behavior with this PR: output shows the installed collection metadata version, not the parent repository tag, for example:

  ```text
  AVD version 6.3.0-dev0
  ```

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced collection version detection to more accurately distinguish between published installations and source checkouts.
  * Improved fallback handling to ensure reliable operation when Git is unavailable, preventing unnecessary version override attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->