### PR TITLE
Refactor(eos_cli_config_gen): Preserve the 'edge' keyword 'spanning-tree portfast edge'

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host6.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host6.md
@@ -8,6 +8,9 @@
   - [SNMP](#snmp)
 - [Monitor Layer 1 Logging](#monitor-layer-1-logging)
   - [Monitor Layer 1 Device Configuration](#monitor-layer-1-device-configuration)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+  - [Port-Channel Interfaces](#port-channel-interfaces)
 - [Routing](#routing)
   - [IP Routing](#ip-routing)
   - [IPv6 Routing](#ipv6-routing)
@@ -83,6 +86,62 @@ snmp-server host 10.6.75.121 vrf MGMT version 2c SNMP-COMMUNITY-2
 !
 monitor layer1
    logging mac fault
+```
+
+## Interfaces
+
+### Ethernet Interfaces
+
+#### Ethernet Interfaces Summary
+
+##### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet1 | Test portfast edge keyword | - | - | - | - | - |
+| Ethernet2 | Test portfast network keyword | - | - | - | - | - |
+
+*Inherited from Port-Channel Interface
+
+#### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet1
+   description Test portfast edge keyword
+   switchport
+   spanning-tree portfast edge
+!
+interface Ethernet2
+   description Test portfast network keyword
+   switchport
+   spanning-tree portfast network
+```
+
+### Port-Channel Interfaces
+
+#### Port-Channel Interfaces Summary
+
+##### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | --------------------- | ------------------ | ------- | -------- |
+| Port-Channel1 | Test portfast edge keyword | - | - | - | - | - | - | - | - |
+| Port-Channel2 | Test portfast network keyword | - | - | - | - | - | - | - | - |
+
+#### Port-Channel Interfaces Device Configuration
+
+```eos
+!
+interface Port-Channel1
+   description Test portfast edge keyword
+   switchport
+   spanning-tree portfast edge
+!
+interface Port-Channel2
+   description Test portfast network keyword
+   switchport
+   spanning-tree portfast network
 ```
 
 ## Routing

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host6.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host6.cfg
@@ -11,6 +11,26 @@ vrf instance TENANT_A
 !
 vrf instance TENANT_B
 !
+interface Port-Channel1
+   description Test portfast edge keyword
+   switchport
+   spanning-tree portfast edge
+!
+interface Port-Channel2
+   description Test portfast network keyword
+   switchport
+   spanning-tree portfast network
+!
+interface Ethernet1
+   description Test portfast edge keyword
+   switchport
+   spanning-tree portfast edge
+!
+interface Ethernet2
+   description Test portfast network keyword
+   switchport
+   spanning-tree portfast network
+!
 interface Management1
    description OOB_MANAGEMENT
    vrf MGMT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host6/eos-config-future.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host6/eos-config-future.yml
@@ -3,4 +3,4 @@ eos_config_future:
   always_render_ip_routing_separator: true
   render_monitor_layer1_without_enabled: true
   only_render_mpls_rsvp_with_settings: true
-  render_spanning_tree_portfast_edge_keyword: true
+  render_spanning_tree_portfast_edge: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host6/eos-config-future.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host6/eos-config-future.yml
@@ -3,3 +3,4 @@ eos_config_future:
   always_render_ip_routing_separator: true
   render_monitor_layer1_without_enabled: true
   only_render_mpls_rsvp_with_settings: true
+  render_spanning_tree_portfast_edge_keyword: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host6/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host6/ethernet-interfaces.yml
@@ -1,0 +1,12 @@
+---
+ethernet_interfaces:
+  - name: Ethernet1
+    description: Test portfast edge keyword
+    switchport:
+      enabled: true
+    spanning_tree_portfast: edge
+  - name: Ethernet2
+    description: Test portfast network keyword
+    switchport:
+      enabled: true
+    spanning_tree_portfast: network

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host6/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host6/port-channel-interfaces.yml
@@ -1,0 +1,12 @@
+---
+port_channel_interfaces:
+  - name: Port-Channel1
+    description: Test portfast edge keyword
+    switchport:
+      enabled: true
+    spanning_tree_portfast: edge
+  - name: Port-Channel2
+    description: Test portfast network keyword
+    switchport:
+      enabled: true
+    spanning_tree_portfast: network

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md
@@ -13,7 +13,7 @@
     | [<samp>&nbsp;&nbsp;new_ip_tacacs_cli_order</samp>](## "eos_config_future.new_ip_tacacs_cli_order") | Boolean |  | `False` |  | Available from AVD 6.1.0.<br>When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.<br>When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source interface name. |
     | [<samp>&nbsp;&nbsp;only_render_mpls_rsvp_with_settings</samp>](## "eos_config_future.only_render_mpls_rsvp_with_settings") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is defined.<br>When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined, even if no sub-settings are set. |
     | [<samp>&nbsp;&nbsp;render_monitor_layer1_without_enabled</samp>](## "eos_config_future.render_monitor_layer1_without_enabled") | Boolean |  | `False` |  | Available from AVD 6.3.0.<br>When `true`, renders the `monitor layer1` CLI block only if `monitor_layer1.logging_transceiver.*` / `monitor_layer1.logging_mac_fault` sub-setting is `true` no matter the value of `monitor_layer1.enabled` is `true` or `false`.<br>When `false` (default), renders the `monitor layer1` cli block only if `monitor_layer1.enabled` is `true`. |
-    | [<samp>&nbsp;&nbsp;render_spanning_tree_portfast_edge_keyword</samp>](## "eos_config_future.render_spanning_tree_portfast_edge_keyword") | Boolean |  | `False` |  | Available from AVD 6.3.0.<br>When `true`, renders `spanning-tree portfast edge` on `ethernet_interfaces` and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`, matching the running-config preserved by EOS 4.33.2F and later.<br>When `false` (default), renders the legacy `spanning-tree portfast` without the `edge` keyword. |
+    | [<samp>&nbsp;&nbsp;render_spanning_tree_portfast_edge</samp>](## "eos_config_future.render_spanning_tree_portfast_edge") | Boolean |  | `False` |  | Available from AVD 6.3.0.<br>When `true`, renders `spanning-tree portfast edge` on `ethernet_interfaces` and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`, matching the running-config preserved by EOS 4.33.2F and later.<br>When `false` (default), renders the legacy `spanning-tree portfast` without the `edge` keyword. |
 
 === "YAML"
 
@@ -49,5 +49,5 @@
       # Available from AVD 6.3.0.
       # When `true`, renders `spanning-tree portfast edge` on `ethernet_interfaces` and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`, matching the running-config preserved by EOS 4.33.2F and later.
       # When `false` (default), renders the legacy `spanning-tree portfast` without the `edge` keyword.
-      render_spanning_tree_portfast_edge_keyword: <bool; default=False>
+      render_spanning_tree_portfast_edge: <bool; default=False>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/eos-config-future.md
@@ -13,6 +13,7 @@
     | [<samp>&nbsp;&nbsp;new_ip_tacacs_cli_order</samp>](## "eos_config_future.new_ip_tacacs_cli_order") | Boolean |  | `False` |  | Available from AVD 6.1.0.<br>When `true`, renders the new EOS CLI order using `ip_tacacs`, sorted by VRF name.<br>When `false` (default), renders the legacy CLI order using `ip_tacacs_source_interfaces`, sorted by source interface name. |
     | [<samp>&nbsp;&nbsp;only_render_mpls_rsvp_with_settings</samp>](## "eos_config_future.only_render_mpls_rsvp_with_settings") | Boolean |  | `False` |  | Available from AVD 6.2.0.<br>When `true`, only renders the `mpls rsvp` CLI block when at least one `mpls.rsvp.*` setting is defined.<br>When `false` (default), renders `mpls rsvp` whenever `mpls.rsvp` is defined, even if no sub-settings are set. |
     | [<samp>&nbsp;&nbsp;render_monitor_layer1_without_enabled</samp>](## "eos_config_future.render_monitor_layer1_without_enabled") | Boolean |  | `False` |  | Available from AVD 6.3.0.<br>When `true`, renders the `monitor layer1` CLI block only if `monitor_layer1.logging_transceiver.*` / `monitor_layer1.logging_mac_fault` sub-setting is `true` no matter the value of `monitor_layer1.enabled` is `true` or `false`.<br>When `false` (default), renders the `monitor layer1` cli block only if `monitor_layer1.enabled` is `true`. |
+    | [<samp>&nbsp;&nbsp;render_spanning_tree_portfast_edge_keyword</samp>](## "eos_config_future.render_spanning_tree_portfast_edge_keyword") | Boolean |  | `False` |  | Available from AVD 6.3.0.<br>When `true`, renders `spanning-tree portfast edge` on `ethernet_interfaces` and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`, matching the running-config preserved by EOS 4.33.2F and later.<br>When `false` (default), renders the legacy `spanning-tree portfast` without the `edge` keyword. |
 
 === "YAML"
 
@@ -44,4 +45,9 @@
       # When `true`, renders the `monitor layer1` CLI block only if `monitor_layer1.logging_transceiver.*` / `monitor_layer1.logging_mac_fault` sub-setting is `true` no matter the value of `monitor_layer1.enabled` is `true` or `false`.
       # When `false` (default), renders the `monitor layer1` cli block only if `monitor_layer1.enabled` is `true`.
       render_monitor_layer1_without_enabled: <bool; default=False>
+
+      # Available from AVD 6.3.0.
+      # When `true`, renders `spanning-tree portfast edge` on `ethernet_interfaces` and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`, matching the running-config preserved by EOS 4.33.2F and later.
+      # When `false` (default), renders the legacy `spanning-tree portfast` without the `edge` keyword.
+      render_spanning_tree_portfast_edge_keyword: <bool; default=False>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -918,7 +918,7 @@ interface {{ ethernet_interface.name }}
    no logging event storm-control discards
 {%     endif %}
 {%     if ethernet_interface.spanning_tree_portfast is arista.avd.defined('edge') %}
-{%         if eos_config_future.render_spanning_tree_portfast_edge_keyword is arista.avd.defined(true) %}
+{%         if eos_config_future.render_spanning_tree_portfast_edge is arista.avd.defined(true) %}
    spanning-tree portfast edge
 {%         else %}
    spanning-tree portfast

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -918,7 +918,11 @@ interface {{ ethernet_interface.name }}
    no logging event storm-control discards
 {%     endif %}
 {%     if ethernet_interface.spanning_tree_portfast is arista.avd.defined('edge') %}
+{%         if eos_config_future.render_spanning_tree_portfast_edge_keyword is arista.avd.defined(true) %}
+   spanning-tree portfast edge
+{%         else %}
    spanning-tree portfast
+{%         endif %}
 {%     elif ethernet_interface.spanning_tree_portfast is arista.avd.defined('network') %}
    spanning-tree portfast network
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -759,7 +759,11 @@ interface {{ port_channel_interface.name }}
    no logging event storm-control discards
 {%     endif %}
 {%     if port_channel_interface.spanning_tree_portfast is arista.avd.defined("edge") %}
+{%         if eos_config_future.render_spanning_tree_portfast_edge_keyword is arista.avd.defined(true) %}
+   spanning-tree portfast edge
+{%         else %}
    spanning-tree portfast
+{%         endif %}
 {%     elif port_channel_interface.spanning_tree_portfast is arista.avd.defined("network") %}
    spanning-tree portfast network
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -759,7 +759,7 @@ interface {{ port_channel_interface.name }}
    no logging event storm-control discards
 {%     endif %}
 {%     if port_channel_interface.spanning_tree_portfast is arista.avd.defined("edge") %}
-{%         if eos_config_future.render_spanning_tree_portfast_edge_keyword is arista.avd.defined(true) %}
+{%         if eos_config_future.render_spanning_tree_portfast_edge is arista.avd.defined(true) %}
    spanning-tree portfast edge
 {%         else %}
    spanning-tree portfast

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -6556,7 +6556,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "new_ip_tacacs_cli_order": {"type": bool, "default": False},
             "only_render_mpls_rsvp_with_settings": {"type": bool, "default": False},
             "render_monitor_layer1_without_enabled": {"type": bool, "default": False},
-            "render_spanning_tree_portfast_edge_keyword": {"type": bool, "default": False},
+            "render_spanning_tree_portfast_edge": {"type": bool, "default": False},
         }
         always_render_ip_routing_separator: bool
         """
@@ -6608,7 +6608,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
         Default value: `False`
         """
-        render_spanning_tree_portfast_edge_keyword: bool
+        render_spanning_tree_portfast_edge: bool
         """
         Available from AVD 6.3.0.
         When `true`, renders `spanning-tree portfast edge` on
@@ -6630,7 +6630,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 new_ip_tacacs_cli_order: bool | UndefinedType = Undefined,
                 only_render_mpls_rsvp_with_settings: bool | UndefinedType = Undefined,
                 render_monitor_layer1_without_enabled: bool | UndefinedType = Undefined,
-                render_spanning_tree_portfast_edge_keyword: bool | UndefinedType = Undefined,
+                render_spanning_tree_portfast_edge: bool | UndefinedType = Undefined,
             ) -> None:
                 """
                 EosConfigFuture.
@@ -6669,7 +6669,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        matter the value of `monitor_layer1.enabled` is `true` or `false`.
                        When `false` (default), renders
                        the `monitor layer1` cli block only if `monitor_layer1.enabled` is `true`.
-                    render_spanning_tree_portfast_edge_keyword:
+                    render_spanning_tree_portfast_edge:
                        Available from AVD 6.3.0.
                        When `true`, renders `spanning-tree portfast edge` on
                        `ethernet_interfaces` and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`,

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -6556,6 +6556,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "new_ip_tacacs_cli_order": {"type": bool, "default": False},
             "only_render_mpls_rsvp_with_settings": {"type": bool, "default": False},
             "render_monitor_layer1_without_enabled": {"type": bool, "default": False},
+            "render_spanning_tree_portfast_edge_keyword": {"type": bool, "default": False},
         }
         always_render_ip_routing_separator: bool
         """
@@ -6607,6 +6608,17 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
         Default value: `False`
         """
+        render_spanning_tree_portfast_edge_keyword: bool
+        """
+        Available from AVD 6.3.0.
+        When `true`, renders `spanning-tree portfast edge` on
+        `ethernet_interfaces` and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`,
+        matching the running-config preserved by EOS 4.33.2F and later.
+        When `false` (default), renders the
+        legacy `spanning-tree portfast` without the `edge` keyword.
+
+        Default value: `False`
+        """
 
         if TYPE_CHECKING:
 
@@ -6618,6 +6630,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 new_ip_tacacs_cli_order: bool | UndefinedType = Undefined,
                 only_render_mpls_rsvp_with_settings: bool | UndefinedType = Undefined,
                 render_monitor_layer1_without_enabled: bool | UndefinedType = Undefined,
+                render_spanning_tree_portfast_edge_keyword: bool | UndefinedType = Undefined,
             ) -> None:
                 """
                 EosConfigFuture.
@@ -6656,6 +6669,13 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        matter the value of `monitor_layer1.enabled` is `true` or `false`.
                        When `false` (default), renders
                        the `monitor layer1` cli block only if `monitor_layer1.enabled` is `true`.
+                    render_spanning_tree_portfast_edge_keyword:
+                       Available from AVD 6.3.0.
+                       When `true`, renders `spanning-tree portfast edge` on
+                       `ethernet_interfaces` and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`,
+                       matching the running-config preserved by EOS 4.33.2F and later.
+                       When `false` (default), renders the
+                       legacy `spanning-tree portfast` without the `edge` keyword.
 
                 """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -2648,7 +2648,7 @@ keys:
 
           When `false` (default), renders the `monitor layer1` cli block only if `monitor_layer1.enabled`
           is `true`.'
-      render_spanning_tree_portfast_edge_keyword:
+      render_spanning_tree_portfast_edge:
         type: bool
         default: false
         description: 'Available from AVD 6.3.0.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -2648,6 +2648,17 @@ keys:
 
           When `false` (default), renders the `monitor layer1` cli block only if `monitor_layer1.enabled`
           is `true`.'
+      render_spanning_tree_portfast_edge_keyword:
+        type: bool
+        default: false
+        description: 'Available from AVD 6.3.0.
+
+          When `true`, renders `spanning-tree portfast edge` on `ethernet_interfaces`
+          and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`,
+          matching the running-config preserved by EOS 4.33.2F and later.
+
+          When `false` (default), renders the legacy `spanning-tree portfast` without
+          the `edge` keyword.'
   errdisable:
     type: dict
     keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_config_future.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_config_future.schema.yml
@@ -46,3 +46,10 @@ keys:
           Available from AVD 6.3.0.
           When `true`, renders the `monitor layer1` CLI block only if `monitor_layer1.logging_transceiver.*` / `monitor_layer1.logging_mac_fault` sub-setting is `true` no matter the value of `monitor_layer1.enabled` is `true` or `false`.
           When `false` (default), renders the `monitor layer1` cli block only if `monitor_layer1.enabled` is `true`.
+      render_spanning_tree_portfast_edge_keyword:
+        type: bool
+        default: false
+        description: |-
+          Available from AVD 6.3.0.
+          When `true`, renders `spanning-tree portfast edge` on `ethernet_interfaces` and `port_channel_interfaces` when `spanning_tree_portfast` is set to `edge`, matching the running-config preserved by EOS 4.33.2F and later.
+          When `false` (default), renders the legacy `spanning-tree portfast` without the `edge` keyword.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_config_future.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_config_future.schema.yml
@@ -46,7 +46,7 @@ keys:
           Available from AVD 6.3.0.
           When `true`, renders the `monitor layer1` CLI block only if `monitor_layer1.logging_transceiver.*` / `monitor_layer1.logging_mac_fault` sub-setting is `true` no matter the value of `monitor_layer1.enabled` is `true` or `false`.
           When `false` (default), renders the `monitor layer1` cli block only if `monitor_layer1.enabled` is `true`.
-      render_spanning_tree_portfast_edge_keyword:
+      render_spanning_tree_portfast_edge:
         type: bool
         default: false
         description: |-


### PR DESCRIPTION
## Change Summary

Preserve the 'edge' keyword 'spanning-tree portfast edge'

## Related Issue(s)

Fixes #7151 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added future knob `render_spanning_tree_portfast_edge` and updated the template logic to render config based on the future knob

## How to test
Added molecule test

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for rendering `spanning-tree portfast edge` for Ethernet and Port-Channel interfaces when enabled.
  * Introduced a new configuration option to control the CLI form used for portfast edge behavior.

* **Documentation**
  * Updated interface documentation with Ethernet and Port-Channel examples and navigation.
  * Added docs for the new configuration option and its behavior.

* **Bug Fixes**
  * Aligns generated interface output with newer EOS running-config formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->