### PR TITLE
Doc: Invert MkDocs exclusions to include docs content

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -44,6 +44,7 @@ jobs:
       - codespell
       - j2lint
       - check_schema_tables_in_docs
+      - check_built_docs_links
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -62,6 +63,7 @@ jobs:
       pyavd: ${{ steps.filter.outputs.pyavd }}
       requirements: ${{ steps.filter.outputs.requirements }}
       anta_runner: ${{ steps.filter.outputs.anta_runner }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -108,6 +110,17 @@ jobs:
               - 'python-avd/pyavd/api/_anta/*'
               - 'python-avd/pyavd/api/_anta/**/*'
               - 'python-avd/pyavd/get_device_anta_catalog.py'
+            docs:
+              - '.github/workflows/pull-request-management.yml'
+              - '.readthedocs.yaml'
+              - 'development/check_built_docs_links.py'
+              - 'docs/**'
+              - 'mkdocs.yml'
+              - 'pyproject.toml'
+              - 'ansible_collections/arista/avd/examples/**'
+              - 'ansible_collections/arista/avd/roles/*/README.md'
+              - 'ansible_collections/arista/avd/roles/*/docs/**'
+              - 'schemas/**'
 
   # -------------------------------------- #
   # Build PyAVD wheel and upload artifact
@@ -722,6 +735,28 @@ jobs:
           python-version: "3.12"
       - name: Check for schema tables in documentation
         run: python development/find_missing_tables.py @.find-missing-tables-args
+
+  # ----------------------------------- #
+  # Check links in built docs
+  # ----------------------------------- #
+  check_built_docs_links:
+    name: Check links in built documentation
+    runs-on: ubuntu-latest
+    needs: [file-changes]
+    if: needs.file-changes.outputs.docs == 'true' || github.event_name == 'merge_group'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+      - name: Install documentation dependencies
+        run: pip install --group doc --upgrade
+      - name: Build documentation
+        run: mkdocs build --strict --clean --site-dir /tmp/avd-doc-site
+      - name: Check internal links in built documentation
+        run: python development/check_built_docs_links.py /tmp/avd-doc-site
 
   # ----------------------------------- #
   # Test of pyavd

--- a/development/check_built_docs_links.py
+++ b/development/check_built_docs_links.py
@@ -115,7 +115,7 @@ def resolve_target(site_dir: Path, source: Path, target: str) -> tuple[Path, str
 
     if relative_target.as_posix() in {"", "."}:
         relative_target = PurePosixPath("index.html")
-    elif target.endswith("/"):
+    elif path.endswith("/"):
         relative_target /= "index.html"
 
     return site_dir / Path(relative_target), fragment

--- a/development/check_built_docs_links.py
+++ b/development/check_built_docs_links.py
@@ -28,6 +28,7 @@ LINK_ATTRS = {
     "video": ("poster", "src"),
 }
 
+
 @dataclass(frozen=True)
 class Link:
     source: Path

--- a/development/check_built_docs_links.py
+++ b/development/check_built_docs_links.py
@@ -27,8 +27,6 @@ LINK_ATTRS = {
     "track": ("src",),
     "video": ("poster", "src"),
 }
-IGNORED_SCHEMES = {"data", "http", "https", "javascript", "mailto", "tel"}
-
 
 @dataclass(frozen=True)
 class Link:
@@ -96,7 +94,7 @@ def srcset_urls(srcset: str) -> list[str]:
 
 def is_internal_url(url: str) -> bool:
     parsed = urlsplit(url)
-    return not parsed.scheme and not parsed.netloc and parsed.scheme not in IGNORED_SCHEMES
+    return not parsed.scheme and not parsed.netloc
 
 
 def resolve_target(site_dir: Path, source: Path, target: str) -> tuple[Path, str]:

--- a/development/check_built_docs_links.py
+++ b/development/check_built_docs_links.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# ruff: noqa: INP001
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import sys
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path, PurePosixPath
+from urllib.parse import unquote, urlsplit
+
+LINK_ATTRS = {
+    "a": ("href",),
+    "area": ("href",),
+    "audio": ("src",),
+    "embed": ("src",),
+    "iframe": ("src",),
+    "img": ("src", "srcset"),
+    "link": ("href",),
+    "object": ("data",),
+    "script": ("src",),
+    "source": ("src", "srcset"),
+    "track": ("src",),
+    "video": ("poster", "src"),
+}
+IGNORED_SCHEMES = {"data", "http", "https", "javascript", "mailto", "tel"}
+
+
+@dataclass(frozen=True)
+class Link:
+    source: Path
+    target: str
+    line: int
+    attribute: str
+
+
+class BuiltDocsParser(HTMLParser):
+    def __init__(self, source: Path) -> None:
+        super().__init__(convert_charrefs=True)
+        self.source = source
+        self.anchors: set[str] = set()
+        self.links: list[Link] = []
+        self._in_config_script = False
+        self._config_script_data: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_dict = {name: value for name, value in attrs if value is not None}
+
+        if tag == "script" and attrs_dict.get("id") == "__config":
+            self._in_config_script = True
+            self._config_script_data = []
+
+        for anchor_attr in ("id", "name"):
+            if anchor_attr in attrs_dict:
+                self.anchors.add(attrs_dict[anchor_attr])
+
+        for attr in LINK_ATTRS.get(tag, ()):
+            value = attrs_dict.get(attr)
+            if not value:
+                continue
+            if attr == "srcset":
+                self.links.extend(Link(self.source, target, self.getpos()[0], attr) for target in srcset_urls(value))
+            else:
+                self.links.append(Link(self.source, value, self.getpos()[0], attr))
+
+    def handle_data(self, data: str) -> None:
+        if self._in_config_script:
+            self._config_script_data.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag != "script" or not self._in_config_script:
+            return
+        self._in_config_script = False
+        try:
+            config = json.loads("".join(self._config_script_data))
+        except json.JSONDecodeError:
+            return
+        search_worker = config.get("search")
+        if isinstance(search_worker, str):
+            self.links.append(Link(self.source, search_worker, self.getpos()[0], "script#__config.search"))
+
+
+def srcset_urls(srcset: str) -> list[str]:
+    urls: list[str] = []
+    for srcset_candidate in srcset.split(","):
+        stripped_candidate = srcset_candidate.strip()
+        if not stripped_candidate:
+            continue
+        urls.append(stripped_candidate.split()[0])
+    return urls
+
+
+def is_internal_url(url: str) -> bool:
+    parsed = urlsplit(url)
+    return not parsed.scheme and not parsed.netloc and parsed.scheme not in IGNORED_SCHEMES
+
+
+def resolve_target(site_dir: Path, source: Path, target: str) -> tuple[Path, str]:
+    parsed = urlsplit(target)
+    fragment = unquote(parsed.fragment)
+    path = unquote(parsed.path)
+
+    if not path:
+        return source, fragment
+
+    if path.startswith("/"):
+        relative_target = PurePosixPath(path.removeprefix("/"))
+    else:
+        source_relative_dir = source.relative_to(site_dir).parent.as_posix()
+        relative_target = PurePosixPath(posixpath.normpath(posixpath.join(source_relative_dir, path)))
+
+    if relative_target.as_posix() in {"", "."}:
+        relative_target = PurePosixPath("index.html")
+    elif target.endswith("/"):
+        relative_target /= "index.html"
+
+    return site_dir / Path(relative_target), fragment
+
+
+def parse_html_files(site_dir: Path, ignored_html_patterns: list[str]) -> tuple[dict[Path, set[str]], list[Link]]:
+    anchors_by_file: dict[Path, set[str]] = {}
+    links: list[Link] = []
+    for html_file in sorted(site_dir.rglob("*.html")):
+        html_file_relative = html_file.relative_to(site_dir).as_posix()
+        if any(PurePosixPath(html_file_relative).match(pattern) for pattern in ignored_html_patterns):
+            continue
+        parser = BuiltDocsParser(html_file)
+        parser.feed(html_file.read_text(encoding="utf-8"))
+        anchors_by_file[html_file] = parser.anchors
+        links.extend(parser.links)
+    return anchors_by_file, links
+
+
+def format_path(path: Path, site_dir: Path) -> str:
+    try:
+        return path.relative_to(site_dir).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def check_links(site_dir: Path, *, check_anchors: bool, ignored_html_patterns: list[str]) -> list[str]:
+    anchors_by_file, links = parse_html_files(site_dir, ignored_html_patterns)
+    errors: list[str] = []
+
+    for link in links:
+        if not is_internal_url(link.target):
+            continue
+
+        target_path, fragment = resolve_target(site_dir, link.source, link.target)
+        if not target_path.exists():
+            errors.append(
+                f"{format_path(link.source, site_dir)}:{link.line}: {link.attribute} points to missing file {link.target!r} "
+                f"(resolved as {format_path(target_path, site_dir)!r})"
+            )
+            continue
+
+        if check_anchors and fragment and target_path.suffix == ".html" and fragment not in anchors_by_file.get(target_path, set()):
+            errors.append(
+                f"{format_path(link.source, site_dir)}:{link.line}: {link.attribute} points to missing anchor {link.target!r} "
+                f"in {format_path(target_path, site_dir)!r}"
+            )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check internal links in a built MkDocs site.")
+    parser.add_argument("site_dir", type=Path, help="Path to the built site directory.")
+    parser.add_argument(
+        "--check-anchors",
+        action="store_true",
+        help="Also validate URL fragments against anchors in generated HTML. This is disabled by default until existing generated ## links are fixed.",
+    )
+    parser.add_argument(
+        "--ignore-html",
+        action="append",
+        default=["docs/overrides/*.html"],
+        help="Generated-site HTML glob to skip while checking links. Can be supplied multiple times.",
+    )
+    args = parser.parse_args()
+
+    site_dir = args.site_dir.resolve()
+    if not site_dir.is_dir():
+        print(f"Site directory does not exist: {site_dir}", file=sys.stderr)  # noqa: T201
+        return 2
+
+    errors = check_links(site_dir, check_anchors=args.check_anchors, ignored_html_patterns=args.ignore_html)
+    if errors:
+        print("\n--- Built Documentation Link Check: FAILED ---", file=sys.stderr)  # noqa: T201
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    print("Success: all internal links in the built documentation resolve.")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,33 @@ site_description: Arista AVD documentation
 copyright: Copyright &copy; 2019 - 2025 Arista Networks
 strict: true
 exclude_docs: |
-  /README.md
+  # Deny everything, then re-include only doc content.
+  # Snippet targets (tables, .cfg artifacts, molecule files, example configs)
+  # are read directly from disk by pymdownx.snippets and do not need
+  # to be part of the MkDocs build.
+  *
+
+  # --- Root ---
+  !/index.md
+
+  # --- docs/ tree (bulk of the site) ---
+  !/docs/**
+  /docs/release-notes/[1-5].*
+  /docs/porting-guides/[4-5].*
+  /docs/pyavd/simple_example_*
+
+  # --- Ansible collection roles ---
+  !/ansible_collections/arista/avd/roles/*/README.md
+  !/ansible_collections/arista/avd/roles/*/docs/**
+  /ansible_collections/arista/avd/roles/*/docs/tables/*
+  /ansible_collections/arista/avd/roles/eos_designs/docs/node-type-variables.md
+
+  # --- Ansible collection examples ---
+  !/ansible_collections/arista/avd/examples/README.md
+  !/ansible_collections/arista/avd/examples/*/README.md
+  /ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/README.md
+  !/ansible_collections/arista/avd/examples/*/images/**
+  !/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/**
 
 # Repository information
 repo_name: AVD on Github
@@ -67,59 +93,6 @@ extra_javascript:
   - docs/stylesheets/sticky-banner.js
 
 plugins:
-  - exclude:
-      glob:
-        - README.md
-        - contributing.md
-        - pylintrc-ansible
-        - ansible_collections/arista/avd/bindep.txt
-        - ansible_collections/arista/avd/CHANGELOG.rst
-        - ansible_collections/arista/avd/CNAME
-        - ansible_collections/arista/avd/collections.yml
-        - ansible_collections/arista/avd/galaxy.yml
-        - ansible_collections/arista/avd/LICENSE
-        - ansible_collections/arista/avd/pytest.ini
-        - ansible_collections/arista/avd/README.md
-        - ansible_collections/arista/avd/requirements.txt
-        - ansible_collections/arista/avd/meta/*
-        - ansible_collections/arista/avd/playbooks/*
-        - ansible_collections/arista/avd/plugins/*
-        - ansible_collections/arista/avd/changelogs/*
-        - ansible_collections/arista/avd/extensions/molecule/*
-        - ansible_collections/arista/avd/tests/*
-        - ansible_collections/arista/avd/plugins/README.md
-        - docs/release-notes/1.0.x.md
-        - docs/release-notes/1.1.x.md
-        - docs/release-notes/2.x.x.md
-        - docs/release-notes/3.x.x.md
-        - docs/release-notes/4.x.x.md
-        - docs/release-notes/5.x.x.md
-        - docs/porting-guides/4.x.x.md
-        - docs/porting-guides/5.x.x.md
-        - docs/pyavd/simple_example_5_to_6.md
-        - docs/pyavd/simple_example_5_x.md
-        - docs/pyavd/simple_example_6_x.md
-        - ansible_collections/arista/avd/roles/*/docs/tables/*
-        # Exclude the table used only as a snippet to avoid mkdocs info log
-        - ansible_collections/arista/avd/roles/eos_designs/docs/node-type-variables.md
-
-        - development/*
-        - galaxy-importer/*
-        - python-avd/*
-      regex:
-        # Exclude examples common md snippets
-        - 'ansible_collections\/arista\/avd\/examples\/common/.*'
-        # Exclude all examples but single-dc-l3ls which is referenced in getting getting-started
-        - 'ansible_collections\/arista\/avd\/examples\/((?!single-dc-l3ls).*)\/documentation\/.*'
-        # Previous regex matches the ipv6 scenario
-        - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls-ipv6/documentation\/.*'
-        - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls-ipv6/README.md'
-        # Exclude all single-dc-l3ls files not referenced in getting getting-started
-        - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls\/documentation\/fabric\/((?!FABRIC-documentation.md).*)'
-        - 'ansible_collections\/arista\/avd\/examples\/single-dc-l3ls\/documentation\/devices\/((?!dc1-leaf1a.md).*)'
-        - ".*.py$"
-        - ".*.pyc$"
-        - ".*.j2$"
   - include_dir_to_nav
   - git-revision-date-localized:
       type: date

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,6 +221,8 @@ nav:
       - Versioning: docs/versioning/semantic-versioning.md
 # Indicates which files should be added to the build site but not present in nav.
 not_in_nav: |-
+  # These generated example docs are linked from docs/user-manual/intro-to-ansible-and-avd.md
+  # and must be built, but they should not appear in the navigation.
   /ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/fabric/FABRIC-documentation.md
   /ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
   /docs/contribution/eos_designs_facts_internal/tables/eos_designs_facts.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ exclude_docs: |
   # are read directly from disk by pymdownx.snippets and do not need
   # to be part of the MkDocs build.
   *
+  !/assets/**
 
   # --- Root ---
   !/index.md
@@ -32,7 +33,13 @@ exclude_docs: |
   !/ansible_collections/arista/avd/examples/*/README.md
   /ansible_collections/arista/avd/examples/single-dc-l3ls-ipv6/README.md
   !/ansible_collections/arista/avd/examples/*/images/**
-  !/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/**
+  !/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/fabric/FABRIC-documentation.md
+  !/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
+
+  # --- Source-only files in otherwise included trees ---
+  /**/*.j2
+  /**/*.py
+  /**/*.pyc
 
 # Repository information
 repo_name: AVD on Github
@@ -214,7 +221,8 @@ nav:
       - Versioning: docs/versioning/semantic-versioning.md
 # Indicates which files should be added to the build site but not present in nav.
 not_in_nav: |-
-  /ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/*
+  /ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/fabric/FABRIC-documentation.md
+  /ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
   /docs/contribution/eos_designs_facts_internal/tables/eos_designs_facts.md
   /ansible_collections/arista/avd/roles/cvp_configlet_upload/README.md
   /ansible_collections/arista/avd/roles/dhcp_provisioner/README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ doc = [
     "mike==1.1.2",
     "mkdocs-git-revision-date-localized-plugin",
     "mkdocs-git-revision-date-plugin",
-    "mkdocs-exclude",
     "mkdocs-include-dir-to-nav",
     "mkdocstrings[python]",
 ]


### PR DESCRIPTION
## Change Summary

Replace the long `mkdocs-exclude` plugin configuration with an include-first `exclude_docs` strategy.

## Related Issue(s)

Fixes #6744

## Component(s) name

`documentation`

## Proposed changes

- Keep only documentation content in the MkDocs build while leaving snippet-only files available on disk.
- Remove the `mkdocs-exclude` plugin configuration from `mkdocs.yml`.
- Remove the unused `mkdocs-exclude` docs dependency from `pyproject.toml`.

## How to test

- `uv run --group doc mkdocs build --strict --clean --site-dir /tmp/avd-6744-mkdocs-site`

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a merge-gating CI check that builds the documentation site and validates internal links (and optionally anchors) to catch broken references early.
* **Bug Fixes**
  * Improved documentation inclusion/exclusion rules so the intended pages appear correctly in the published navigation.
* **Documentation**
  * Refined MkDocs configuration to more precisely control what’s treated as documentation versus excluded content (while keeping assets excluded).
* **Chores**
  * Updated documentation build dependency group by removing an unused MkDocs exclusion package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->