### PR TITLE
CI: Remove pytest warnings

### DIFF
--- a/python-avd/tests/pyavd/j2filters/test_range_expand.py
+++ b/python-avd/tests/pyavd/j2filters/test_range_expand.py
@@ -13,7 +13,7 @@ from pyavd.j2filters import range_expand
 RANGE_TO_EXPAND_INVALID_VALUES = [
     pytest.param(True, TypeError, "value must be a Sequence, got <class 'bool'>", id="Wrong input type - bool"),
     pytest.param({"key": "value"}, TypeError, "value must be a Sequence, got <class 'dict'>", id="Wrong input type - dict"),
-    pytest.param(33, TypeError, "", id="Wrong input type - int"),
+    pytest.param(33, TypeError, "value must be a Sequence, got <class 'int'>: 33", id="Wrong input type - int"),
     pytest.param(
         "Ethernet4-2",
         ValueError,

--- a/python-avd/tests/pyavd/molecule_scenarios/conftest.py
+++ b/python-avd/tests/pyavd/molecule_scenarios/conftest.py
@@ -43,7 +43,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             molecule_scenarios.append(MOLECULE_SCENARIOS[molecule_scenario_extended_name])
 
     if "molecule_host" in metafunc.fixturenames:
-        metafunc.parametrize("molecule_host", chain.from_iterable(scenario.hosts for scenario in molecule_scenarios), ids=get_test_id)
+        metafunc.parametrize("molecule_host", list(chain.from_iterable(scenario.hosts for scenario in molecule_scenarios)), ids=get_test_id)
 
     if "molecule_scenario" in metafunc.fixturenames:
         metafunc.parametrize("molecule_scenario", molecule_scenarios, ids=get_test_id)


### PR DESCRIPTION
## Change Summary

Address current warnings in our CI (to be future proof for pytest 10.x)

## Related Issue(s)

Fixes #7110 

## Component(s) name

`ci`

## Proposed changes

* Not using iterator anymore but lists
* fixing the empty match

## How to test

CI is 🍏  and no more pytest warnings

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for invalid input handling by checking for a more specific error message.
  * Adjusted test data generation for molecule scenarios to use a fully materialized host list, keeping test execution consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->