### PR TITLE
CI: Move pre-commit run in autofix workflow

### DIFF
--- a/.github/workflows/pull-request-autofix.yml
+++ b/.github/workflows/pull-request-autofix.yml
@@ -29,12 +29,20 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Run pre-commit
+      - name: Run pre-commit autofix pass
+        id: pre_commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         continue-on-error: true
         with:
-          # Only run markdownlint for now, until all pre-commit.ci hooks are migrated to autofix.ci.
-          extra_args: markdownlint-cli2 --all-files
+          extra_args: --all-files
+
+      - name: Fail if pre-commit failed without fixes
+        if: steps.pre_commit.outcome == 'failure'
+        run: |
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "pre-commit failed and did not produce changes for autofix.ci to commit."
+            exit 1
+          fi
 
       - name: Commit back any git diff
         uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -41,9 +41,6 @@ jobs:
       - galaxy_importer
       - ansible_lint
       - test_pyavd
-      - codespell
-      - j2lint
-      - check_schema_tables_in_docs
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -670,58 +667,6 @@ jobs:
         working-directory: collections
         run: |
           ansible-lint --force-color --strict -v
-
-  # ----------------------------------- #
-  # Codespell
-  # ----------------------------------- #
-  codespell:
-    name: Check for common misspellings in text files
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Install codespell
-        run: pip install codespell==2.4.2
-      - name: Run codespell
-        run: codespell --config .codespellrc
-
-  # ----------------------------------- #
-  # j2lint
-  # ----------------------------------- #
-  j2lint:
-    name: Check for linting errors on Jinja2 files
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Install j2lint
-        run: pip install j2lint==1.2.0
-      - name: Run j2lint
-        run: j2lint .
-
-  # ----------------------------------- #
-  # Check schema tables in docs
-  # ----------------------------------- #
-  check_schema_tables_in_docs:
-    name: Check for schema tables in documentation
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Check for schema tables in documentation
-        run: python development/find_missing_tables.py @.find-missing-tables-args
 
   # ----------------------------------- #
   # Test of pyavd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,33 @@
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
   autoupdate_commit_msg: "CI: pre-commit autoupdate"
-  skip: [pyright, codespell, j2lint, markdownlint-cli2, check-schema-tables-in-docs]
+  autofix_prs: false
+  # Keep pre-commit.ci for autoupdate only. Run hooks through autofix.ci.
+  skip:
+    - trailing-whitespace
+    - end-of-file-fixer
+    - check-added-large-files
+    - check-merge-conflict
+    - insert-license
+    - ruff
+    - ruff-format
+    - pyright
+    - pylint
+    - yamllint
+    - j2lint
+    - codespell
+    - zizmor
+    - pdm-export
+    - docs-plugin-modules
+    - docs-plugin-filter
+    - docs-plugin-lookup
+    - docs-plugin-test
+    - docs-plugin-vars
+    - schemas
+    - check-schema-tables-in-docs
+    - sort-hosts-yml
+    - templates
+    - markdownlint-cli2
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Contributing pull requests are gladly welcomed for this repository. If you are p
 
 You can also open an [issue](https://github.com/aristanetworks/avd/issues) to report any problems or submit enhancements.
 
+<!-- Intentional autofix workflow test typo: teh -->
+
 ## License
 
 Copyright (c) 2019-2026 Arista Networks, Inc.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ Contributing pull requests are gladly welcomed for this repository. If you are p
 
 You can also open an [issue](https://github.com/aristanetworks/avd/issues) to report any problems or submit enhancements.
 
-<!-- Intentional autofix workflow test typo: teh -->
-
 ## License
 
 Copyright (c) 2019-2026 Arista Networks, Inc.


### PR DESCRIPTION
## Change Summary

Move pre-commit hook execution from pre-commit.ci to autofix.ci while keeping pre-commit.ci for autoupdates only.

## Related Issue(s)

Fixes #7199

## Component(s) name

`ci`

## Proposed changes

- Update pull-request-autofix.yml to run pre-commit --all-files instead of only markdownlint-cli2.
- Allow autofix.ci to commit generated/fixed changes back to PR branches.
- Fail the autofix workflow when pre-commit fails.
- Configure pre-commit.ci with autofix_prs: false.
- Skip all hooks in pre-commit.ci so hook execution is owned by autofix.ci.

## How to test

CI is 🍏  and pre-commit issues are blocking CI (will make a commit that does this to demonstrate)

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Expanded pull request automation to run a broader set of automated fixes and improved failure messaging when no meaningful changes are produced.
  * Updated CI hook configuration to reduce redundant or conflicting automated checks and align the required merge gates with the streamlined workflow.
  * Adjusted required checks so fewer auxiliary linting steps are needed for merge approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->