### PR TITLE
CI: Jinja coverage for last if in a nested if condition

### DIFF
--- a/development/coverage_plugins/coverage_plugins/jinja/source_template.py
+++ b/development/coverage_plugins/coverage_plugins/jinja/source_template.py
@@ -113,6 +113,11 @@ def covered_structural_control_branch_arcs(
     No-else ``if`` statements use the source ``endif`` line as the false branch
     target. Jinja may report the runtime jump from the last line in a multiline
     ``if`` tag to that ``endif`` label instead of from the first tag line.
+
+    When the ``if`` is the last statement in its parent block body, the false
+    branch jumps past the ``endif`` to the first statement of the enclosing
+    block's continuation. Accept any arc from the tag range that lands beyond
+    the ``endif`` line as also covering the false branch.
     """
     recorded_arc_set = set(recorded_arcs)
     reportable_line_set = set(reportable_lines)
@@ -124,7 +129,11 @@ def covered_structural_control_branch_arcs(
             continue
 
         start_line, end_line = tag_ranges.get(from_line, (from_line, from_line))
-        if any((line_number, to_line) in recorded_arc_set for line_number in range(start_line, end_line + 1)):
+        tag_line_range = range(start_line, end_line + 1)
+        if any((line_number, to_line) in recorded_arc_set for line_number in tag_line_range):
+            covered_branch_arcs.add((from_line, to_line))
+        elif any(raw_from_line in tag_line_range and raw_to_line > to_line for raw_from_line, raw_to_line in recorded_arcs):
+            # The if is the last statement in its parent body: false branch jumps past the endif.
             covered_branch_arcs.add((from_line, to_line))
 
     return covered_branch_arcs

--- a/development/coverage_plugins/tests/test_jinja.py
+++ b/development/coverage_plugins/tests/test_jinja.py
@@ -762,6 +762,21 @@ def test_nested_optional_input_shape_reports_missing_inner_output(tmp_path: Path
     assert analysis.missing_branch_arcs() == {3: [4]}
 
 
+def test_last_if_in_body_false_branch_is_credited_when_parent_exits(tmp_path: Path) -> None:
+    # The inner `if` is the last statement in the outer body.  When outer=True
+    # but inner=False the runtime arc jumps past the inner endif directly to the
+    # statement that follows the outer endif.  The plugin must credit the false
+    # branch of the inner if even though the arc lands beyond its endif line.
+    analysis = _analyze_rendered_template(
+        tmp_path,
+        "{% if outer %}\n{% if inner %}\ncontent\n{% endif %}\n{% endif %}\nafter\n",
+        {"outer": True, "inner": False},
+    )
+
+    # The false branch (inner → endif) is covered; the true branch (content) is missing.
+    assert analysis.missing_branch_arcs() == {2: [3]}
+
+
 def test_optional_block_after_static_output_records_both_branches(tmp_path: Path) -> None:
     analysis = _analyze_rendered_template(
         tmp_path,


### PR DESCRIPTION
## Change Summary

When the ``if`` is the last statement in its parent block body, the false branch jumps past the ``endif`` to the first statement of the enclosing block's continuation. Accept any arc from the tag range that lands beyond the ``endif`` line as also covering the false branch.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
Updated the logic for covered_structural_control_branch_arcs method under source_template to cover the if is the last statement in its parent body: false branch jumps past the endif.

## How to test
Tested on PR #7166 
The `if management_ldap.server_defaults.search.username is arista.avd.defined` is partially covered however i have the test in host3 where i have server_defaults defined but not search.username and it still raise the partially covered warning.
See the below CI
https://app.codecov.io/gh/aristanetworks/avd/commit/70a8d902ee5ac81f81650271a6df09eb6eee11e7#182676a2ce1209ee11e2e3608c1d68f9-R38

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage reporting for Jinja templates so false branches are counted correctly when an `if` is the last statement in a block and execution continues past the matching end tag.
  * Added test coverage for nested conditional templates to verify this branch-tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->