### PR TITLE
Refactor(eos_cli_config_gen): Remove the primary key from management ldap server hosts

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -1328,6 +1328,11 @@ management api models
 | ldap1.example.com | 636 | MGMT | 10 | dc=host1,dc=example,dc=com | uid | LDAP_HOST_SSL_PROFILE | HOST_GROUP_POLICY | cn=host-admin,dc=example,dc=com |
 | ldap2.example.com | - | default | - | - | - | - | - | cn=admin2,dc=example,dc=com |
 | 10.1.1.1 | - | - | - | - | - | LDAP_HOST_SSL_PROFILE | - | - |
+| 10.1.1.1 | 101 | - | - | - | - | - | - | - |
+| 10.1.1.1 | 201 | - | - | - | - | - | - | - |
+| 10.1.1.1 | 101 | vrf1 | - | - | - | - | - | - |
+| 10.1.1.1 | 101 | vrf2 | - | - | - | - | - | - |
+| 10.1.1.1 | - | vrf3 | - | - | - | - | - | - |
 
 ### LDAP Group Policies
 
@@ -1380,6 +1385,16 @@ management ldap
    !
    server host 10.1.1.1
       ssl-profile LDAP_HOST_SSL_PROFILE
+   !
+   server host 10.1.1.1 port 101
+   !
+   server host 10.1.1.1 port 201
+   !
+   server host 10.1.1.1 port 101 vrf vrf1
+   !
+   server host 10.1.1.1 port 101 vrf vrf2
+   !
+   server host 10.1.1.1 vrf vrf3
    !
    group policy HOST_GROUP_POLICY
       group "Network Operator" role network-operator

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -8056,6 +8056,16 @@ management ldap
    server host 10.1.1.1
       ssl-profile LDAP_HOST_SSL_PROFILE
    !
+   server host 10.1.1.1 port 101
+   !
+   server host 10.1.1.1 port 201
+   !
+   server host 10.1.1.1 port 101 vrf vrf1
+   !
+   server host 10.1.1.1 port 101 vrf vrf2
+   !
+   server host 10.1.1.1 vrf vrf3
+   !
    group policy HOST_GROUP_POLICY
       group "Network Operator" role network-operator
    !

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ldap.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ldap.yml
@@ -42,16 +42,16 @@ management_ldap:
     # Host4: Same host name with port
     - host: 10.1.1.1
       port: 101
-    
+
     # Host5: Same host name with different port
     - host: 10.1.1.1
       port: 201
-    
+
     # Host6: Same host and port with vrf
     - host: 10.1.1.1
       port: 101
       vrf: vrf1
-    
+
     # Host7: Same host and port with different vrf
     - host: 10.1.1.1
       port: 101

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ldap.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ldap.yml
@@ -57,7 +57,7 @@ management_ldap:
       port: 101
       vrf: vrf2
 
-    # Host3b: Same host name with vrf (no port)
+    # Host8: Same host name with vrf (no port)
     - host: 10.1.1.1
       vrf: vrf3
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ldap.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ldap.yml
@@ -39,6 +39,28 @@ management_ldap:
     - host: 10.1.1.1
       ssl_profile: LDAP_HOST_SSL_PROFILE
 
+    # Host4: Same host name with port
+    - host: 10.1.1.1
+      port: 101
+    
+    # Host5: Same host name with different port
+    - host: 10.1.1.1
+      port: 201
+    
+    # Host6: Same host and port with vrf
+    - host: 10.1.1.1
+      port: 101
+      vrf: vrf1
+    
+    # Host7: Same host and port with different vrf
+    - host: 10.1.1.1
+      port: 101
+      vrf: vrf2
+
+    # Host3b: Same host name with vrf (no port)
+    - host: 10.1.1.1
+      vrf: vrf3
+
   group_policies:
     # Policy 1: both search_filter and groups; one group with privilege, one without
     - policy: LDAP_GROUP_POLICY

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ldap.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ldap.md
@@ -18,8 +18,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;username</samp>](## "management_ldap.server_defaults.search.username") | String | Required |  |  | LDAP username (full DN) for search bind operations (e.g., cn=ldap-admin,dc=example,dc=com). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "management_ldap.server_defaults.search.password") | String | Required |  |  | Password for the search bind user. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;password_type</samp>](## "management_ldap.server_defaults.search.password_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Password encryption type.<br>- 0 = clear text<br>- 7 = obfuscated<br>- 8a = AES-256-GCM encrypted.<br>Omit to provide an unobfuscated string (EOS will store it obfuscated). |
-    | [<samp>&nbsp;&nbsp;server_hosts</samp>](## "management_ldap.server_hosts") | List, items: Dictionary |  |  |  | List of LDAP server hosts. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;host</samp>](## "management_ldap.server_hosts.[].host") | String | Required, Unique |  |  | Hostname or IP address of the LDAP server. |
+    | [<samp>&nbsp;&nbsp;server_hosts</samp>](## "management_ldap.server_hosts") | List, items: Dictionary |  |  |  | List of LDAP server hosts.<br>Combination of 'host', 'port' and 'vrf' should be unique. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;host</samp>](## "management_ldap.server_hosts.[].host") | String | Required |  |  | Hostname or IP address of the LDAP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "management_ldap.server_hosts.[].port") | Integer |  |  | Min: 0<br>Max: 65535 | Port of LDAP server (EOS default 389). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "management_ldap.server_hosts.[].vrf") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;base_dn</samp>](## "management_ldap.server_hosts.[].base_dn") | String |  |  |  | Base Distinguished Name used for LDAP searches (e.g., dc=example,dc=com). |
@@ -81,10 +81,11 @@
           password_type: <str; "0" | "7" | "8a">
 
       # List of LDAP server hosts.
+      # Combination of 'host', 'port' and 'vrf' should be unique.
       server_hosts:
 
           # Hostname or IP address of the LDAP server.
-        - host: <str; required; unique>
+        - host: <str; required>
 
           # Port of LDAP server (EOS default 389).
           port: <int; 0-65535>

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -25773,10 +25773,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
-        class ServerHosts(AvdIndexedList[str, ServerHostsItem]):
-            """Subclass of AvdIndexedList with `ServerHostsItem` items. Primary key is `host` (`str`)."""
-
-            _primary_key: ClassVar[str] = "host"
+        class ServerHosts(AvdList[ServerHostsItem]):
+            """Subclass of AvdList with `ServerHostsItem` items."""
 
         ServerHosts._item_type = ServerHostsItem
 
@@ -25910,9 +25908,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         server_hosts: ServerHosts
         """
         List of LDAP server hosts.
+        Combination of 'host', 'port' and 'vrf' should be unique.
 
-        Subclass of AvdIndexedList with `ServerHostsItem` items. Primary key is
-        `host` (`str`).
+        Subclass of
+        AvdList with `ServerHostsItem` items.
         """
         group_policies: GroupPolicies
         """
@@ -25944,9 +25943,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        Subclass of AvdModel.
                     server_hosts:
                        List of LDAP server hosts.
+                       Combination of 'host', 'port' and 'vrf' should be unique.
 
-                       Subclass of AvdIndexedList with `ServerHostsItem` items. Primary key is
-                       `host` (`str`).
+                       Subclass of
+                       AvdList with `ServerHostsItem` items.
                     group_policies:
                        Named LDAP group policies that map LDAP groups to EOS roles and privilege levels.
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -9897,14 +9897,16 @@ keys:
                 - int
       server_hosts:
         type: list
-        primary_key: host
-        description: List of LDAP server hosts.
+        description: 'List of LDAP server hosts.
+
+          Combination of ''host'', ''port'' and ''vrf'' should be unique.'
         items:
           type: dict
           $ref: eos_cli_config_gen#/keys/management_ldap/keys/server_defaults
           keys:
             host:
               type: str
+              required: true
               description: Hostname or IP address of the LDAP server.
             port:
               type: int

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ldap.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ldap.schema.yml
@@ -62,14 +62,16 @@ keys:
                   - int
       server_hosts:
         type: list
-        primary_key: host
-        description: List of LDAP server hosts.
+        description: |-
+          List of LDAP server hosts.
+          Combination of 'host', 'port' and 'vrf' should be unique.
         items:
           type: dict
           $ref: "eos_cli_config_gen#/keys/management_ldap/keys/server_defaults"
           keys:
             host:
               type: str
+              required: true
               description: Hostname or IP address of the LDAP server.
             port:
               type: int


### PR DESCRIPTION
## Change Summary

Remove the primary key from management ldap server hosts.

> [!NOTE]
> This is a Refactor because we had not released it yet.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Remove the primary key from management ldap server hosts as it support same host with different port and vrf.

## How to test
Added tests in molecule.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded management LDAP examples and generated configuration to support multiple server entries for the same address with different ports and VRFs.

* **Documentation**
  * Clarified LDAP server host rules so the combination of host, port, and VRF is treated as unique.
  * Updated examples and tables to reflect the revised LDAP server host format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->