### PR TITLE
CI: Bump ansible-lint to newer version and prevent the slope

### DIFF
--- a/ansible_collections/arista/avd/.ansible-lint
+++ b/ansible_collections/arista/avd/.ansible-lint
@@ -1,8 +1,6 @@
 ---
 profile: production
 
-skip_list:
-  - var-naming[no-role-prefix] # TODO: Fix internal variable names as a breaking change for AVD 6.0.0
 mock_modules:
   # The following task files depend on other collections and ansible-lint is running in offline mode on galaxy/automation hub
   # so need to mock the modules or ignore the files.

--- a/ansible_collections/arista/avd/.ansible-lint-ignore
+++ b/ansible_collections/arista/avd/.ansible-lint-ignore
@@ -1,0 +1,21 @@
+# This file contains ignores rule violations for ansible-lint
+roles/anta_runner/defaults/main/directories.yml var-naming[no-role-prefix] skip
+roles/anta_runner/defaults/main/main.yml var-naming[no-role-prefix] skip
+roles/anta_runner/tasks/main.yml var-naming[no-role-prefix] skip
+roles/build_output_folders/defaults/main.yml var-naming[no-role-prefix] skip
+roles/build_output_folders/tasks/main.yml var-naming[no-role-prefix] skip
+roles/cv_deploy/defaults/main/directories.yml var-naming[no-role-prefix] skip
+roles/cv_deploy/defaults/main/main.yml var-naming[no-role-prefix] skip
+roles/cv_deploy/tasks/main.yml var-naming[no-role-prefix] skip
+roles/eos_cli_config_gen/defaults/main/main.yml var-naming[no-role-prefix] skip
+roles/eos_cli_config_gen/defaults/main/output_directories.yml var-naming[no-role-prefix] skip
+roles/eos_cli_config_gen/tasks/main.yml var-naming[no-role-prefix] skip
+roles/eos_cli_config_gen/vars/main.yml var-naming[no-role-prefix] skip
+roles/eos_config_deploy_eapi/defaults/main.yml var-naming[no-role-prefix] skip
+roles/eos_config_deploy_eapi/tasks/main.yml var-naming[no-role-prefix] skip
+roles/eos_designs/defaults/main/main.yml var-naming[no-role-prefix] skip
+roles/eos_designs/defaults/main/output_directories.yml var-naming[no-role-prefix] skip
+roles/eos_designs/tasks/main.yml var-naming[no-role-prefix] skip
+roles/eos_designs/vars/main.yml var-naming[no-role-prefix] skip
+roles/eos_snapshot/defaults/main.yml var-naming[no-role-prefix] skip
+roles/eos_snapshot/tasks/main.yml var-naming[no-role-prefix] skip

--- a/ansible_collections/arista/avd/.yamllint
+++ b/ansible_collections/arista/avd/.yamllint
@@ -22,6 +22,9 @@ rules:
     min-spaces-inside: 0 # yamllint defaults to 0
     max-spaces-inside: 1 # yamllint defaults to 0
     level: error
+  brackets:
+    max-spaces-inside: 0
+    level: error
   octal-values:
     forbid-implicit-octal: true # yamllint defaults to false
     forbid-explicit-octal: true # yamllint defaults to false

--- a/ansible_collections/arista/avd/extensions/molecule/digital_twin/inventory/group_vars/DIGITAL_TWIN_ETHERNET_PORTS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/digital_twin/inventory/group_vars/DIGITAL_TWIN_ETHERNET_PORTS.yml
@@ -8,7 +8,7 @@ l3leaf:
     loopback_ipv4_pool: 192.168.3.128/28
     vtep_loopback_ipv4_pool: 192.168.3.144/28
     bgp_as: 65001
-    mlag_interfaces: [ Ethernet4, Ethernet5 ]
+    mlag_interfaces: [Ethernet4, Ethernet5]
   node_groups:
     - group: NODE_GROUP_A
       nodes:
@@ -40,9 +40,9 @@ l3leaf:
         - name: digital.twin.ethernet.ports.2
           id: 2
           mgmt_ip: 192.169.3.2/32
-          uplink_interfaces: [ Ethernet3 ]
-          uplink_switches: [ digital-twin-ethernet-ports-1 ]
-          uplink_switch_interfaces: [ Ethernet3 ]
+          uplink_interfaces: [Ethernet3]
+          uplink_switches: [digital-twin-ethernet-ports-1]
+          uplink_switch_interfaces: [Ethernet3]
           # (Dotted switch name) validate_state should be set to False in Digital Twin mode for l3_interfaces
           l3_interfaces:
             - name: Ethernet19
@@ -71,9 +71,9 @@ l3leaf:
           id: 1
           platform: custom-platform
           mgmt_ip: 192.169.3.3/32
-          uplink_interfaces: [ Ethernet6 ]
-          uplink_switches: [ digital-twin-ethernet-ports-1 ]
-          uplink_switch_interfaces: [ Ethernet6 ]
+          uplink_interfaces: [Ethernet6]
+          uplink_switches: [digital-twin-ethernet-ports-1]
+          uplink_switch_interfaces: [Ethernet6]
 
 custom_platform_settings:
   - platforms:
@@ -85,25 +85,25 @@ firewalls:
   - name: firewall-1
     adapters:
       # validate_state should be set to False in Digital Twin mode for standalone interfaces facing connected endpoints
-      - endpoint_ports: [ Eth1, Eth2 ]
-        switch_ports: [ Ethernet1, Ethernet1 ]
-        switches: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
+      - endpoint_ports: [Eth1, Eth2]
+        switch_ports: [Ethernet1, Ethernet1]
+        switches: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
 
       # validate_state should be set to False in Digital Twin mode for PO (and its member interfaces) facing connected endpoints
-      - endpoint_ports: [ Eth3, Eth4 ]
-        switch_ports: [ Ethernet9, Ethernet9 ]
-        switches: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
+      - endpoint_ports: [Eth3, Eth4]
+        switch_ports: [Ethernet9, Ethernet9]
+        switches: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
         port_channel:
           mode: active
 
 network_ports:
   # validate_state should be set to False in Digital Twin mode for standalone network_port interfaces
-  - switches: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
-    switch_ports: [ Ethernet2, Ethernet2 ]
+  - switches: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
+    switch_ports: [Ethernet2, Ethernet2]
 
   # validate_state should be set to False in Digital Twin mode for PO (and member interfaces) network_port interfaces
-  - switches: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
-    switch_ports: [ Ethernet16, Ethernet16 ]
+  - switches: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
+    switch_ports: [Ethernet16, Ethernet16]
     port_channel:
       mode: active
 
@@ -122,15 +122,15 @@ tenants:
             vxlan: false
         l3_interfaces:
           # validate_state should be set to False in Digital Twin mode for l3_interfaces
-          - interfaces: [ Ethernet10.100, Ethernet10.100 ]
-            ip_addresses: [ "192.168.3.160/31", "192.168.3.162/31" ]
-            nodes: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
-          - interfaces: [ Ethernet10.101, Ethernet10.101 ]
-            ip_addresses: [ "192.168.3.164/31", "192.168.3.166/31" ]
-            nodes: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
-          - interfaces: [ Ethernet10, Ethernet10 ]
-            ip_addresses: [ "192.168.3.168/31", "192.168.3.170/31" ]
-            nodes: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
+          - interfaces: [Ethernet10.100, Ethernet10.100]
+            ip_addresses: ["192.168.3.160/31", "192.168.3.162/31"]
+            nodes: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
+          - interfaces: [Ethernet10.101, Ethernet10.101]
+            ip_addresses: ["192.168.3.164/31", "192.168.3.166/31"]
+            nodes: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
+          - interfaces: [Ethernet10, Ethernet10]
+            ip_addresses: ["192.168.3.168/31", "192.168.3.170/31"]
+            nodes: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
         l3_port_channels:
           # validate_state should be set to False in Digital Twin mode for l3_port_channels and members
           # PO with sub-interface
@@ -170,68 +170,68 @@ tenants:
 l3_edge:
   p2p_links:
     # validate_state should NOT be set to False in Digital Twin mode for standalone interfaces (including subs) facing another fabric device
-    - nodes: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
-      interfaces: [ Ethernet11, Ethernet11 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.184/31", "192.168.3.185/31" ]
-    - nodes: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
-      interfaces: [ Ethernet11.100, Ethernet11.100 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.186/31", "192.168.3.187/31" ]
-    - nodes: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
-      interfaces: [ Ethernet11.101, Ethernet11.101 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.188/31", "192.168.3.189/31" ]
+    - nodes: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
+      interfaces: [Ethernet11, Ethernet11]
+      as: [65001, 65001]
+      ip: ["192.168.3.184/31", "192.168.3.185/31"]
+    - nodes: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
+      interfaces: [Ethernet11.100, Ethernet11.100]
+      as: [65001, 65001]
+      ip: ["192.168.3.186/31", "192.168.3.187/31"]
+    - nodes: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
+      interfaces: [Ethernet11.101, Ethernet11.101]
+      as: [65001, 65001]
+      ip: ["192.168.3.188/31", "192.168.3.189/31"]
 
     # validate_state should be set to False in Digital Twin mode for standalone interfaces (including subs) facing non-fabric device
-    - nodes: [ digital-twin-ethernet-ports-1, external-device-1 ]
-      interfaces: [ Ethernet13, Ethernet13 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.190/31", "192.168.3.191/31" ]
-    - nodes: [ digital-twin-ethernet-ports-1, external-device-1 ]
-      interfaces: [ Ethernet13.100, Ethernet13.100 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.192/31", "192.168.3.193/31" ]
+    - nodes: [digital-twin-ethernet-ports-1, external-device-1]
+      interfaces: [Ethernet13, Ethernet13]
+      as: [65001, 65001]
+      ip: ["192.168.3.190/31", "192.168.3.191/31"]
+    - nodes: [digital-twin-ethernet-ports-1, external-device-1]
+      interfaces: [Ethernet13.100, Ethernet13.100]
+      as: [65001, 65001]
+      ip: ["192.168.3.192/31", "192.168.3.193/31"]
 
     # (Dotted switch name) validate_state should be set to False in Digital Twin mode for standalone interfaces (including subs) facing non-fabric device
-    - nodes: [ digital.twin.ethernet.ports.2, external-device-2 ]
-      interfaces: [ Ethernet13, Ethernet13 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.194/31", "192.168.3.195/31" ]
-    - nodes: [ digital.twin.ethernet.ports.2, external-device-2 ]
-      interfaces: [ Ethernet13.100, Ethernet13.100 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.196/31", "192.168.3.197/31" ]
+    - nodes: [digital.twin.ethernet.ports.2, external-device-2]
+      interfaces: [Ethernet13, Ethernet13]
+      as: [65001, 65001]
+      ip: ["192.168.3.194/31", "192.168.3.195/31"]
+    - nodes: [digital.twin.ethernet.ports.2, external-device-2]
+      interfaces: [Ethernet13.100, Ethernet13.100]
+      as: [65001, 65001]
+      ip: ["192.168.3.196/31", "192.168.3.197/31"]
 
     # validate_state should NOT be set to False in Digital Twin mode for PO (and its member interfaces) facing another fabric device
-    - nodes: [ digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.198/31", "192.168.3.199/31" ]
+    - nodes: [digital-twin-ethernet-ports-1, digital.twin.ethernet.ports.2]
+      as: [65001, 65001]
+      ip: ["192.168.3.198/31", "192.168.3.199/31"]
       port_channel:
         nodes_child_interfaces:
           - node: digital-twin-ethernet-ports-1
-            interfaces: [ Ethernet14 ]
+            interfaces: [Ethernet14]
           - node: digital.twin.ethernet.ports.2
-            interfaces: [ Ethernet14 ]
+            interfaces: [Ethernet14]
 
     # validate_state should be set to False in Digital Twin mode for PO (and its member interfaces) facing non-fabric device
-    - nodes: [ digital-twin-ethernet-ports-1, external-device-3 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.200/31", "192.168.3.201/31" ]
+    - nodes: [digital-twin-ethernet-ports-1, external-device-3]
+      as: [65001, 65001]
+      ip: ["192.168.3.200/31", "192.168.3.201/31"]
       port_channel:
         nodes_child_interfaces:
           - node: digital-twin-ethernet-ports-1
-            interfaces: [ Ethernet15 ]
+            interfaces: [Ethernet15]
           - node: external-device-3
-            interfaces: [ Ethernet15 ]
+            interfaces: [Ethernet15]
 
     # (Dotted switch name) validate_state should be set to False in Digital Twin mode for PO (and its member interfaces) facing non-fabric device
-    - nodes: [ digital.twin.ethernet.ports.2, external-device-4 ]
-      as: [ 65001, 65001 ]
-      ip: [ "192.168.3.202/31", "192.168.3.203/31" ]
+    - nodes: [digital.twin.ethernet.ports.2, external-device-4]
+      as: [65001, 65001]
+      ip: ["192.168.3.202/31", "192.168.3.203/31"]
       port_channel:
         nodes_child_interfaces:
           - node: digital.twin.ethernet.ports.2
-            interfaces: [ Ethernet15 ]
+            interfaces: [Ethernet15]
           - node: external-device-4
-            interfaces: [ Ethernet15 ]
+            interfaces: [Ethernet15]

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/monitor-connectivity-host-local-interfaces-not-in-interface-sets.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/monitor-connectivity-host-local-interfaces-not-in-interface-sets.yml
@@ -14,7 +14,7 @@ monitor_connectivity:
   interval: 5
   interface_sets:
     - name: SET_INTERNET
-      interfaces: [ Ethernet1, Ethernet2 ]
+      interfaces: [Ethernet1, Ethernet2]
   hosts:
     - name: DNS1
       ip: 8.8.8.8

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/monitor-connectivity-local-interfaces-not-in-interface-sets.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/monitor-connectivity-local-interfaces-not-in-interface-sets.yml
@@ -14,7 +14,7 @@ monitor_connectivity:
   interval: 5
   interface_sets:
     - name: SET_INTERNET
-      interfaces: [ Ethernet1, Ethernet2 ]
+      interfaces: [Ethernet1, Ethernet2]
   local_interfaces: Loopback0
 
 expected_error_message: >-

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/monitor-connectivity-vrf-host-local-interfaces-not-in-interface-sets.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/monitor-connectivity-vrf-host-local-interfaces-not-in-interface-sets.yml
@@ -16,7 +16,7 @@ monitor_connectivity:
     - name: MGMT
       interface_sets:
         - name: SET_MGMT
-          interfaces: [ Management1 ]
+          interfaces: [Management1]
       hosts:
         - name: MGMT_SERVER
           ip: 10.0.0.1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/monitor-connectivity-vrf-local-interfaces-not-in-interface-sets.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/inventory/host_vars/monitor-connectivity-vrf-local-interfaces-not-in-interface-sets.yml
@@ -16,7 +16,7 @@ monitor_connectivity:
     - name: MGMT
       interface_sets:
         - name: SET_MGMT
-          interfaces: [ Management1 ]
+          interfaces: [Management1]
       local_interfaces: Loopback0
 
 expected_error_message: >-

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/OVERLAY_EBGP_EVPN_GATEWAY_TESTS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/OVERLAY_EBGP_EVPN_GATEWAY_TESTS.yml
@@ -101,7 +101,7 @@ l3leaf:
       mgmt_ip: 192.168.0.209/24
       evpn_route_servers: [evpn-gateway-l2-evpn-role-server]
       filter:
-        tenants: [ EVPN_GATEWAY_TESTS, RD_RT_REWRITE_PARTIAL_TESTS ]
+        tenants: [EVPN_GATEWAY_TESTS, RD_RT_REWRITE_PARTIAL_TESTS]
       evpn_gateway:
         remote_peers:
           - hostname: DCI_TEST

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/monitor-combined-settings.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/monitor-combined-settings.yml
@@ -26,11 +26,11 @@ monitor_connectivity:
   interval: 10
   interface_sets:
     - name: SET_LOOPBACK0
-      interfaces: [ Loopback0 ]
+      interfaces: [Loopback0]
     - name: SET_LOOPBACK1
-      interfaces: [ Loopback1 ]
+      interfaces: [Loopback1]
     - name: SET_LOOPBACK2
-      interfaces: [ Loopback2 ]
+      interfaces: [Loopback2]
   hosts:
     - name: INTERNET_CHECK
       # local address_only: true with local_interfaces

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/monitor-connectivity-settings.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/monitor-connectivity-settings.yml
@@ -18,13 +18,13 @@ monitor_connectivity:
   interval: 5
   interface_sets:
     - name: SET_INTERNET
-      interfaces: [ Ethernet1, Ethernet2 ]
+      interfaces: [Ethernet1, Ethernet2]
     - name: SET_INTERNET_1
-      interfaces: [ Ethernet4, Ethernet3 ]
+      interfaces: [Ethernet4, Ethernet3]
     - name: SET_INTERNET_2
-      interfaces: [ Ethernet5, Ethernet6 ]
+      interfaces: [Ethernet5, Ethernet6]
     - name: SET_LOOPBACK0
-      interfaces: [ Loopback0 ]
+      interfaces: [Loopback0]
   local_interfaces: SET_LOOPBACK0
   address_only: true
   hosts:
@@ -51,11 +51,11 @@ monitor_connectivity:
       # testing default vrf.address_only
       interface_sets:
         - name: SET_MGMT
-          interfaces: [ Management0 ]
+          interfaces: [Management0]
         - name: SET_MGMT_1
-          interfaces: [ Loopback100 ]
+          interfaces: [Loopback100]
         - name: SET_MGMT_2
-          interfaces: [ Loopback101, Loopback102, Loopback103, Loopback104 ]
+          interfaces: [Loopback101, Loopback102, Loopback103, Loopback104]
       hosts:
         - name: MGMT_SERVER
           description: Management server
@@ -79,13 +79,13 @@ monitor_connectivity:
       # testing vrf.address_only: true.
       interface_sets:
         - name: Vrf_Set_MGMT
-          interfaces: [ Management0 ]
+          interfaces: [Management0]
         - name: SET_MGMT_1
-          interfaces: [ Loopback200 ]
+          interfaces: [Loopback200]
         - name: SET_MGMT_2
-          interfaces: [ Loopback201 ]
+          interfaces: [Loopback201]
         - name: SET_MGMT_3
-          interfaces: [ Loopback202 ]
+          interfaces: [Loopback202]
       local_interfaces: Vrf_Set_MGMT
       address_only: true
       hosts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dev = [
     {include-group = "pytest"},
     {include-group = "molecule"},
     "ansible-doc-extractor>=0.1.11",
-    "ansible-lint>=26.4.0",
+    "ansible-lint>=26.6.0",
     "aristaproto[compiler]==0.1.5",
     "bump-my-version>=1.3.0",
     "codespell>=2.4.2",


### PR DESCRIPTION
## Change Summary

Removing `skip_list` and adding everything in `.ansible-lint-ignore` file from there to be able to track more specifically where we have issues.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd`
`ci`

## Proposed changes

* force the parenthesis because otherwise ansible-lint is sad when it runs.

## How to test

CI is green

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting setup and development tooling versions.
  * Added stricter YAML formatting checks and expanded lint coverage for offline validation.
* **Style**
  * Standardized inline list formatting across multiple inventory and test YAML files.
  * Removed extra whitespace inside bracketed lists for interface, tenant, and routing entries.
* **Bug Fixes**
  * Added lint ignores for existing naming-rule exceptions in several collection files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->