### PR TITLE
Fix(eos_cli_config_gen): Remove unreachable WRED missing-units branch  in QOS profile documentation

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -15155,6 +15155,7 @@ Priority Flow Control is **enabled**.
 | -------- | ---- | --------------- | ------------- | ------------- | ---------------- | ------ |
 | 1 | All | - | 1 kbytes | 10 kbytes | 100 | - |
 | 2 | All | 2 | 2 kbytes | 200 kbytes | 50 | 10 |
+| 3 | All | - | - | - | - | - |
 | 4 | All | - | 1 kbytes | 10 kbytes | 90 | - |
 | 1 | Multicast | - | - | - | - | - |
 | 2 | Multicast | - | - | - | - | - |

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -15120,7 +15120,6 @@ Priority Flow Control is **enabled**.
 | -------- | ---- | --------------- | ------------- | ------------- | ---------------- | ------ |
 | 1 | All | - | 1 kbytes | 10 kbytes | 100 | - |
 | 2 | All | 2 | 2 kbytes | 200 kbytes | 50 | 10 |
-| 3 | All | - | - | - | - | - |
 | 4 | All | - | 1 kbytes | 10 kbytes | 90 | - |
 | 1 | Multicast | - | - | - | - | - |
 | 2 | Multicast | - | - | - | - | - |

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/qos-profiles.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/qos-profiles.yml
@@ -190,8 +190,6 @@ qos_profiles:
               min: 1
               max: 10
               drop_probability: 90
-      # TODO: Open issue. documentation/qos-profiles.j2 has a WRED drop threshold branch for missing units,
-      # but qos_profiles.[].tx_queues[].random_detect.drop.threshold.units is required by schema validation.
     mc_tx_queues:
       - id: 1
         bandwidth_percent: 50

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
@@ -145,16 +145,12 @@
 {%                 for uc_tx_queue in profile.uc_tx_queues | arista.avd.natural_sort(sort_key='id') %}
 {%                     set type = "Unicast" %}
 {%                     set precedence = uc_tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
-{%                     set min = uc_tx_queue.random_detect.drop.threshold.min | arista.avd.default("-") %}
-{%                     set max = uc_tx_queue.random_detect.drop.threshold.max | arista.avd.default("-") %}
 {%                     set prob = uc_tx_queue.random_detect.drop.threshold.drop_probability | arista.avd.default("-") %}
 {%                     set weight = uc_tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
 {%                     set units = uc_tx_queue.random_detect.drop.threshold.units | arista.avd.default("") %}
-{%                     if units %}
-| {{ uc_tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} {{ units }} | {{ max }} {{ units }} | {{ prob }} | {{ weight }} |
-{%                     else %}
+{%                     set min = (uc_tx_queue.random_detect.drop.threshold.min | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
+{%                     set max = (uc_tx_queue.random_detect.drop.threshold.max | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
 | {{ uc_tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} | {{ max }} | {{ prob }} | {{ weight }} |
-{%                     endif %}
 {%                 endfor %}
 {%             endif %}
 {%             if profile.mc_tx_queues is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
@@ -114,12 +114,12 @@
 {%         endif %}
 {%         set ns = namespace(wred_table=false) %}
 {%         for tx_queue in profile.tx_queues | arista.avd.default([]) %}
-{%             if tx_queue.random_detect.drop.threshold.units is arista.avd.defined() %}
+{%             if tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
 {%                 set ns.wred_table = true %}
 {%             endif %}
 {%         endfor %}
 {%         for tx_queue in profile.uc_tx_queues | arista.avd.default([]) %}
-{%             if tx_queue.random_detect.drop.threshold.units is arista.avd.defined() %}
+{%             if tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
 {%                 set ns.wred_table = true %}
 {%             endif %}
 {%         endfor %}
@@ -131,26 +131,30 @@
 | -------- | ---- | --------------- | ------------- | ------------- | ---------------- | ------ |
 {%             if profile.tx_queues is arista.avd.defined %}
 {%                 for tx_queue in profile.tx_queues | arista.avd.natural_sort(sort_key='id') %}
-{%                     set type = "All" %}
-{%                     set precedence = tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
-{%                     set prob = tx_queue.random_detect.drop.threshold.drop_probability | arista.avd.default("-") %}
-{%                     set weight = tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
-{%                     set units = tx_queue.random_detect.drop.threshold.units | arista.avd.default("") %}
-{%                     set min = (tx_queue.random_detect.drop.threshold.min | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
-{%                     set max = (tx_queue.random_detect.drop.threshold.max | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
+{%                     if tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
+{%                         set type = "All" %}
+{%                         set precedence = tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
+{%                         set prob = tx_queue.random_detect.drop.threshold.drop_probability %}
+{%                         set weight = tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
+{%                         set units = tx_queue.random_detect.drop.threshold.units %}
+{%                         set min = tx_queue.random_detect.drop.threshold.min ~ " " ~ units %}
+{%                         set max = tx_queue.random_detect.drop.threshold.max ~ " " ~ units %}
 | {{ tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} | {{ max }} | {{ prob }} | {{ weight }} |
+{%                     endif %}
 {%                 endfor %}
 {%             endif %}
 {%             if profile.uc_tx_queues is arista.avd.defined %}
 {%                 for uc_tx_queue in profile.uc_tx_queues | arista.avd.natural_sort(sort_key='id') %}
-{%                     set type = "Unicast" %}
-{%                     set precedence = uc_tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
-{%                     set prob = uc_tx_queue.random_detect.drop.threshold.drop_probability | arista.avd.default("-") %}
-{%                     set weight = uc_tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
-{%                     set units = uc_tx_queue.random_detect.drop.threshold.units | arista.avd.default("") %}
-{%                     set min = (uc_tx_queue.random_detect.drop.threshold.min | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
-{%                     set max = (uc_tx_queue.random_detect.drop.threshold.max | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
+{%                     if uc_tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
+{%                         set type = "Unicast" %}
+{%                         set precedence = uc_tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
+{%                         set prob = uc_tx_queue.random_detect.drop.threshold.drop_probability %}
+{%                         set weight = uc_tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
+{%                         set units = uc_tx_queue.random_detect.drop.threshold.units %}
+{%                         set min = uc_tx_queue.random_detect.drop.threshold.min ~ " " ~ units %}
+{%                         set max = uc_tx_queue.random_detect.drop.threshold.max ~ " " ~ units %}
 | {{ uc_tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} | {{ max }} | {{ prob }} | {{ weight }} |
+{%                     endif %}
 {%                 endfor %}
 {%             endif %}
 {%             if profile.mc_tx_queues is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
@@ -114,13 +114,13 @@
 {%         endif %}
 {%         set ns = namespace(wred_table=false) %}
 {%         for tx_queue in profile.tx_queues | arista.avd.default([]) %}
-{%             if tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
+{%             if tx_queue.random_detect.drop.threshold is arista.avd.defined %}
 {%                 set ns.wred_table = true %}
 {%                 break %}
 {%             endif %}
 {%         endfor %}
 {%         for uc_tx_queue in profile.uc_tx_queues | arista.avd.default([]) %}
-{%             if uc_tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
+{%             if uc_tx_queue.random_detect.drop.threshold is arista.avd.defined %}
 {%                 set ns.wred_table = true %}
 {%                 break %}
 {%             endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
@@ -116,11 +116,13 @@
 {%         for tx_queue in profile.tx_queues | arista.avd.default([]) %}
 {%             if tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
 {%                 set ns.wred_table = true %}
+{%                 break %}
 {%             endif %}
 {%         endfor %}
-{%         for tx_queue in profile.uc_tx_queues | arista.avd.default([]) %}
-{%             if tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
+{%         for uc_tx_queue in profile.uc_tx_queues | arista.avd.default([]) %}
+{%             if uc_tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
 {%                 set ns.wred_table = true %}
+{%                 break %}
 {%             endif %}
 {%         endfor %}
 {%         if ns.wred_table %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
@@ -133,30 +133,42 @@
 | -------- | ---- | --------------- | ------------- | ------------- | ---------------- | ------ |
 {%             if profile.tx_queues is arista.avd.defined %}
 {%                 for tx_queue in profile.tx_queues | arista.avd.natural_sort(sort_key='id') %}
+{%                     set type = "All" %}
 {%                     if tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
-{%                         set type = "All" %}
 {%                         set precedence = tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
 {%                         set prob = tx_queue.random_detect.drop.threshold.drop_probability %}
 {%                         set weight = tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
 {%                         set units = tx_queue.random_detect.drop.threshold.units %}
 {%                         set min = tx_queue.random_detect.drop.threshold.min ~ " " ~ units %}
 {%                         set max = tx_queue.random_detect.drop.threshold.max ~ " " ~ units %}
-| {{ tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} | {{ max }} | {{ prob }} | {{ weight }} |
+{%                     else %}
+{%                         set precedence = "-" %}
+{%                         set prob = "-" %}
+{%                         set weight = "-" %}
+{%                         set min = "-" %}
+{%                         set max = "-" %}
 {%                     endif %}
+| {{ tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} | {{ max }} | {{ prob }} | {{ weight }} |
 {%                 endfor %}
 {%             endif %}
 {%             if profile.uc_tx_queues is arista.avd.defined %}
 {%                 for uc_tx_queue in profile.uc_tx_queues | arista.avd.natural_sort(sort_key='id') %}
+{%                     set type = "Unicast" %}
 {%                     if uc_tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
-{%                         set type = "Unicast" %}
 {%                         set precedence = uc_tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
 {%                         set prob = uc_tx_queue.random_detect.drop.threshold.drop_probability %}
 {%                         set weight = uc_tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
 {%                         set units = uc_tx_queue.random_detect.drop.threshold.units %}
 {%                         set min = uc_tx_queue.random_detect.drop.threshold.min ~ " " ~ units %}
 {%                         set max = uc_tx_queue.random_detect.drop.threshold.max ~ " " ~ units %}
-| {{ uc_tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} | {{ max }} | {{ prob }} | {{ weight }} |
+{%                     else %}
+{%                         set precedence = "-" %}
+{%                         set prob = "-" %}
+{%                         set weight = "-" %}
+{%                         set min = "-" %}
+{%                         set max = "-" %}
 {%                     endif %}
+| {{ uc_tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} | {{ max }} | {{ prob }} | {{ weight }} |
 {%                 endfor %}
 {%             endif %}
 {%             if profile.mc_tx_queues is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
@@ -134,40 +134,24 @@
 {%             if profile.tx_queues is arista.avd.defined %}
 {%                 for tx_queue in profile.tx_queues | arista.avd.natural_sort(sort_key='id') %}
 {%                     set type = "All" %}
-{%                     if tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
-{%                         set precedence = tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
-{%                         set prob = tx_queue.random_detect.drop.threshold.drop_probability %}
-{%                         set weight = tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
-{%                         set units = tx_queue.random_detect.drop.threshold.units %}
-{%                         set min = tx_queue.random_detect.drop.threshold.min ~ " " ~ units %}
-{%                         set max = tx_queue.random_detect.drop.threshold.max ~ " " ~ units %}
-{%                     else %}
-{%                         set precedence = "-" %}
-{%                         set prob = "-" %}
-{%                         set weight = "-" %}
-{%                         set min = "-" %}
-{%                         set max = "-" %}
-{%                     endif %}
+{%                     set precedence = tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
+{%                     set prob = tx_queue.random_detect.drop.threshold.drop_probability | arista.avd.default("-") %}
+{%                     set weight = tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
+{%                     set units = tx_queue.random_detect.drop.threshold.units | arista.avd.default("") %}
+{%                     set min = (tx_queue.random_detect.drop.threshold.min | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
+{%                     set max = (tx_queue.random_detect.drop.threshold.max | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
 | {{ tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} | {{ max }} | {{ prob }} | {{ weight }} |
 {%                 endfor %}
 {%             endif %}
 {%             if profile.uc_tx_queues is arista.avd.defined %}
 {%                 for uc_tx_queue in profile.uc_tx_queues | arista.avd.natural_sort(sort_key='id') %}
 {%                     set type = "Unicast" %}
-{%                     if uc_tx_queue.random_detect.drop.threshold is arista.avd.defined() %}
-{%                         set precedence = uc_tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
-{%                         set prob = uc_tx_queue.random_detect.drop.threshold.drop_probability %}
-{%                         set weight = uc_tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
-{%                         set units = uc_tx_queue.random_detect.drop.threshold.units %}
-{%                         set min = uc_tx_queue.random_detect.drop.threshold.min ~ " " ~ units %}
-{%                         set max = uc_tx_queue.random_detect.drop.threshold.max ~ " " ~ units %}
-{%                     else %}
-{%                         set precedence = "-" %}
-{%                         set prob = "-" %}
-{%                         set weight = "-" %}
-{%                         set min = "-" %}
-{%                         set max = "-" %}
-{%                     endif %}
+{%                     set precedence = uc_tx_queue.random_detect.drop.threshold.drop_precedence | arista.avd.default("-") %}
+{%                     set prob = uc_tx_queue.random_detect.drop.threshold.drop_probability | arista.avd.default("-") %}
+{%                     set weight = uc_tx_queue.random_detect.drop.threshold.weight | arista.avd.default("-") %}
+{%                     set units = uc_tx_queue.random_detect.drop.threshold.units | arista.avd.default("") %}
+{%                     set min = (uc_tx_queue.random_detect.drop.threshold.min | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
+{%                     set max = (uc_tx_queue.random_detect.drop.threshold.max | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
 | {{ uc_tx_queue.id }} | {{ type }} | {{ precedence }} | {{ min }} | {{ max }} | {{ prob }} | {{ weight }} |
 {%                 endfor %}
 {%             endif %}


### PR DESCRIPTION
## Change Summary
Remove unreachable WRED missing-units branch  in QOS profile documentation

## Related Issue(s)

Fixes #7133 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
qos-profiles.j2 — 

- Removed dead else branch in uc_tx_queues WRED block; units is required: true in schema so the no-units path is unreachable. 
- Aligned min/max variable construction with tx_queues for consistency

## How to test


## Checklist

### User Checklist
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WRED configuration output so TX and UC TX queues display correctly when threshold values are set.
  * Adjusted formatting so minimum and maximum values show units only when available, preventing incomplete or inconsistent table entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->