### PR TITLE
CI: Make autofix support the schema auto generated files

### DIFF
--- a/.github/workflows/pull-request-autofix.yml
+++ b/.github/workflows/pull-request-autofix.yml
@@ -29,6 +29,48 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Configure generated-file merge behavior for autofix
+        env:
+          PYTHONPATH: python-avd
+        run: |
+          # autofix-ci commits changes made by pre-commit, then for pull requests it
+          # checks out the real PR head and runs `git cherry-pick --no-commit` with
+          # the generated autofix commit. AVD marks large generated files as
+          # non-mergeable in committed .gitattributes, so that cherry-pick can fail
+          # even when the generated output is correct.
+          #
+          # Keep this override local to the Actions checkout. .git/info/attributes
+          # has higher precedence than committed .gitattributes, but it is not
+          # committed and does not affect contributors' local Git behavior.
+          # See development/ci.md for the rationale and rejected alternatives.
+          mkdir -p .git/info
+          python - <<'PY' >> .git/info/attributes
+          from schema_tools.constants import REPO_ROOT, SCHEMAS
+
+          generated_paths: set[str] = set()
+
+          for schema_paths in SCHEMAS.values():
+              if schema_paths.fragments_dir:
+                  generated_paths.add(schema_paths.yaml_file.relative_to(REPO_ROOT).as_posix())
+
+              if schema_paths.python_class:
+                  generated_paths.add(schema_paths.python_class.relative_to(REPO_ROOT).as_posix())
+
+              if schema_paths.docs_path:
+                  generated_paths.add((schema_paths.docs_path / "tables" / "*.md").relative_to(REPO_ROOT).as_posix())
+
+          for generated_path in sorted(generated_paths):
+              print(f"/{generated_path} merge=generated-autofix diff")
+          PY
+
+          # During autofix-ci's cherry-pick, %B is the incoming autofix-generated
+          # file and %A is the worktree file from the checked-out PR head.
+          git config --local merge.generated-autofix.name "Keep incoming autofix-generated file"
+          git config --local merge.generated-autofix.driver "cp %B %A"
+
+          git check-attr merge diff -- \
+            python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+
       - name: Run pre-commit autofix pass
         id: pre_commit
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
@@ -14,7 +14,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "snmp_server.engine_ids.remotes.[].id") | String |  |  |  | Remote engine ID in hexadecimal.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address</samp>](## "snmp_server.engine_ids.remotes.[].address") | String |  |  |  | Hostname or IP of remote engine.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.engine_ids.remotes.[].udp_port") | Integer |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  | SNMP contact. |
+    | [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_server.contact") | String |  |  |  | SNMP contact name. |
     | [<samp>&nbsp;&nbsp;location</samp>](## "snmp_server.location") | String |  |  |  | SNMP location. |
     | [<samp>&nbsp;&nbsp;communities</samp>](## "snmp_server.communities") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "snmp_server.communities.[].name") | String | Required, Unique |  |  | Community name. |
@@ -91,7 +91,7 @@
             address: <str>
             udp_port: <int>
 
-      # SNMP contact.
+      # SNMP contact name.
       contact: <str>
 
       # SNMP location.

--- a/development/ci.md
+++ b/development/ci.md
@@ -1,0 +1,51 @@
+<!--
+  ~ Copyright (c) 2026 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+
+# AVD CI Notes
+
+This file captures maintainer-facing CI decisions and implementation notes.
+
+## autofix.ci and generated files
+
+AVD uses pre-commit hooks to regenerate schemas, generated Python classes, and schema documentation tables. Some of these generated files are intentionally marked as non-mergeable in committed `.gitattributes` to keep normal Git behavior explicit and avoid noisy generated-file merges for contributors.
+
+`autofix-ci/action` has a different constraint. On pull requests, the action commits any changes created by pre-commit, fetches the real PR head, checks it out, and runs:
+
+```shell
+git cherry-pick --no-commit <autofix-commit>
+```
+
+If a generated file is changed by both the PR head and the autofix commit, Git can fail the cherry-pick with a binary-style conflict because the committed attributes include `-merge`.
+
+The autofix workflow configures a local-only merge driver to handle this case. It writes generated-file attributes to `.git/info/attributes` and configures `merge.generated-autofix` in the local checkout. This does not change committed `.gitattributes`, does not require contributor Git configuration, and does not affect local developer behavior.
+
+The generated paths are discovered from `python-avd/schema_tools/constants.py`, using the same `SCHEMAS` registry used by the schema builder. If generated schema or table paths move, update the schema tooling registry; the autofix workflow should follow that move automatically.
+
+### Strategy options
+
+The selected strategy is **default checkout plus CI-local merge driver**.
+
+- Keeps the standard `actions/checkout` behavior for pull requests, so autofix runs against GitHub's PR merge result.
+- Preserves validation against the effective merge with `devel`.
+- Resolves generated edit/edit conflicts during `autofix-ci/action`'s cherry-pick.
+- Keeps contributor local Git behavior unchanged.
+
+The rejected alternative was **PR-head checkout plus CI-local merge driver**.
+
+- This would make the autofix commit a direct child of the PR head and reduce cherry-pick conflicts.
+- It would also stop the autofix pass from validating the merged result with latest `devel`, which is a broader semantic change than needed.
+
+The fallback alternative is **no schema/docs autofix**.
+
+- This is the safest Git behavior.
+- It requires contributors, maintainers, or another automation path to push regenerated schema and documentation outputs.
+- It does not support moving the schema-generation pre-commit hook fully to autofix.ci.
+
+### Known limitations
+
+The CI-local merge driver is intended for generated edit/edit conflicts. It does not reliably solve generated file moves or modify/delete conflicts. For schema or table moves, prefer committing regenerated outputs explicitly in the PR, or expect maintainer intervention.
+
+Contributors should still run pre-commit locally and commit generated outputs when possible. The autofix workflow is a compatibility layer, not the source of truth for generated artifacts.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -68706,7 +68706,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         engine_ids: EngineIds
         """Subclass of AvdModel."""
         contact: str | None
-        """SNMP contact."""
+        """SNMP contact name."""
         location: str | None
         """SNMP location."""
         communities: Communities
@@ -68760,7 +68760,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 Args:
                     engine_ids: Subclass of AvdModel.
-                    contact: SNMP contact.
+                    contact: SNMP contact name.
                     location: SNMP location.
                     communities: Subclass of AvdIndexedList with `CommunitiesItem` items. Primary key is `name` (`str`).
                     ipv4_acls: Subclass of AvdList with `Ipv4AclsItem` items.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -24906,7 +24906,7 @@ keys:
                   - str
       contact:
         type: str
-        description: SNMP contact.
+        description: SNMP contact name.
       location:
         type: str
         description: SNMP location.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
@@ -42,7 +42,7 @@ keys:
                     - str
       contact:
         type: str
-        description: SNMP contact.
+        description: SNMP contact name.
       location:
         type: str
         description: SNMP location.


### PR DESCRIPTION
## Change Summary

for now we can't merge on schema changes because of how autofix works (cf doc included in the PR). This PR manipulates git attributes to make it work

## Related Issue(s)

Reported by dev

## Component(s) name

`ci``

## Proposed changes

* manipulate git attributes in autofix workflow

## How to test

* Follow up commits showing it works

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI autofix handling for generated schema files by configuring a local merge driver to reduce cherry-pick/merge conflicts.

* **Documentation**
  * Added/expanded maintainer guidance on regenerating schema artifacts and how CI avoids merge failures for non-mergeable generated files.
  * Updated SNMP documentation and generated schema text for `snmp_server.contact` (“SNMP contact name”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->