### PR TITLE
Bump: Pre-release 6.4.0-dev0

### DIFF
--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -10,7 +10,7 @@ namespace: arista
 name: avd
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 6.3.0
+version: 6.4.0-dev0
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
 

--- a/ansible_collections/arista/avd/requirements.txt
+++ b/ansible_collections/arista/avd/requirements.txt
@@ -8,7 +8,7 @@ distlib>=0.3.9
 grpclib>=0.4.8
 jinja2>=3.0
 netaddr>=0.7.19
-pyavd==6.3.0
+pyavd==6.4.0.dev0
 pyavd-utils==0.0.6
 python-socks[asyncio]>=2.7.2
 pyyaml>=6.0.0

--- a/docs/avd-requirements.txt
+++ b/docs/avd-requirements.txt
@@ -9,7 +9,7 @@ distlib>=0.3.9
 grpclib>=0.4.8
 jinja2>=3.0
 netaddr>=0.7.19
-pyavd==6.3.0
+pyavd==6.4.0.dev0
 pyavd-utils==0.0.6
 python-socks[asyncio]>=2.7.2
 pyyaml>=6.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,7 @@ exclude_also = [
 
 [tool.bumpversion]
 
-current_version = "6.3.0"
+current_version = "6.4.0-dev0"
 
 allow_dirty = true
 commit = false

--- a/python-avd/pyavd/__init__.py
+++ b/python-avd/pyavd/__init__.py
@@ -18,7 +18,7 @@ PYAVD_PRERELEASE = ""  # Set this to aN or bN for alpha and beta releases of pya
 __author__ = "Arista Networks"
 __copyright__ = "Copyright 2023-2026 Arista Networks"
 __license__ = "Apache 2.0"
-__version__ = "6.3.0"
+__version__ = "6.4.0.dev0"
 
 __all__ = [
     "get_avd_facts",

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -85,7 +85,7 @@ version = {attr = "pyavd.__version__"}
 [dependency-groups]
 # helping pdm generate the flat list of requirements in pre-commit
 self = [
-  "pyavd==6.3.0"
+  "pyavd==6.4.0.dev0"
 ]
 
 [tool.black]


### PR DESCRIPTION
## Change Summary

Pre-release 6.4.0-dev0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to `6.4.0-dev0` across the collection and Python package.
  * Aligned pinned dependency versions and local requirement references to the new development release.
  * Refreshed release/versioning configuration so future version updates follow the new baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->