### PR TITLE
Feat(eos_cli_config_gen): Add some ISIS and MPLS related keys to SVIs (vlan_interfaces)

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -7971,21 +7971,21 @@ interface Tunnel6
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
-| Vlan42 | EVPN_UNDERLAY | - | - | - | Level-1: sha |
-| Vlan83 | EVPN_UNDERLAY | - | - | - | md5 |
-| Vlan84 | EVPN_UNDERLAY | - | - | - | sha |
-| Vlan85 | EVPN_UNDERLAY | - | - | - | sha |
-| Vlan86 | EVPN_UNDERLAY | - | - | - | shared-secret |
-| Vlan87 | EVPN_UNDERLAY | - | - | - | shared-secret |
-| Vlan88 | EVPN_UNDERLAY | - | - | - | Level-1: md5<br>Level-2: text |
-| Vlan90 | EVPN_UNDERLAY | - | - | - | Level-1: shared-secret<br>Level-2: shared-secret |
-| Vlan91 | EVPN_UNDERLAY | - | - | - | Level-1: md5<br>Level-2: text |
-| Vlan92 | EVPN_UNDERLAY | - | - | - | Level-1: shared-secret<br>Level-2: shared-secret |
-| Vlan2002 | EVPN_UNDERLAY | True | - | passive | md5 |
-| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - |
-| Vlan4094 | EVPN_UNDERLAY | - | - | - | Level-1: sha<br>Level-2: sha |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ----------------- | ------------- | ------------------------ |
+| Vlan42 | EVPN_UNDERLAY | - | - | - | - | - | Level-1: sha |
+| Vlan83 | EVPN_UNDERLAY | - | - | - | level-2 | True | md5 |
+| Vlan84 | EVPN_UNDERLAY | - | - | - | - | - | sha |
+| Vlan85 | EVPN_UNDERLAY | - | - | - | - | - | sha |
+| Vlan86 | EVPN_UNDERLAY | - | - | - | - | - | shared-secret |
+| Vlan87 | EVPN_UNDERLAY | - | - | - | - | - | shared-secret |
+| Vlan88 | EVPN_UNDERLAY | - | - | - | - | - | Level-1: md5<br>Level-2: text |
+| Vlan90 | EVPN_UNDERLAY | - | - | - | - | - | Level-1: shared-secret<br>Level-2: shared-secret |
+| Vlan91 | EVPN_UNDERLAY | - | - | - | - | - | Level-1: md5<br>Level-2: text |
+| Vlan92 | EVPN_UNDERLAY | - | - | - | - | - | Level-1: shared-secret<br>Level-2: shared-secret |
+| Vlan2002 | EVPN_UNDERLAY | True | - | passive | - | - | md5 |
+| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - | - | - |
+| Vlan4094 | EVPN_UNDERLAY | - | - | - | - | - | Level-1: sha<br>Level-2: sha |
 
 ##### Multicast Routing
 
@@ -8118,6 +8118,8 @@ interface Vlan83
    description SVI Description
    no shutdown
    isis enable EVPN_UNDERLAY
+   isis circuit-type level-2
+   isis hello padding
    isis authentication mode md5
    isis authentication key 0 password
    ip address virtual 10.10.83.1/24
@@ -8142,6 +8144,7 @@ interface Vlan85
    arp cache dynamic capacity 50000
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   mpls ip
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
    isis authentication key 0 password

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -8467,6 +8467,9 @@ interface Vlan4092
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    ip address 10.255.251.0/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    isis enable EVPN_UNDERLAY
    isis metric 50
    isis network point-to-point

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -8144,6 +8144,8 @@ interface Vlan85
    arp cache dynamic capacity 50000
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   mpls ldp igp sync
+   no mpls ldp interface
    mpls ip
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -73,6 +73,7 @@
   - [Switchport Default](#switchport-default)
   - [Interface Defaults](#interface-defaults)
   - [DPS Interfaces](#dps-interfaces)
+  - [VLAN Interfaces](#vlan-interfaces)
   - [VXLAN Interface](#vxlan-interface)
 - [Switchport Port-security](#switchport-port-security)
   - [Switchport Port-security Summary](#switchport-port-security-summary)
@@ -89,6 +90,7 @@
   - [PBR Policy Maps](#pbr-policy-maps)
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
+  - [BFD Interfaces](#bfd-interfaces)
 - [Monitor Loop Protection](#monitor-loop-protection)
   - [Monitor Loop Protection Configuration](#monitor-loop-protection-configuration)
 - [MPLS](#mpls)
@@ -1004,6 +1006,42 @@ interface Dps1
    ip address 192.168.42.42/24
 ```
 
+### VLAN Interfaces
+
+#### VLAN Interfaces Summary
+
+| Interface | Description | VRF | MTU | Shutdown |
+| --------- | ----------- | --- | --- | -------- |
+| Vlan85 | SVI Description | default | - | - |
+
+##### IPv4
+
+| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | ACL In | ACL Out |
+| --------- | --- | ---------- | ------------------ | ------------------------- | ------ | ------- |
+| Vlan85 | default | 10.10.84.1/24 | - | - | - | - |
+
+##### ISIS
+
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ----------------- | ------------- | ------------------------ |
+| Vlan85 | EVPN_UNDERLAY | - | - | - | - | False | sha |
+
+#### VLAN Interfaces Device Configuration
+
+```eos
+!
+interface Vlan85
+   description SVI Description
+   ip address 10.10.84.1/24
+   bfd interval 500 min-rx 500 multiplier 5
+   bfd echo
+   no mpls ip
+   isis enable EVPN_UNDERLAY
+   no isis hello padding
+   isis authentication mode sha key-id 2
+   isis authentication key 0 password
+```
+
 ### VXLAN Interface
 
 #### VXLAN Interface Summary
@@ -1173,6 +1211,7 @@ router ospf 701
 
 | Interface | ISIS Instance | ISIS Metric | Interface Mode |
 | --------- | ------------- | ----------- | -------------- |
+| Vlan85 | EVPN_UNDERLAY | - | - |
 
 #### ISIS IPv4 Address Family Summary
 
@@ -1427,6 +1466,12 @@ policy-map type pbr POLICY_DROP_THEN_NEXTHOP
 router bfd
    session stats snapshot interval dangerous 8
 ```
+
+### BFD Interfaces
+
+| Interface | Interval | Minimum RX | Multiplier | Echo |
+| --------- | -------- | ---------- | ---------- | ---- |
+| Vlan85 | 500 | 500 | 5 | True |
 
 ## Monitor Loop Protection
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1035,6 +1035,7 @@ interface Vlan85
    ip address 10.10.84.1/24
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   no mpls ldp igp sync
    no mpls ip
    isis enable EVPN_UNDERLAY
    no isis hello padding

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4592,6 +4592,8 @@ interface Vlan83
    description SVI Description
    no shutdown
    isis enable EVPN_UNDERLAY
+   isis circuit-type level-2
+   isis hello padding
    isis authentication mode md5
    isis authentication key 0 password
    ip address virtual 10.10.83.1/24
@@ -4616,6 +4618,7 @@ interface Vlan85
    arp cache dynamic capacity 50000
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   mpls ip
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
    isis authentication key 0 password

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4939,6 +4939,9 @@ interface Vlan4092
 interface Vlan4093
    description MLAG_PEER_L3_PEERING
    ip address 10.255.251.0/31
+   mpls ldp igp sync
+   mpls ldp interface
+   mpls ip
    isis enable EVPN_UNDERLAY
    isis metric 50
    isis network point-to-point

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4618,6 +4618,8 @@ interface Vlan85
    arp cache dynamic capacity 50000
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   mpls ldp igp sync
+   no mpls ldp interface
    mpls ip
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host2.cfg
@@ -252,6 +252,17 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
+interface Vlan85
+   description SVI Description
+   ip address 10.10.84.1/24
+   bfd interval 500 min-rx 500 multiplier 5
+   bfd echo
+   no mpls ip
+   isis enable EVPN_UNDERLAY
+   no isis hello padding
+   isis authentication mode sha key-id 2
+   isis authentication key 0 password
+!
 interface Vxlan1
    shutdown
    vxlan vlan 110 vni 10110

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host2.cfg
@@ -257,6 +257,7 @@ interface Vlan85
    ip address 10.10.84.1/24
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   no mpls ldp igp sync
    no mpls ip
    isis enable EVPN_UNDERLAY
    no isis hello padding

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
@@ -239,6 +239,11 @@ vlan_interfaces:
   - name: Vlan4093
     description: MLAG_PEER_L3_PEERING
     ip_address: 10.255.251.0/31
+    mpls:
+      ip: true
+      ldp:
+        igp_sync: true
+        interface: true
     isis_enable: EVPN_UNDERLAY
     isis_metric: 50
     isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
@@ -119,6 +119,9 @@ vlan_interfaces:
           key_id: 2
     mpls:
       ip: true
+      ldp:
+        igp_sync: true
+        interface: false
 
   - name: Vlan86
     description: SVI Description

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
@@ -75,6 +75,8 @@ vlan_interfaces:
         key_type: 0
         key: password
         mode: md5
+    isis_hello_padding: true
+    isis_circuit_type: level-2
 
   - name: Vlan84
     description: SVI Description
@@ -115,6 +117,8 @@ vlan_interfaces:
         mode: sha
         sha:
           key_id: 2
+    mpls:
+      ip: true
 
   - name: Vlan86
     description: SVI Description

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host2/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host2/vlan-interfaces.yml
@@ -1,0 +1,23 @@
+---
+### VLAN Interfaces ###
+vlan_interfaces:
+  - name: Vlan85
+    description: SVI Description
+    ip_address: 10.10.84.1/24
+    bfd:
+      echo: true
+      interval: 500
+      min_rx: 500
+      multiplier: 5
+    # Test isis auth both sha
+    isis_enable: "EVPN_UNDERLAY"
+    isis_hello_padding: false
+    isis_authentication:
+      both:
+        key_type: 0
+        key: password
+        mode: sha
+        sha:
+          key_id: 2
+    mpls:
+      ip: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host2/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host2/vlan-interfaces.yml
@@ -21,3 +21,5 @@ vlan_interfaces:
           key_id: 2
     mpls:
       ip: false
+      ldp:
+        igp_sync: false

--- a/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -468,9 +468,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ----------------- | ------------- | ------------------------ |
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -453,9 +453,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ----------------- | ------------- | ------------------------ |
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -468,9 +468,9 @@ interface Loopback10
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ----------------- | ------------- | ------------------------ |
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -468,9 +468,9 @@ interface Loopback10
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ----------------- | ------------- | ------------------------ |
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -467,9 +467,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
-| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ----------------- | ------------- | ------------------------ |
+| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/extensions/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -467,9 +467,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
-| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ----------------- | ------------- | ------------------------ |
+| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -192,6 +192,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_passive</samp>](## "vlan_interfaces.[].isis_passive") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_metric</samp>](## "vlan_interfaces.[].isis_metric") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_network_point_to_point</samp>](## "vlan_interfaces.[].isis_network_point_to_point") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_circuit_type</samp>](## "vlan_interfaces.[].isis_circuit_type") | String |  |  | Valid Values:<br>- <code>level-1-2</code><br>- <code>level-1</code><br>- <code>level-2</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_hello_padding</samp>](## "vlan_interfaces.[].isis_hello_padding") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication</samp>](## "vlan_interfaces.[].isis_authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "vlan_interfaces.[].isis_authentication.both") | Dictionary |  |  |  | Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
@@ -295,6 +297,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_policy</samp>](## "vlan_interfaces.[].traffic_policy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "vlan_interfaces.[].traffic_policy.input") | String |  |  |  | Ingress traffic policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "vlan_interfaces.[].traffic_policy.output") | String |  |  |  | Egress traffic policy. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mpls</samp>](## "vlan_interfaces.[].mpls") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "vlan_interfaces.[].mpls.ip") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ldp</samp>](## "vlan_interfaces.[].mpls.ldp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "vlan_interfaces.[].mpls.ldp.interface") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igp_sync</samp>](## "vlan_interfaces.[].mpls.ldp.igp_sync") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ntp_serve</samp>](## "vlan_interfaces.[].ntp_serve") | Boolean |  |  |  | Enable/disable serving NTP to clients. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pvlan_mapping</samp>](## "vlan_interfaces.[].pvlan_mapping") | String |  |  |  | List of VLANs as string. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;metadata</samp>](## "vlan_interfaces.[].metadata") | Dictionary |  |  |  |  |
@@ -719,6 +726,8 @@
         isis_passive: <bool>
         isis_metric: <int>
         isis_network_point_to_point: <bool>
+        isis_circuit_type: <str; "level-1-2" | "level-1" | "level-2">
+        isis_hello_padding: <bool>
         isis_authentication:
 
           # Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
@@ -937,6 +946,11 @@
 
           # Egress traffic policy.
           output: <str>
+        mpls:
+          ip: <bool>
+          ldp:
+            interface: <bool>
+            igp_sync: <bool>
 
         # Enable/disable serving NTP to clients.
         ntp_serve: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -298,10 +298,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "vlan_interfaces.[].traffic_policy.input") | String |  |  |  | Ingress traffic policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "vlan_interfaces.[].traffic_policy.output") | String |  |  |  | Egress traffic policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mpls</samp>](## "vlan_interfaces.[].mpls") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "vlan_interfaces.[].mpls.ip") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "vlan_interfaces.[].mpls.ip") | Boolean |  |  |  | Enable MPLS traffic on interface if MPLS enabled globally. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ldp</samp>](## "vlan_interfaces.[].mpls.ldp") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "vlan_interfaces.[].mpls.ldp.interface") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igp_sync</samp>](## "vlan_interfaces.[].mpls.ldp.igp_sync") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "vlan_interfaces.[].mpls.ldp.interface") | Boolean |  |  |  | Enable LDP on this interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igp_sync</samp>](## "vlan_interfaces.[].mpls.ldp.igp_sync") | Boolean |  |  |  | Tell the IGP to keep a link at max metric until LDP labels are ready. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ntp_serve</samp>](## "vlan_interfaces.[].ntp_serve") | Boolean |  |  |  | Enable/disable serving NTP to clients. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;pvlan_mapping</samp>](## "vlan_interfaces.[].pvlan_mapping") | String |  |  |  | List of VLANs as string. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;metadata</samp>](## "vlan_interfaces.[].metadata") | Dictionary |  |  |  |  |
@@ -947,9 +947,15 @@
           # Egress traffic policy.
           output: <str>
         mpls:
+
+          # Enable MPLS traffic on interface if MPLS enabled globally.
           ip: <bool>
           ldp:
+
+            # Enable LDP on this interface.
             interface: <bool>
+
+            # Tell the IGP to keep a link at max metric until LDP labels are ready.
             igp_sync: <bool>
 
         # Enable/disable serving NTP to clients.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -228,8 +228,8 @@
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Circuit Type | Hello Padding | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ----------------- | ------------- | ------------------------ |
 {%         for vlan_interface in vlan_interfaces | arista.avd.natural_sort('name') %}
 {%             if vlan_interface.isis_authentication.both.mode is arista.avd.defined %}
 {%                 set isis_authentication_mode = vlan_interface.isis_authentication.both.mode %}
@@ -240,6 +240,8 @@
 {%             elif vlan_interface.isis_authentication.level_2.mode is arista.avd.defined %}
 {%                 set isis_authentication_mode = "Level-2: " ~ vlan_interface.isis_authentication.level_2.mode %}
 {%             endif %}
+{%             set isis_circuit_type = vlan_interface.isis_circuit_type | arista.avd.default("-") %}
+{%             set isis_hello_padding = vlan_interface.isis_hello_padding | arista.avd.default("-") %}
 {%             if vlan_interface.isis_enable is arista.avd.defined %}
 {%                 set isis_metric = vlan_interface.isis_metric | arista.avd.default('-') %}
 {%                 if vlan_interface.isis_network_point_to_point is arista.avd.defined %}
@@ -249,7 +251,7 @@
 {%                 else %}
 {%                     set mode = "-" %}
 {%                 endif %}
-| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} | {{ isis_authentication_mode | arista.avd.default("-") }} |
+| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} | {{ isis_circuit_type }} | {{ isis_hello_padding }} | {{ isis_authentication_mode | arista.avd.default("-") }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -273,6 +273,8 @@ interface {{ vlan_interface.name }}
 {%     endif %}
 {%     if vlan_interface.mpls.ldp.igp_sync is arista.avd.defined(true) %}
    mpls ldp igp sync
+{%     elif vlan_interface.mpls.ldp.igp_sync is arista.avd.defined(false) %}
+   no mpls ldp igp sync
 {%     endif %}
 {%     if vlan_interface.mpls.ldp.interface is arista.avd.defined(true) %}
    mpls ldp interface

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -271,6 +271,14 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.ipv6_access_group_out is arista.avd.defined %}
    ipv6 access-group {{ vlan_interface.ipv6_access_group_out }} out
 {%     endif %}
+{%     if vlan_interface.mpls.ldp.igp_sync is arista.avd.defined(true) %}
+   mpls ldp igp sync
+{%     endif %}
+{%     if vlan_interface.mpls.ldp.interface is arista.avd.defined(true) %}
+   mpls ldp interface
+{%     elif vlan_interface.mpls.ldp.interface is arista.avd.defined(false) %}
+   no mpls ldp interface
+{%     endif %}
 {%     if vlan_interface.multicast is arista.avd.defined %}
 {%         if vlan_interface.multicast.ipv4.boundaries is arista.avd.defined %}
 {%             for boundary in vlan_interface.multicast.ipv4.boundaries | arista.avd.natural_sort("boundary") %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -307,6 +307,11 @@ interface {{ vlan_interface.name }}
    multicast ipv6 static
 {%         endif %}
 {%     endif %}
+{%     if vlan_interface.mpls.ip is arista.avd.defined(true) %}
+   mpls ip
+{%     elif vlan_interface.mpls.ip is arista.avd.defined(false) %}
+   no mpls ip
+{%     endif %}
 {%     if vlan_interface.ip_nat is arista.avd.defined %}
 {%         set interface_ip_nat = vlan_interface.ip_nat %}
 {%         include 'eos/interface-ip-nat.j2' %}
@@ -385,11 +390,19 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.isis_bfd is arista.avd.defined(true) %}
    isis bfd
 {%     endif %}
+{%     if vlan_interface.isis_circuit_type is arista.avd.defined %}
+   isis circuit-type {{ vlan_interface.isis_circuit_type }}
+{%     endif %}
 {%     if vlan_interface.isis_metric is arista.avd.defined %}
    isis metric {{ vlan_interface.isis_metric }}
 {%     endif %}
 {%     if vlan_interface.isis_passive is arista.avd.defined(true) %}
    isis passive
+{%     endif %}
+{%     if vlan_interface.isis_hello_padding is arista.avd.defined(false) %}
+   no isis hello padding
+{%     elif vlan_interface.isis_hello_padding is arista.avd.defined(true) %}
+   isis hello padding
 {%     endif %}
 {%     if vlan_interface.isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -73505,6 +73505,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
+        IsisCircuitType: TypeAlias = Literal["level-1-2", "level-1", "level-2"]
+
         class IsisAuthentication(AvdModel):
             """Subclass of AvdModel."""
 
@@ -74597,6 +74599,51 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
+        class Mpls(AvdModel):
+            """Subclass of AvdModel."""
+
+            class Ldp(AvdModel):
+                """Subclass of AvdModel."""
+
+                _fields: ClassVar[dict] = {"interface": {"type": bool}, "igp_sync": {"type": bool}}
+                interface: bool | None
+                igp_sync: bool | None
+
+                if TYPE_CHECKING:
+
+                    def __init__(self, *, interface: bool | None | UndefinedType = Undefined, igp_sync: bool | None | UndefinedType = Undefined) -> None:
+                        """
+                        Ldp.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            interface: interface
+                            igp_sync: igp_sync
+
+                        """
+
+            _fields: ClassVar[dict] = {"ip": {"type": bool}, "ldp": {"type": Ldp}}
+            ip: bool | None
+            ldp: Ldp
+            """Subclass of AvdModel."""
+
+            if TYPE_CHECKING:
+
+                def __init__(self, *, ip: bool | None | UndefinedType = Undefined, ldp: Ldp | UndefinedType = Undefined) -> None:
+                    """
+                    Mpls.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        ip: ip
+                        ldp: Subclass of AvdModel.
+
+                    """
+
         class Metadata(AvdModel):
             """Subclass of AvdModel."""
 
@@ -74714,6 +74761,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "isis_passive": {"type": bool},
             "isis_metric": {"type": int},
             "isis_network_point_to_point": {"type": bool},
+            "isis_circuit_type": {"type": str},
+            "isis_hello_padding": {"type": bool},
             "isis_authentication": {"type": IsisAuthentication},
             "mtu": {"type": int},
             "no_autostate": {"type": bool},
@@ -74724,6 +74773,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "service_policy": {"type": ServicePolicy},
             "tcp_mss_ceiling": {"type": TcpMssCeiling},
             "traffic_policy": {"type": TrafficPolicy},
+            "mpls": {"type": Mpls},
             "ntp_serve": {"type": bool},
             "pvlan_mapping": {"type": str},
             "metadata": {"type": Metadata},
@@ -74876,6 +74926,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         isis_passive: bool | None
         isis_metric: int | None
         isis_network_point_to_point: bool | None
+        isis_circuit_type: IsisCircuitType | None
+        isis_hello_padding: bool | None
         isis_authentication: IsisAuthentication
         """Subclass of AvdModel."""
         mtu: int | None
@@ -74898,6 +74950,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         tcp_mss_ceiling: TcpMssCeiling
         """Subclass of AvdModel."""
         traffic_policy: TrafficPolicy
+        """Subclass of AvdModel."""
+        mpls: Mpls
         """Subclass of AvdModel."""
         ntp_serve: bool | None
         """Enable/disable serving NTP to clients."""
@@ -74974,6 +75028,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 isis_passive: bool | None | UndefinedType = Undefined,
                 isis_metric: int | None | UndefinedType = Undefined,
                 isis_network_point_to_point: bool | None | UndefinedType = Undefined,
+                isis_circuit_type: IsisCircuitType | None | UndefinedType = Undefined,
+                isis_hello_padding: bool | None | UndefinedType = Undefined,
                 isis_authentication: IsisAuthentication | UndefinedType = Undefined,
                 mtu: int | None | UndefinedType = Undefined,
                 no_autostate: bool | None | UndefinedType = Undefined,
@@ -74984,6 +75040,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 service_policy: ServicePolicy | UndefinedType = Undefined,
                 tcp_mss_ceiling: TcpMssCeiling | UndefinedType = Undefined,
                 traffic_policy: TrafficPolicy | UndefinedType = Undefined,
+                mpls: Mpls | UndefinedType = Undefined,
                 ntp_serve: bool | None | UndefinedType = Undefined,
                 pvlan_mapping: str | None | UndefinedType = Undefined,
                 metadata: Metadata | UndefinedType = Undefined,
@@ -75089,6 +75146,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     isis_passive: isis_passive
                     isis_metric: isis_metric
                     isis_network_point_to_point: isis_network_point_to_point
+                    isis_circuit_type: isis_circuit_type
+                    isis_hello_padding: isis_hello_padding
                     isis_authentication: Subclass of AvdModel.
                     mtu: mtu
                     no_autostate: no_autostate
@@ -75103,6 +75162,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     service_policy: Subclass of AvdModel.
                     tcp_mss_ceiling: Subclass of AvdModel.
                     traffic_policy: Subclass of AvdModel.
+                    mpls: Subclass of AvdModel.
                     ntp_serve: Enable/disable serving NTP to clients.
                     pvlan_mapping: List of VLANs as string.
                     metadata: Subclass of AvdModel.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -74607,7 +74607,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 _fields: ClassVar[dict] = {"interface": {"type": bool}, "igp_sync": {"type": bool}}
                 interface: bool | None
+                """Enable LDP on this interface."""
                 igp_sync: bool | None
+                """Tell the IGP to keep a link at max metric until LDP labels are ready."""
 
                 if TYPE_CHECKING:
 
@@ -74619,13 +74621,14 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         Subclass of AvdModel.
 
                         Args:
-                            interface: interface
-                            igp_sync: igp_sync
+                            interface: Enable LDP on this interface.
+                            igp_sync: Tell the IGP to keep a link at max metric until LDP labels are ready.
 
                         """
 
             _fields: ClassVar[dict] = {"ip": {"type": bool}, "ldp": {"type": Ldp}}
             ip: bool | None
+            """Enable MPLS traffic on interface if MPLS enabled globally."""
             ldp: Ldp
             """Subclass of AvdModel."""
 
@@ -74639,7 +74642,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Subclass of AvdModel.
 
                     Args:
-                        ip: ip
+                        ip: Enable MPLS traffic on interface if MPLS enabled globally.
                         ldp: Subclass of AvdModel.
 
                     """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -26979,6 +26979,14 @@ keys:
           - str
         isis_network_point_to_point:
           type: bool
+        isis_circuit_type:
+          type: str
+          valid_values:
+          - level-1-2
+          - level-1
+          - level-2
+        isis_hello_padding:
+          type: bool
         isis_authentication:
           type: dict
           $ref: eos_cli_config_gen#/keys/router_isis/keys/authentication
@@ -27207,6 +27215,18 @@ keys:
             output:
               type: str
               description: Egress traffic policy.
+        mpls:
+          type: dict
+          keys:
+            ip:
+              type: bool
+            ldp:
+              type: dict
+              keys:
+                interface:
+                  type: bool
+                igp_sync:
+                  type: bool
         ntp_serve:
           type: bool
           description: Enable/disable serving NTP to clients.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -27220,13 +27220,17 @@ keys:
           keys:
             ip:
               type: bool
+              description: Enable MPLS traffic on interface if MPLS enabled globally.
             ldp:
               type: dict
               keys:
                 interface:
                   type: bool
+                  description: Enable LDP on this interface.
                 igp_sync:
                   type: bool
+                  description: Tell the IGP to keep a link at max metric until LDP
+                    labels are ready.
         ntp_serve:
           type: bool
           description: Enable/disable serving NTP to clients.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -540,6 +540,11 @@ keys:
             - str
         isis_network_point_to_point:
           type: bool
+        isis_circuit_type:
+          type: str
+          valid_values: ["level-1-2", "level-1", "level-2"]
+        isis_hello_padding:
+          type: bool
         isis_authentication:
           type: dict
           $ref: "eos_cli_config_gen#/keys/router_isis/keys/authentication"
@@ -764,6 +769,18 @@ keys:
             output:
               type: str
               description: Egress traffic policy.
+        mpls:
+          type: dict
+          keys:
+            ip:
+              type: bool
+            ldp:
+              type: dict
+              keys:
+                interface:
+                  type: bool
+                igp_sync:
+                  type: bool
         ntp_serve:
           type: bool
           description: Enable/disable serving NTP to clients.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -774,13 +774,16 @@ keys:
           keys:
             ip:
               type: bool
+              description: Enable MPLS traffic on interface if MPLS enabled globally.
             ldp:
               type: dict
               keys:
                 interface:
                   type: bool
+                  description: Enable LDP on this interface.
                 igp_sync:
                   type: bool
+                  description: Tell the IGP to keep a link at max metric until LDP labels are ready.
         ntp_serve:
           type: bool
           description: Enable/disable serving NTP to clients.


### PR DESCRIPTION
## Change Summary

Add some missing options for IS-IS and MPLS under SVIs

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add hello-padding and circuit type, as well as enabling mpls. Same schema as for existing `ethernet_interfaces`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-VLAN IS-IS interface options for **circuit type** and **hello padding**, now rendered in generated VLAN SVI configuration.
  * Expanded VLAN SVI rendering to support **MPLS/LDP** controls, including **MPLS IP** plus LDP behavior for **IGP sync** and **interface enable/disable**.
* **Documentation**
  * Updated VLAN interface schema/docs to include the new **IS-IS** and **MPLS/LDP** fields.
  * Refreshed device example outputs and VLAN/ISIS tables with the expanded column set and MPLS details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->