### PR TITLE
Fix(eos_cli_config_gen): Optimize ECN threshold detection and fix variable naming in qos-profiles.j2

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -15035,7 +15035,6 @@ policy-map type quality-of-service pmap_test1
 
 | TX queue | Type | Min Threshold | Max Threshold | Max Mark Probability |
 | -------- | ---- | ------------- | ------------- | -------------------- |
-| 1 | All | - | - | - |
 | 2 | All | 320 kbytes | 320 kbytes | 90 |
 | 4 | All | 320 segments | 320 segments | - |
 
@@ -15132,10 +15131,7 @@ Priority Flow Control is **enabled**.
 
 | TX queue | Type | Min Threshold | Max Threshold | Max Mark Probability |
 | -------- | ---- | ------------- | ------------- | -------------------- |
-| 1 | All | - | - | - |
-| 2 | All | - | - | - |
 | 3 | All | 320 kbytes | 320 kbytes | - |
-| 4 | All | - | - | - |
 | 1 | Multicast | - | - | - |
 | 2 | Multicast | - | - | - |
 | 4 | Multicast | - | - | - |

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -15044,6 +15044,7 @@ policy-map type quality-of-service pmap_test1
 
 | TX queue | Type | Min Threshold | Max Threshold | Max Mark Probability |
 | -------- | ---- | ------------- | ------------- | -------------------- |
+| 1 | All | - | - | - |
 | 2 | All | 320 kbytes | 320 kbytes | 90 |
 | 4 | All | 320 segments | 320 segments | - |
 
@@ -15140,7 +15141,10 @@ Priority Flow Control is **enabled**.
 
 | TX queue | Type | Min Threshold | Max Threshold | Max Mark Probability |
 | -------- | ---- | ------------- | ------------- | -------------------- |
+| 1 | All | - | - | - |
+| 2 | All | - | - | - |
 | 3 | All | 320 kbytes | 320 kbytes | - |
+| 4 | All | - | - | - |
 | 1 | Multicast | - | - | - |
 | 2 | Multicast | - | - | - |
 | 4 | Multicast | - | - | - |

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
@@ -89,26 +89,22 @@
 | -------- | ---- | ------------- | ------------- | -------------------- |
 {%             if profile.tx_queues is arista.avd.defined %}
 {%                 for tx_queue in profile.tx_queues | arista.avd.natural_sort(sort_key='id') %}
-{%                     if tx_queue.random_detect.ecn.threshold is arista.avd.defined %}
-{%                         set type = "All" %}
-{%                         set prob = tx_queue.random_detect.ecn.threshold.max_probability | arista.avd.default("-") %}
-{%                         set units = tx_queue.random_detect.ecn.threshold.units %}
-{%                         set min = tx_queue.random_detect.ecn.threshold.min ~ " " ~ units %}
-{%                         set max = tx_queue.random_detect.ecn.threshold.max ~ " " ~ units %}
+{%                     set type = "All" %}
+{%                     set prob = tx_queue.random_detect.ecn.threshold.max_probability | arista.avd.default("-") %}
+{%                     set units = tx_queue.random_detect.ecn.threshold.units | arista.avd.default("") %}
+{%                     set min = (tx_queue.random_detect.ecn.threshold.min | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
+{%                     set max = (tx_queue.random_detect.ecn.threshold.max | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
 | {{ tx_queue.id }} | {{ type }} | {{ min }} | {{ max }} | {{ prob }} |
-{%                     endif %}
 {%                 endfor %}
 {%             endif %}
 {%             if profile.uc_tx_queues is arista.avd.defined %}
 {%                 for uc_tx_queue in profile.uc_tx_queues | arista.avd.natural_sort(sort_key='id') %}
-{%                     if uc_tx_queue.random_detect.ecn.threshold is arista.avd.defined %}
-{%                         set type = "Unicast" %}
-{%                         set prob = uc_tx_queue.random_detect.ecn.threshold.max_probability | arista.avd.default("-") %}
-{%                         set units = uc_tx_queue.random_detect.ecn.threshold.units %}
-{%                         set min = uc_tx_queue.random_detect.ecn.threshold.min ~ " " ~ units %}
-{%                         set max = uc_tx_queue.random_detect.ecn.threshold.max ~ " " ~ units %}
+{%                     set type = "Unicast" %}
+{%                     set prob = uc_tx_queue.random_detect.ecn.threshold.max_probability | arista.avd.default("-") %}
+{%                     set units = uc_tx_queue.random_detect.ecn.threshold.units | arista.avd.default("") %}
+{%                     set min = (uc_tx_queue.random_detect.ecn.threshold.min | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
+{%                     set max = (uc_tx_queue.random_detect.ecn.threshold.max | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
 | {{ uc_tx_queue.id }} | {{ type }} | {{ min }} | {{ max }} | {{ prob }} |
-{%                     endif %}
 {%                 endfor %}
 {%             endif %}
 {%             if profile.mc_tx_queues is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
@@ -89,22 +89,26 @@
 | -------- | ---- | ------------- | ------------- | -------------------- |
 {%             if profile.tx_queues is arista.avd.defined %}
 {%                 for tx_queue in profile.tx_queues | arista.avd.natural_sort(sort_key='id') %}
-{%                     set type = "All" %}
-{%                     set prob = tx_queue.random_detect.ecn.threshold.max_probability | arista.avd.default("-") %}
-{%                     set units = tx_queue.random_detect.ecn.threshold.units | arista.avd.default("") %}
-{%                     set min = (tx_queue.random_detect.ecn.threshold.min | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
-{%                     set max = (tx_queue.random_detect.ecn.threshold.max | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
+{%                     if tx_queue.random_detect.ecn.threshold is arista.avd.defined %}
+{%                         set type = "All" %}
+{%                         set prob = tx_queue.random_detect.ecn.threshold.max_probability | arista.avd.default("-") %}
+{%                         set units = tx_queue.random_detect.ecn.threshold.units %}
+{%                         set min = tx_queue.random_detect.ecn.threshold.min ~ " " ~ units %}
+{%                         set max = tx_queue.random_detect.ecn.threshold.max ~ " " ~ units %}
 | {{ tx_queue.id }} | {{ type }} | {{ min }} | {{ max }} | {{ prob }} |
+{%                     endif %}
 {%                 endfor %}
 {%             endif %}
 {%             if profile.uc_tx_queues is arista.avd.defined %}
 {%                 for uc_tx_queue in profile.uc_tx_queues | arista.avd.natural_sort(sort_key='id') %}
-{%                     set type = "Unicast" %}
-{%                     set prob = uc_tx_queue.random_detect.ecn.threshold.max_probability | arista.avd.default("-") %}
-{%                     set units = uc_tx_queue.random_detect.ecn.threshold.units | arista.avd.default("") %}
-{%                     set min = (uc_tx_queue.random_detect.ecn.threshold.min | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
-{%                     set max = (uc_tx_queue.random_detect.ecn.threshold.max | arista.avd.default("-")) ~ (" " ~ units if units != "" else "") %}
+{%                     if uc_tx_queue.random_detect.ecn.threshold is arista.avd.defined %}
+{%                         set type = "Unicast" %}
+{%                         set prob = uc_tx_queue.random_detect.ecn.threshold.max_probability | arista.avd.default("-") %}
+{%                         set units = uc_tx_queue.random_detect.ecn.threshold.units %}
+{%                         set min = uc_tx_queue.random_detect.ecn.threshold.min ~ " " ~ units %}
+{%                         set max = uc_tx_queue.random_detect.ecn.threshold.max ~ " " ~ units %}
 | {{ uc_tx_queue.id }} | {{ type }} | {{ min }} | {{ max }} | {{ prob }} |
+{%                     endif %}
 {%                 endfor %}
 {%             endif %}
 {%             if profile.mc_tx_queues is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/qos-profiles.j2
@@ -70,13 +70,15 @@
 {%         endif %}
 {%         set ns = namespace(ecn_table=false) %}
 {%         for tx_queue in profile.tx_queues | arista.avd.default([]) %}
-{%             if tx_queue.random_detect.ecn.threshold.units is arista.avd.defined() %}
+{%             if tx_queue.random_detect.ecn.threshold is arista.avd.defined() %}
 {%                 set ns.ecn_table = true %}
+{%                 break %}
 {%             endif %}
 {%         endfor %}
-{%         for tx_queue in profile.uc_tx_queues | arista.avd.default([]) %}
-{%             if tx_queue.random_detect.ecn.threshold.units is arista.avd.defined() %}
+{%         for uc_tx_queue in profile.uc_tx_queues | arista.avd.default([]) %}
+{%             if uc_tx_queue.random_detect.ecn.threshold is arista.avd.defined() %}
 {%                 set ns.ecn_table = true %}
+{%                 break %}
 {%             endif %}
 {%         endfor %}
 {%         if ns.ecn_table %}


### PR DESCRIPTION

## Change Summary
Optimize ECN threshold detection and fix variable naming in qos-profiles.j2

## Related Issue(s)

Fixes #7222

## Component(s) name
`eos_cli_config_gen `

## Proposed changes
Add early-exit break statements in ECN threshold detection loops for optimization, and fix variable naming from tx_queue to uc_tx_queue in the unicast loop for consistency.

## How to test
Run molecule

## Checklist

### User Checklist
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ECN configuration detection so the ECN Configuration section is generated when an ECN threshold is defined.
  * Prevented redundant queue processing after the applicable ECN threshold is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->