### PR TITLE
Fix(eos_cli_config_gen): Make IP ACL max-entry error path testable without invalid molecule fixtures

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/ip-access-lists-max-entries-exceeded.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/ip-access-lists-max-entries-exceeded.yml
@@ -1,0 +1,23 @@
+# Negative test to catch when the number of ACL entries exceeds the defined maximum
+# and ensure the error message is clear to the user
+ip_access_lists_max_entries: 2
+ip_access_lists:
+  - name: TEST_ACL
+    entries:
+      - sequence: 10
+        action: permit
+        protocol: tcp
+        source: 10.0.0.0/8
+        destination: 192.168.0.0/16
+      - sequence: 20
+        action: permit
+        protocol: udp
+        source: 172.16.0.0/12
+        destination: 192.168.0.0/16
+      - sequence: 30
+        action: deny
+        protocol: ip
+        source: any
+        destination: any
+
+expected_error_message: "Error during plugin execution: The number of ACL entries is above defined maximum!"

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/hosts.yml
@@ -4,5 +4,6 @@ all:
     EOS_CLI_CONFIG_GEN_NEGATIVE_TESTS:
       hosts:
         conflicting-deprecated-and-new-keys:
+        ip-access-lists-max-entries-exceeded:
         router-bfd-dangerous-interval-false:
         router-bfd-dangerous-interval-not-set:

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-access-lists.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-access-lists.j2
@@ -123,7 +123,7 @@ ip access-list {{ acl.name }}
 {%                     set counter.acle_number = counter.acle_number + 1 %}
 {%                     if counter.acle_number > ip_access_lists_max_entries %}
 {#                     j2lint: disable=V1 #}
-   {{ a_non_existing_var | mandatory('The number of ACL entries is above defined maximum!') }}
+   {{ a_non_existing_var | arista.avd._mandatory('The number of ACL entries is above defined maximum!') }}
 {%                     endif %}
 {%                 endif %}
 {%             endif %}

--- a/python-avd/pyavd/j2filters/_mandatory.py
+++ b/python-avd/pyavd/j2filters/_mandatory.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from typing import Any
+
+from jinja2.runtime import Undefined
+
+from pyavd._errors import AristaAvdInvalidInputsError
+
+
+def _mandatory(value: Any, msg: str | None = None) -> Any:
+    """
+    Hidden compatibility shim for legacy eos_cli_config_gen templates.
+
+    This only restores the small part of Ansible's mandatory filter behavior
+    needed by templates that moved from Ansible templating to PyAVD templating.
+    Do not use this for new validation; prefer schema or Python validation.
+    """
+    if isinstance(value, Undefined) or value is None:
+        raise AristaAvdInvalidInputsError(msg or "Mandatory variable is not defined.")
+
+    return value

--- a/python-avd/pyavd/templater.py
+++ b/python-avd/pyavd/templater.py
@@ -134,6 +134,7 @@ class Templar:
             snmp_hash,
             status_render,
         )
+        from .j2filters._mandatory import _mandatory  # noqa: PLC0415
         from .j2tests.contains import contains  # noqa: PLC0415
         from .j2tests.defined import defined  # noqa: PLC0415
 
@@ -146,6 +147,10 @@ class Templar:
                 "arista.avd.hide_passwords": hide_passwords,
                 "arista.avd.is_in_filter": is_in_filter,
                 "arista.avd.list_compress": list_compress,
+                # Hidden compatibility shim for legacy templates that relied on
+                # Ansible's mandatory filter before PyAVD owned rendering.
+                # Do not document or use for new validation.
+                "arista.avd._mandatory": _mandatory,
                 "arista.avd.natural_sort": natural_sort,
                 "arista.avd.range_expand": range_expand,
                 "arista.avd.snmp_hash": snmp_hash,

--- a/python-avd/tests/pyavd/j2filters/test_mandatory.py
+++ b/python-avd/tests/pyavd/j2filters/test_mandatory.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from re import escape
+from typing import Any
+
+import pytest
+from jinja2.runtime import Undefined
+
+from pyavd._errors import AristaAvdInvalidInputsError
+from pyavd.j2filters._mandatory import _mandatory
+
+
+def test_mandatory_returns_defined_value() -> None:
+    assert _mandatory("value", "custom error") == "value"
+
+
+@pytest.mark.parametrize("value", [Undefined(name="a_non_existing_var"), None])
+def test_mandatory_raises_custom_message(value: Any) -> None:
+    with pytest.raises(AristaAvdInvalidInputsError, match=escape("The number of ACL entries is above defined maximum!")):
+        _mandatory(value, "The number of ACL entries is above defined maximum!")
+
+
+def test_mandatory_raises_default_message() -> None:
+    with pytest.raises(AristaAvdInvalidInputsError, match=escape("Mandatory variable is not defined.")):
+        _mandatory(Undefined(name="a_non_existing_var"))


### PR DESCRIPTION

## Change Summary
Make IP ACL max-entry error path testable without invalid molecule fixtures

## Related Issue(s)

Fixes #7131 

## Component(s) name

`arista.avd. eos_cli_config_gen `

## Proposed changes
**Created:** `/inventory/host_vars/ip-access-lists-max-entries-exceeded.yml`

-  Sets ip_access_lists_max_entries: 2 (limit)
- Defines 3 ACL entries (exceeds limit)
- Includes expected error message that matches the template

Updated: `/inventory/hosts.yml`


## How to test
Run Molecule

## Checklist

### User Checklist
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for stricter ACL entry-limit validation with clearer failure handling.
  * Introduced a compatibility filter to preserve expected template behavior in more cases.

* **Bug Fixes**
  * Improved error handling when ACL configurations exceed the configured maximum entries.
  * Added coverage for invalid input scenarios, including missing or empty values.

* **Tests**
  * Added negative test coverage for ACL entry-limit violations.
  * Added unit tests for the new compatibility filter and its error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->