### PR TITLE
Refactor: Remove quotes for AVDActionPlugin AnsibleActionFail errors

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/conflicting-deprecated-and-new-keys.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/conflicting-deprecated-and-new-keys.yml
@@ -69,5 +69,5 @@ router_bgp:
             enabled: true
 
 expected_error_message: >-
-  Error during plugin 'arista.avd.eos_cli_config_gen' execution: 'Missing the validated structured config for host 'conflicting-deprecated-and-new-keys'.
-  Ensure the 'arista.avd.validate_inputs' task ran successfully for this host and that no validation errors occurred.'
+  Error during plugin 'arista.avd.eos_cli_config_gen' execution: Missing the validated structured config for host 'conflicting-deprecated-and-new-keys'.
+  Ensure the 'arista.avd.validate_inputs' task ran successfully for this host and that no validation errors occurred.

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/ip-access-lists-max-entries-exceeded.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/ip-access-lists-max-entries-exceeded.yml
@@ -21,5 +21,4 @@ ip_access_lists:
         destination: any
 
 expected_error_message: >-
-  Error during plugin 'arista.avd.eos_cli_config_gen' execution:
-  'The number of ACL entries is above defined maximum!'
+  Error during plugin 'arista.avd.eos_cli_config_gen' execution: The number of ACL entries is above defined maximum!

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/router-bfd-dangerous-interval-false.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/router-bfd-dangerous-interval-false.yml
@@ -5,5 +5,4 @@ router_bfd:
   session_snapshot_interval_dangerous: false
 
 expected_error_message: >-
-  Error during plugin 'arista.avd.eos_cli_config_gen' execution:
-  'router_bfd.session_snapshot_interval_dangerous was set to False but we expected True!'
+  Error during plugin 'arista.avd.eos_cli_config_gen' execution: router_bfd.session_snapshot_interval_dangerous was set to False but we expected True!

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/router-bfd-dangerous-interval-not-set.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen_negative_unit_tests/inventory/host_vars/router-bfd-dangerous-interval-not-set.yml
@@ -4,5 +4,4 @@ router_bfd:
   session_snapshot_interval: 3
 
 expected_error_message: >-
-  Error during plugin 'arista.avd.eos_cli_config_gen' execution:
-  'router_bfd.session_snapshot_interval_dangerous was expected but not set!'
+  Error during plugin 'arista.avd.eos_cli_config_gen' execution: router_bfd.session_snapshot_interval_dangerous was expected but not set!

--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/avd_action_plugin/avd_action_plugin.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/avd_action_plugin/avd_action_plugin.py
@@ -106,7 +106,7 @@ class AVDActionPlugin(ActionBase):
 
         except Exception as exc:
             # Recast errors as AnsibleActionFail
-            msg = f"Error during plugin '{self.ansible_name}' execution: '{exc}'"
+            msg = f"Error during plugin '{self.ansible_name}' execution: {exc}"
             raise_action_fail(msg, exc)
 
         return self.result

--- a/ansible_collections/arista/avd/tests/integration/targets/validate_inputs/tests/test_validate_inputs_missing_file.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/validate_inputs/tests/test_validate_inputs_missing_file.yml
@@ -19,4 +19,4 @@
       - expected_error in result.msg
   vars:
     expected_error: |-
-      Error during plugin 'arista.avd.validate_inputs' execution: 'Unexpected errors occurred while processing 1 host(s): testhost.
+      Error during plugin 'arista.avd.validate_inputs' execution: Unexpected errors occurred while processing 1 host(s): testhost.

--- a/ansible_collections/arista/avd/tests/unit/action/test_eos_cli_config_gen.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_eos_cli_config_gen.py
@@ -194,7 +194,7 @@ def test_run_wraps_exceptions_as_action_fail(action_module: Callable[..., Action
         patch(f"{MODULE_PATH}.get_device_config", side_effect=original_error, create=True),
         patch(f"{LOG_HANDLERS_PATH}.Display", return_value=shared_display),
         patch(f"{LOG_CONFIG_PATH}.Display", return_value=shared_display),
-        pytest.raises(AnsibleActionFail, match=r"Error during plugin 'arista.avd.eos_cli_config_gen' execution: 'pyavd exploded'") as exc_info,
+        pytest.raises(AnsibleActionFail, match=r"Error during plugin 'arista.avd.eos_cli_config_gen' execution: pyavd exploded") as exc_info,
     ):
         module.run(task_vars={"inventory_hostname": "test-device"})
 

--- a/ansible_collections/arista/avd/tests/unit/action/test_eos_designs_documentation.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_eos_designs_documentation.py
@@ -139,7 +139,7 @@ def test_run_wraps_exceptions_as_action_fail(action_module: Callable[..., Action
         patch(f"{MODULE_PATH}.get_fabric_documentation", side_effect=original_error),
         patch(f"{LOG_HANDLERS_PATH}.Display", return_value=shared_display),
         patch(f"{LOG_CONFIG_PATH}.Display", return_value=shared_display),
-        pytest.raises(AnsibleActionFail, match=r"Error during plugin 'arista.avd.eos_designs_documentation' execution: 'pyavd exploded'") as exc_info,
+        pytest.raises(AnsibleActionFail, match=r"Error during plugin 'arista.avd.eos_designs_documentation' execution: pyavd exploded") as exc_info,
     ):
         module.run(task_vars={"fabric_name": FABRIC_NAME, "inventory_hostname": "spine1"})
 

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
@@ -99,7 +99,7 @@ class TestAVDActionPlugin:
 
         plugin = self._plugin_factory(ActionModule)
 
-        with pytest.raises(AnsibleActionFail, match="Error during plugin 'pytest_action_plugin' execution: 'Something went wrong'"):
+        with pytest.raises(AnsibleActionFail, match="Error during plugin 'pytest_action_plugin' execution: Something went wrong"):
             plugin.run()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

As reported in the issue

## Related Issue(s)

Fixes #7231 

## Component(s) name

`arista.avd`

## Proposed changes

* Remove the quotes
* Refactor the tests

## How to test

CI is green

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Aligned several plugin and validation error messages with the actual output shown during failures.
  * Removed extra quote characters and corrected string formatting mismatches in reported error text.
  * Updated affected negative and unit tests (and expected error fixtures) to match the corrected error message format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->