### PR TITLE
Test: Refactor AVDActionPlugin test fixture

### DIFF
--- a/ansible_collections/arista/avd/tests/unit/action/conftest.py
+++ b/ansible_collections/arista/avd/tests/unit/action/conftest.py
@@ -5,14 +5,11 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 
 import pytest
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator
-
-    from ansible.plugins.action import ActionBase
+    from collections.abc import Generator
 
 
 @pytest.fixture(autouse=True)
@@ -27,30 +24,3 @@ def reset_avd_logger() -> Generator[None, None, None]:
     logger.propagate = original_propagate
     logger.handlers = original_handlers
     logger.setLevel(original_level)
-
-
-@pytest.fixture
-def action_module() -> Callable[..., ActionBase]:
-    """
-    Factory that builds an ActionModule instance with mocked Ansible plumbing.
-
-    Each test passes the specific ``ActionModule`` class under test (e.g. the one from
-    ``plugins.action.eos_cli_config_gen``, ``plugins.action.eos_designs_documentation``, ``plugins.action.eos_designs_facts``,
-    ``plugins.action.eos_designs_structured_config`` or ``plugins.action.validate_inputs``).
-    """
-
-    def _factory(action_module_cls: type[ActionBase], task_args: dict | None = None) -> ActionBase:
-        mock_task = MagicMock()
-        mock_task.args = task_args or {}
-        mock_task.async_val = False
-        mock_task.check_mode = False
-        return action_module_cls(
-            task=mock_task,
-            connection=MagicMock(),
-            play_context=MagicMock(),
-            loader=MagicMock(),
-            templar=MagicMock(),
-            shared_loader_obj=MagicMock(),
-        )
-
-    return _factory

--- a/ansible_collections/arista/avd/tests/unit/action/test_eos_designs_documentation.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_eos_designs_documentation.py
@@ -122,8 +122,7 @@ def test_load_facts_raises_with_path_and_upstream_task_when_file_missing(action_
 
 def test_run_wraps_exceptions_as_action_fail(action_module: Callable[..., ActionModule], tmp_path: Path) -> None:
     """Test that any exception during execution is wrapped with the 'Error during plugin ... execution:' prefix and chained."""
-    module = action_module(ActionModule)
-    module.ansible_name = "arista.avd.eos_designs_documentation"  # pyright: ignore[reportAttributeAccessIssue]
+    module = action_module(ActionModule, ansible_name="arista.avd.eos_designs_documentation")
     facts_path = tmp_path / "eos_designs_facts.json"
     facts_path.write_text(json.dumps({"spine1": {}}), encoding="UTF-8")
     validated_args = {**BASE_VALIDATED_ARGS, "structured_config_dir": str(tmp_path)}
@@ -148,8 +147,7 @@ def test_run_wraps_exceptions_as_action_fail(action_module: Callable[..., Action
 
 def test_run_raises_when_pyavd_not_installed(action_module: Callable[..., ActionModule]) -> None:
     """Test that AnsibleActionFail is raised immediately when pyavd is missing."""
-    module = action_module(ActionModule)
-    module.ansible_name = "arista.avd.eos_designs_documentation"  # pyright: ignore[reportAttributeAccessIssue]
+    module = action_module(ActionModule, ansible_name="arista.avd.eos_designs_documentation")
     shared_display = MagicMock(verbosity=0)
 
     with (

--- a/ansible_collections/arista/avd/tests/unit/conftest.py
+++ b/ansible_collections/arista/avd/tests/unit/conftest.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ansible.plugins.action import ActionBase
+
+
+@pytest.fixture
+def action_module() -> Callable[..., ActionBase]:
+    """
+    Factory that builds an ActionModule instance with mocked Ansible plumbing.
+
+    Each test passes the specific ``ActionModule`` class under test.
+    Tests can pass ``ansible_name`` to model plugin metadata normally injected by Ansible's plugin loader.
+    """
+
+    def _factory(action_module_cls: type[ActionBase], task_args: dict[str, Any] | None = None, *, ansible_name: str | None = None) -> ActionBase:
+        mock_task = MagicMock()
+        mock_task.args = task_args or {}
+        mock_task.async_val = False
+        mock_task.check_mode = False
+        module = action_module_cls(
+            task=mock_task,
+            connection=MagicMock(),
+            play_context=MagicMock(),
+            loader=MagicMock(),
+            templar=MagicMock(),
+            shared_loader_obj=MagicMock(),
+        )
+        if ansible_name is not None:
+            module.ansible_name = ansible_name
+        return module
+
+    return _factory

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/utils/test_avd_action_plugin.py
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file.
 import logging
 import warnings
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import ExitStack
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -42,22 +42,7 @@ class TestAVDActionPlugin:
 
             yield shared_mock_instance
 
-    def _plugin_factory(self, cls: type[AVDActionPlugin], task_args: dict[str, Any] | None = None) -> AVDActionPlugin:
-        """Factory method to instantiate the provided AVDActionPlugin class with mocks for testing."""
-        # Create mock objects for the Ansible ActionBase constructor arguments
-        mock_task = MagicMock()
-        mock_task.args = task_args or {}
-        mock_task.async_val = False
-        mock_task.check_mode = False
-
-        # Return the instantiated plugin class with a full set of mocks
-        instance = cls(task=mock_task, connection=MagicMock(), play_context=MagicMock(), loader=MagicMock(), templar=MagicMock(), shared_loader_obj=MagicMock())
-
-        # Ignoring Pyright since 'ansible_name' is not typed in Ansible world
-        instance.ansible_name = "pytest_action_plugin"  # pyright: ignore[reportAttributeAccessIssue]
-        return instance
-
-    def test_wrong_logging_config(self) -> None:
+    def test_wrong_logging_config(self, action_module: Callable[..., AVDActionPlugin]) -> None:
         """Test that an exception is raised when _primary_logger_name is not part of the targeted loggers."""
 
         class ActionModule(AVDActionPlugin):
@@ -71,9 +56,9 @@ class TestAVDActionPlugin:
             "the _logging_config.target_loggers tuple for the plugin to work correctly."
         )
         with pytest.raises(ValueError, match=match):
-            self._plugin_factory(ActionModule)
+            action_module(ActionModule)
 
-    def test_run_success(self) -> None:
+    def test_run_success(self, action_module: Callable[..., AVDActionPlugin]) -> None:
         """Test a successful run of the plugin."""
 
         class ActionModule(AVDActionPlugin):
@@ -81,14 +66,14 @@ class TestAVDActionPlugin:
                 _task_vars = task_vars
                 self.result["status"] = "success"
 
-        plugin = self._plugin_factory(cls=ActionModule)
+        plugin = action_module(ActionModule)
 
         result = plugin.run()
 
         assert result["status"] == "success"
         assert "failed" not in result
 
-    def test_run_failure_recast_as_ansible_exception(self) -> None:
+    def test_run_failure_recast_as_ansible_exception(self, action_module: Callable[..., AVDActionPlugin]) -> None:
         """Test that a generic exception in main() is recast as AnsibleActionFail."""
 
         class ActionModule(AVDActionPlugin):
@@ -97,7 +82,7 @@ class TestAVDActionPlugin:
                 msg = "Something went wrong"
                 raise ValueError(msg)
 
-        plugin = self._plugin_factory(ActionModule)
+        plugin = action_module(ActionModule, ansible_name="pytest_action_plugin")
 
         with pytest.raises(AnsibleActionFail, match="Error during plugin 'pytest_action_plugin' execution: 'Something went wrong'"):
             plugin.run()
@@ -167,7 +152,9 @@ class TestAVDActionPlugin:
             ),
         ],
     )
-    def test_log_levels_set_by_verbosity(self, mock_display: MagicMock, verbosity: int, expected_levels: dict[str, int]) -> None:
+    def test_log_levels_set_by_verbosity(
+        self, action_module: Callable[..., AVDActionPlugin], mock_display: MagicMock, verbosity: int, expected_levels: dict[str, int]
+    ) -> None:
         """Test that log levels are set correctly based on verbosity for both internal and external libraries."""
 
         class ActionModule(AVDActionPlugin):
@@ -181,7 +168,7 @@ class TestAVDActionPlugin:
                     logger = logging.getLogger(logger_name)
                     assert logger.level == expected_level
 
-        plugin = self._plugin_factory(ActionModule)
+        plugin = action_module(ActionModule)
 
         # Set the desired verbosity and run the plugin
         mock_display.verbosity = verbosity
@@ -195,7 +182,9 @@ class TestAVDActionPlugin:
             pytest.param(3, ["vvv", "v", "warning", "error"], id="v3-debug_enabled"),
         ],
     )
-    def test_default_logging_behavior(self, mock_display: MagicMock, verbosity: int, expected_methods_called: list[str]) -> None:
+    def test_default_logging_behavior(
+        self, action_module: Callable[..., AVDActionPlugin], mock_display: MagicMock, verbosity: int, expected_methods_called: list[str]
+    ) -> None:
         """Test the end-to-end default logging behavior (live display on, save logs off)."""
 
         class ActionModule(AVDActionPlugin):
@@ -206,7 +195,7 @@ class TestAVDActionPlugin:
                 self.logger.warning("A warning message.")
                 self.logger.error("An error message.")
 
-        plugin = self._plugin_factory(ActionModule)
+        plugin = action_module(ActionModule)
 
         # Set the desired verbosity and run the plugin
         mock_display.verbosity = verbosity
@@ -240,6 +229,7 @@ class TestAVDActionPlugin:
     )
     def test_logging_with_context_and_format(
         self,
+        action_module: Callable[..., AVDActionPlugin],
         mock_display: MagicMock,
         add_hostname: bool,
         add_role: bool,
@@ -255,7 +245,7 @@ class TestAVDActionPlugin:
                 _task_vars = task_vars
                 self.logger.warning("A message from the plugin.")
 
-        plugin = self._plugin_factory(ActionModule)
+        plugin = action_module(ActionModule)
 
         plugin.run(task_vars=task_vars)
 
@@ -264,7 +254,7 @@ class TestAVDActionPlugin:
         mock_display.warning.assert_called_once_with(expected_message)
 
     @pytest.mark.usefixtures("mock_display")
-    def test_logging_with_save_logs(self) -> None:
+    def test_logging_with_save_logs(self, action_module: Callable[..., AVDActionPlugin]) -> None:
         """Test that logs are saved to the result."""
 
         class ActionModule(AVDActionPlugin):
@@ -275,14 +265,14 @@ class TestAVDActionPlugin:
                 self.logger.info("An info message not to save.")
 
         # Enable the feature via task args
-        plugin = self._plugin_factory(ActionModule, task_args={"save_logs": True})
+        plugin = action_module(ActionModule, task_args={"save_logs": True})
         result = plugin.run()
 
         # Assert that the logs were saved to the result dictionary
         assert result["logs"]["warnings"] == ["A warning to save."]
         assert result["logs"]["errors"] == ["An error to save."]
 
-    def test_logging_with_live_display_false(self, mock_display: MagicMock) -> None:
+    def test_logging_with_live_display_false(self, action_module: Callable[..., AVDActionPlugin], mock_display: MagicMock) -> None:
         """Test that logs are never displayed in Ansible."""
 
         class ActionModule(AVDActionPlugin):
@@ -291,7 +281,7 @@ class TestAVDActionPlugin:
                 self.logger.info("This should not be displayed live.")
 
         # Enable the feature via task args
-        plugin = self._plugin_factory(ActionModule, task_args={"live_display": False})
+        plugin = action_module(ActionModule, task_args={"live_display": False})
 
         # Set the desired verbosity and run the plugin
         mock_display.verbosity = 1
@@ -307,7 +297,7 @@ class TestAVDActionPlugin:
             pytest.param(DeprecationWarning, "This is a deprecation.", "deprecations", id="deprecation_warning"),
         ],
     )
-    def test_warning_capture(self, warning_type: type[Warning], message: str, expected_key: str) -> None:
+    def test_warning_capture(self, action_module: Callable[..., AVDActionPlugin], warning_type: type[Warning], message: str, expected_key: str) -> None:
         """Test that Python warnings are captured and added to the correct list in the result."""
 
         class ActionModule(AVDActionPlugin):
@@ -315,7 +305,7 @@ class TestAVDActionPlugin:
                 _task_vars = task_vars
                 warnings.warn(message, warning_type, stacklevel=1)
 
-        plugin = self._plugin_factory(ActionModule)
+        plugin = action_module(ActionModule)
 
         result = plugin.run()
 
@@ -325,7 +315,7 @@ class TestAVDActionPlugin:
         else:
             assert result[expected_key] == [message]
 
-    def test_handles_dirty_logger_state(self) -> None:
+    def test_handles_dirty_logger_state(self, action_module: Callable[..., AVDActionPlugin]) -> None:
         """Test that the plugin can handle a logger with pre-existing handlers and restore them correctly upon exit."""
 
         class ActionModule(AVDActionPlugin):
@@ -352,7 +342,7 @@ class TestAVDActionPlugin:
             # The plugin should restore all existing handlers, including pytest-owned handlers.
             expected_handlers = [*original_handlers, sticky_handler]
 
-            plugin = self._plugin_factory(ActionModule)
+            plugin = action_module(ActionModule)
             plugin.run()
 
             assert logger.handlers == expected_handlers


### PR DESCRIPTION
## Change Summary

Refactor Ansible action plugin unit test setup to share the mocked `ActionModule` factory across unit tests and make `ansible_name` setup explicit where failure messages depend on it.

## Component(s) name

`tests`

## Proposed changes

- Move the common `action_module` fixture to `ansible_collections/arista/avd/tests/unit/conftest.py` so action plugin unit tests and plugin utility tests can reuse it.
- Keep the AVD logger reset fixture scoped to `tests/unit/action`.
- Replace direct per-test `ansible_name` assignment with the shared fixture parameter.
- Remove the duplicate `_plugin_factory` from `test_avd_action_plugin.py`.

## How to test

Tests are green 🍏 

## Checklist


### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the CONTRIBUTING (https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and the documentation has been updated accordingly. (not applicable, test-only refactor)
- [x] I have updated molecule CI (https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (not applicable, unit-test-only refactor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolation for action plugin tests, reducing cross-test interference from logging state.
  * Kept action plugin error handling and log-related behavior covered by updated test scenarios.

* **Tests**
  * Added a shared test setup for creating action plugin instances with consistent defaults.
  * Updated unit tests to use the new setup and verify logging, warnings capture, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->