### PR TITLE
Feat(eos_cli_config_gen):  Add support for enforce-first-as in router bgp

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -9889,11 +9889,13 @@ ASN Notation: asdot
 
 | Settings | Value |
 | -------- | ----- |
+| Enforce first AS | False |
 
 ##### TEST-ENFORCE-FIRST-AS-TRUE
 
 | Settings | Value |
 | -------- | ----- |
+| Enforce first AS | True |
 
 ##### test-link-bandwidth1
 

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -9988,6 +9988,7 @@ ASN Notation: asdot
 | 10.255.251.3 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | TENANT_A_PROJECT02 | - | large | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
 | 10.255.251.4 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | TENANT_A_PROJECT02 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | True | - | - | - | - |
 | 1.1.1.1 | - | VRF02 | - | - | - | - | - | - | - | - | - |
+| 1.2.3.5 | - | VRF02 | - | - | - | - | - | - | - | - | - |
 | 10.1.1.0 | Inherited from peer group OBS_WAN | YELLOW-C1 | - | - | - | - | Inherited from peer group OBS_WAN(interval: 2000, min_rx: 2000, multiplier: 3) | - | - | - | - |
 
 #### BGP Neighbor Interfaces
@@ -11441,6 +11442,8 @@ router bgp 65101
       neighbor 1.1.1.1 additional-paths receive
       neighbor 1.1.1.1 additional-paths send ecmp limit 24
       neighbor 1.1.1.1 password 7 <removed>
+      neighbor 1.1.1.1 enforce-first-as
+      no neighbor 1.2.3.5 enforce-first-as
       redistribute connected include leaked route-map RM_VRF_CONNECTED
       redistribute isis level-2 include leaked route-map RM_VRF_ISIS
       redistribute ospf include leaked route-map RM_VRF_OSPF

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -9885,6 +9885,16 @@ ASN Notation: asdot
 | -------- | ----- |
 | TTL Max Hops | 42 |
 
+##### TEST-ENFORCE-FIRST-AS-FALSE
+
+| Settings | Value |
+| -------- | ----- |
+
+##### TEST-ENFORCE-FIRST-AS-TRUE
+
+| Settings | Value |
+| -------- | ----- |
+
 ##### test-link-bandwidth1
 
 | Settings | Value |
@@ -9953,6 +9963,8 @@ ASN Notation: asdot
 | 192.0.3.7 | 65438 | default | - | - | - | - | - | - | True | - | - |
 | 192.0.3.8 | 65438 | default | - | - | - | - | True | - | - | - | Inherited from peer group TEST |
 | 192.0.3.9 | 65438 | default | - | - | - | - | False | - | - | - | Inherited from peer group TEST |
+| 192.168.0.11 | - | default | - | - | - | - | - | - | - | - | - |
+| 192.168.0.12 | - | default | - | - | - | - | - | - | - | - | - |
 | 192.168.42.42 | 65004 | default | - | - | - | - | - | - | - | - | - |
 | 192.168.251.1 | - | default | True | - | - | - | - | - | - | - | - |
 | 192.168.251.2 | - | default | - | - | - | - | - | - | - | - | - |
@@ -9988,7 +10000,7 @@ ASN Notation: asdot
 | 10.255.251.3 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | TENANT_A_PROJECT02 | - | large | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
 | 10.255.251.4 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | TENANT_A_PROJECT02 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | True | - | - | - | - |
 | 1.1.1.1 | - | VRF02 | - | - | - | - | - | - | - | - | - |
-| 1.2.3.5 | - | VRF02 | - | - | - | - | - | - | - | - | - |
+| 192.168.0.10 | - | VRF02 | - | - | - | - | - | - | - | - | - |
 | 10.1.1.0 | Inherited from peer group OBS_WAN | YELLOW-C1 | - | - | - | - | Inherited from peer group OBS_WAN(interval: 2000, min_rx: 2000, multiplier: 3) | - | - | - | - |
 
 #### BGP Neighbor Interfaces
@@ -10426,6 +10438,10 @@ router bgp 65101
    neighbor STARDARD-COMMUNITY send-community standard
    neighbor TEST peer group
    neighbor TEST ttl maximum-hops 42
+   neighbor TEST-ENFORCE-FIRST-AS-FALSE peer group
+   no neighbor TEST-ENFORCE-FIRST-AS-FALSE enforce-first-as
+   neighbor TEST-ENFORCE-FIRST-AS-TRUE peer group
+   neighbor TEST-ENFORCE-FIRST-AS-TRUE enforce-first-as
    neighbor test-link-bandwidth1 peer group
    neighbor test-link-bandwidth1 ttl maximum-hops 1
    neighbor test-link-bandwidth1 missing-policy address-family all include community-list prefix-list direction in action deny
@@ -10515,6 +10531,8 @@ router bgp 65101
    neighbor 192.0.3.9 peer group TEST
    neighbor 192.0.3.9 remote-as 65438
    no neighbor 192.0.3.9 bfd
+   neighbor 192.168.0.11 enforce-first-as
+   no neighbor 192.168.0.12 enforce-first-as
    neighbor 192.168.42.42 remote-as 65004
    neighbor 192.168.42.42 next-hop-self
    neighbor 192.168.251.1 shutdown
@@ -11443,7 +11461,7 @@ router bgp 65101
       neighbor 1.1.1.1 additional-paths send ecmp limit 24
       neighbor 1.1.1.1 password 7 <removed>
       neighbor 1.1.1.1 enforce-first-as
-      no neighbor 1.2.3.5 enforce-first-as
+      no neighbor 192.168.0.10 enforce-first-as
       redistribute connected include leaked route-map RM_VRF_CONNECTED
       redistribute isis level-2 include leaked route-map RM_VRF_ISIS
       redistribute ospf include leaked route-map RM_VRF_OSPF

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -6245,6 +6245,10 @@ router bgp 65101
    neighbor STARDARD-COMMUNITY send-community standard
    neighbor TEST peer group
    neighbor TEST ttl maximum-hops 42
+   neighbor TEST-ENFORCE-FIRST-AS-FALSE peer group
+   no neighbor TEST-ENFORCE-FIRST-AS-FALSE enforce-first-as
+   neighbor TEST-ENFORCE-FIRST-AS-TRUE peer group
+   neighbor TEST-ENFORCE-FIRST-AS-TRUE enforce-first-as
    neighbor test-link-bandwidth1 peer group
    neighbor test-link-bandwidth1 ttl maximum-hops 1
    neighbor test-link-bandwidth1 missing-policy address-family all include community-list prefix-list direction in action deny
@@ -6334,6 +6338,8 @@ router bgp 65101
    neighbor 192.0.3.9 peer group TEST
    neighbor 192.0.3.9 remote-as 65438
    no neighbor 192.0.3.9 bfd
+   neighbor 192.168.0.11 enforce-first-as
+   no neighbor 192.168.0.12 enforce-first-as
    neighbor 192.168.42.42 remote-as 65004
    neighbor 192.168.42.42 next-hop-self
    neighbor 192.168.251.1 shutdown
@@ -7262,7 +7268,7 @@ router bgp 65101
       neighbor 1.1.1.1 additional-paths send ecmp limit 24
       neighbor 1.1.1.1 password 7 CRWZZy7NjZF5vUQbiZLrzw==
       neighbor 1.1.1.1 enforce-first-as
-      no neighbor 1.2.3.5 enforce-first-as
+      no neighbor 192.168.0.10 enforce-first-as
       redistribute connected include leaked route-map RM_VRF_CONNECTED
       redistribute isis level-2 include leaked route-map RM_VRF_ISIS
       redistribute ospf include leaked route-map RM_VRF_OSPF

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -7261,6 +7261,8 @@ router bgp 65101
       neighbor 1.1.1.1 additional-paths receive
       neighbor 1.1.1.1 additional-paths send ecmp limit 24
       neighbor 1.1.1.1 password 7 CRWZZy7NjZF5vUQbiZLrzw==
+      neighbor 1.1.1.1 enforce-first-as
+      no neighbor 1.2.3.5 enforce-first-as
       redistribute connected include leaked route-map RM_VRF_CONNECTED
       redistribute isis level-2 include leaked route-map RM_VRF_ISIS
       redistribute ospf include leaked route-map RM_VRF_OSPF

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
@@ -1711,7 +1711,6 @@ router_bgp:
             additional_paths:
               receive: true
               send: any
-
         networks:
           - prefix: 2.3.4.0/24
             route_map: BARFOO

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
@@ -1711,6 +1711,7 @@ router_bgp:
             additional_paths:
               receive: true
               send: any
+
         networks:
           - prefix: 2.3.4.0/24
             route_map: BARFOO
@@ -1949,6 +1950,9 @@ router_bgp:
             receive: true
             send: ecmp
             send_limit: 24
+          enforce_first_as: true
+        - ip_address: 1.2.3.5
+          enforce_first_as: false
       bgp:
         additional_paths:
           send: limit

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
@@ -300,6 +300,10 @@ router_bgp:
       description: 'BGP Connection in passive mode'
       remote_as: 65003
       passive: true
+    - name: TEST-ENFORCE-FIRST-AS-TRUE
+      enforce_first_as: true
+    - name: TEST-ENFORCE-FIRST-AS-FALSE
+      enforce_first_as: false
   aggregate_addresses:
     - prefix: 1.1.1.0/24
       advertise_only: true
@@ -1516,6 +1520,10 @@ router_bgp:
       peer_group: TEST
       bfd: false
       remote_as: 65438
+    - ip_address: 192.168.0.11
+      enforce_first_as: true
+    - ip_address: 192.168.0.12
+      enforce_first_as: false
   neighbor_interfaces:
     - name: Ethernet2
       peer_group: PG-FOO-v4
@@ -1950,7 +1958,7 @@ router_bgp:
             send: ecmp
             send_limit: 24
           enforce_first_as: true
-        - ip_address: 1.2.3.5
+        - ip_address: 192.168.0.10
           enforce_first_as: false
       bgp:
         additional_paths:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -1205,6 +1205,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.vrfs.[].neighbors.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.vrfs.[].neighbors.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].neighbors.[].default_originate.route_map") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.vrfs.[].neighbors.[].enforce_first_as") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;update_source</samp>](## "router_bgp.vrfs.[].neighbors.[].update_source") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name. |
@@ -4146,6 +4147,7 @@
                 enabled: <bool>
                 always: <bool>
                 route_map: <str>
+              enforce_first_as: <bool>
               update_source: <str>
 
               # Inbound route-map name.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -110,6 +110,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "router_bgp.peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "router_bgp.peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "router_bgp.peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -178,6 +179,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.neighbors.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.neighbors.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.neighbors.[].default_originate.route_map") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.neighbors.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "router_bgp.neighbors.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "router_bgp.neighbors.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "router_bgp.neighbors.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -1870,6 +1872,9 @@
             # Route-map name.
             route_map: <str>
 
+          # Enforce the first AS for eBGP routes (default).
+          enforce_first_as: <bool>
+
           # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
           send_community: <str>
 
@@ -2022,6 +2027,9 @@
             enabled: <bool>
             always: <bool>
             route_map: <str>
+
+          # Enforce the first AS for eBGP routes (default).
+          enforce_first_as: <bool>
 
           # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
           send_community: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -110,7 +110,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS in eBGP updates. EOS default is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "router_bgp.peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "router_bgp.peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "router_bgp.peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -179,7 +179,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.neighbors.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.neighbors.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.neighbors.[].default_originate.route_map") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.neighbors.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.neighbors.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS in eBGP updates. EOS default is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "router_bgp.neighbors.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "router_bgp.neighbors.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "router_bgp.neighbors.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -1207,7 +1207,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.vrfs.[].neighbors.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.vrfs.[].neighbors.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].neighbors.[].default_originate.route_map") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.vrfs.[].neighbors.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.vrfs.[].neighbors.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS in eBGP updates. EOS default is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;update_source</samp>](## "router_bgp.vrfs.[].neighbors.[].update_source") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name. |
@@ -1872,7 +1872,7 @@
             # Route-map name.
             route_map: <str>
 
-          # Enforce the first AS for eBGP routes (default).
+          # Enforce the first AS in eBGP updates. EOS default is true.
           enforce_first_as: <bool>
 
           # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
@@ -2028,7 +2028,7 @@
             always: <bool>
             route_map: <str>
 
-          # Enforce the first AS for eBGP routes (default).
+          # Enforce the first AS in eBGP updates. EOS default is true.
           enforce_first_as: <bool>
 
           # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
@@ -4156,7 +4156,7 @@
                 always: <bool>
                 route_map: <str>
 
-              # Enforce the first AS for eBGP routes (default).
+              # Enforce the first AS in eBGP updates. EOS default is true.
               enforce_first_as: <bool>
               update_source: <str>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -1205,7 +1205,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_bgp.vrfs.[].neighbors.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.vrfs.[].neighbors.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].neighbors.[].default_originate.route_map") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.vrfs.[].neighbors.[].enforce_first_as") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "router_bgp.vrfs.[].neighbors.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;update_source</samp>](## "router_bgp.vrfs.[].neighbors.[].update_source") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.vrfs.[].neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name. |
@@ -4147,6 +4147,8 @@
                 enabled: <bool>
                 always: <bool>
                 route_map: <str>
+
+              # Enforce the first AS for eBGP routes (default).
               enforce_first_as: <bool>
               update_source: <str>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
@@ -76,6 +76,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -212,6 +213,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -317,6 +319,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "network_services.[].bgp_peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "network_services.[].bgp_peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "network_services.[].bgp_peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "network_services.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "network_services.[].bgp_peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "network_services.[].bgp_peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "network_services.[].bgp_peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -453,6 +456,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -656,6 +660,9 @@
 
               # Route-map name.
               route_map: <str>
+
+            # Enforce the first AS for eBGP routes (default).
+            enforce_first_as: <bool>
 
             # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
             send_community: <str>
@@ -1000,6 +1007,9 @@
 
                   # Route-map name.
                   route_map: <str>
+
+                # Enforce the first AS for eBGP routes (default).
+                enforce_first_as: <bool>
 
                 # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                 send_community: <str>
@@ -1251,6 +1261,9 @@
               # Route-map name.
               route_map: <str>
 
+            # Enforce the first AS for eBGP routes (default).
+            enforce_first_as: <bool>
+
             # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
             send_community: <str>
 
@@ -1594,6 +1607,9 @@
 
                   # Route-map name.
                   route_map: <str>
+
+                # Enforce the first AS for eBGP routes (default).
+                enforce_first_as: <bool>
 
                 # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                 send_community: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
@@ -76,7 +76,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS in eBGP updates. EOS default is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "<network_services_keys.name>.[].bgp_peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -213,7 +213,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS in eBGP updates. EOS default is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -319,7 +319,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "network_services.[].bgp_peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "network_services.[].bgp_peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "network_services.[].bgp_peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "network_services.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "network_services.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS in eBGP updates. EOS default is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "network_services.[].bgp_peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "network_services.[].bgp_peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "network_services.[].bgp_peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -456,7 +456,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].default_originate.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].default_originate.route_map") | String |  |  |  | Route-map name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS for eBGP routes (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enforce_first_as</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].enforce_first_as") | Boolean |  |  |  | Enforce the first AS in eBGP updates. EOS default is true. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send_community</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].send_community") | String |  |  |  | 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].maximum_routes") | Integer |  |  | Min: 0<br>Max: 4294967294 | Maximum number of routes (0 means unlimited). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;maximum_routes_warning_limit</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].maximum_routes_warning_limit") | String |  |  |  | Maximum number of routes after which a warning is issued (0 means never warn) or<br>Percentage of maximum number of routes at which to warn ("<1-100> percent").<br> |
@@ -661,7 +661,7 @@
               # Route-map name.
               route_map: <str>
 
-            # Enforce the first AS for eBGP routes (default).
+            # Enforce the first AS in eBGP updates. EOS default is true.
             enforce_first_as: <bool>
 
             # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
@@ -1008,7 +1008,7 @@
                   # Route-map name.
                   route_map: <str>
 
-                # Enforce the first AS for eBGP routes (default).
+                # Enforce the first AS in eBGP updates. EOS default is true.
                 enforce_first_as: <bool>
 
                 # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
@@ -1261,7 +1261,7 @@
               # Route-map name.
               route_map: <str>
 
-            # Enforce the first AS for eBGP routes (default).
+            # Enforce the first AS in eBGP updates. EOS default is true.
             enforce_first_as: <bool>
 
             # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
@@ -1608,7 +1608,7 @@
                   # Route-map name.
                   route_map: <str>
 
-                # Enforce the first AS for eBGP routes (default).
+                # Enforce the first AS in eBGP updates. EOS default is true.
                 enforce_first_as: <bool>
 
                 # 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-bgp.j2
@@ -234,6 +234,11 @@ ASN Notation: {{ router_bgp.as_notation | arista.avd.default('asplain') }}
 {%             if peer_group.default_originate.enabled is arista.avd.defined(true) %}
 | Default originate | True |
 {%             endif %}
+{%             if peer_group.enforce_first_as is arista.avd.defined(true) %}
+| Enforce first AS | True |
+{%             elif peer_group.enforce_first_as is arista.avd.defined(false) %}
+| Enforce first AS | False |
+{%             endif %}
 {%             if peer_group.session_tracker is arista.avd.defined %}
 | Session tracker | {{ peer_group.session_tracker }} |
 {%             endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -2988,6 +2988,11 @@ router bgp {{ router_bgp.as }}
 {%                 endif %}
       {{ neighbor_default_originate_cli }}
 {%             endif %}
+{%             if neighbor.enforce_first_as is arista.avd.defined(true) %}
+      neighbor {{ neighbor.ip_address }} enforce-first-as
+{%             elif neighbor.enforce_first_as is arista.avd.defined(false) %}
+      no neighbor {{ neighbor.ip_address }} enforce-first-as
+{%             endif %}
 {%             if neighbor.send_community is arista.avd.defined('all') %}
       neighbor {{ neighbor.ip_address }} send-community
 {%             elif neighbor.send_community is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -260,6 +260,11 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
    {{ default_originate_cli }}
 {%         endif %}
+{%         if peer_group.enforce_first_as is arista.avd.defined(true) %}
+   neighbor {{ peer_group.name }} enforce-first-as
+{%         elif peer_group.enforce_first_as is arista.avd.defined(false) %}
+   no neighbor {{ peer_group.name }} enforce-first-as
+{%         endif %}
 {%         if peer_group.send_community is arista.avd.defined('all') %}
    neighbor {{ peer_group.name }} send-community
 {%         elif peer_group.send_community is arista.avd.defined %}
@@ -435,6 +440,11 @@ router bgp {{ router_bgp.as }}
 {%                 set default_originate_cli = default_originate_cli ~ " always" %}
 {%             endif %}
    {{ default_originate_cli }}
+{%         endif %}
+{%         if neighbor.enforce_first_as is arista.avd.defined(true) %}
+   neighbor {{ neighbor.ip_address }} enforce-first-as
+{%         elif neighbor.enforce_first_as is arista.avd.defined(false) %}
+   no neighbor {{ neighbor.ip_address }} enforce-first-as
 {%         endif %}
 {%         if neighbor.send_community is arista.avd.defined('all') %}
    neighbor {{ neighbor.ip_address }} send-community

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -56411,6 +56411,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     "maximum_routes_warning_only": {"type": bool},
                     "allowas_in": {"type": AllowasIn},
                     "default_originate": {"type": DefaultOriginate},
+                    "enforce_first_as": {"type": bool},
                     "update_source": {"type": str},
                     "route_map_in": {"type": str},
                     "route_map_out": {"type": str},
@@ -56488,6 +56489,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 """Subclass of AvdModel."""
                 default_originate: DefaultOriginate
                 """Subclass of AvdModel."""
+                enforce_first_as: bool | None
                 update_source: str | None
                 route_map_in: str | None
                 """Inbound route-map name."""
@@ -56534,6 +56536,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         maximum_routes_warning_only: bool | None | UndefinedType = Undefined,
                         allowas_in: AllowasIn | UndefinedType = Undefined,
                         default_originate: DefaultOriginate | UndefinedType = Undefined,
+                        enforce_first_as: bool | None | UndefinedType = Undefined,
                         update_source: str | None | UndefinedType = Undefined,
                         route_map_in: str | None | UndefinedType = Undefined,
                         route_map_out: str | None | UndefinedType = Undefined,
@@ -56596,6 +56599,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             maximum_routes_warning_only: maximum_routes_warning_only
                             allowas_in: Subclass of AvdModel.
                             default_originate: Subclass of AvdModel.
+                            enforce_first_as: enforce_first_as
                             update_source: update_source
                             route_map_in: Inbound route-map name.
                             route_map_out: Outbound route-map name.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -56490,6 +56490,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 default_originate: DefaultOriginate
                 """Subclass of AvdModel."""
                 enforce_first_as: bool | None
+                """Enforce the first AS for eBGP routes (default)."""
                 update_source: str | None
                 route_map_in: str | None
                 """Inbound route-map name."""
@@ -56599,7 +56600,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             maximum_routes_warning_only: maximum_routes_warning_only
                             allowas_in: Subclass of AvdModel.
                             default_originate: Subclass of AvdModel.
-                            enforce_first_as: enforce_first_as
+                            enforce_first_as: Enforce the first AS for eBGP routes (default).
                             update_source: update_source
                             route_map_in: Inbound route-map name.
                             route_map_out: Outbound route-map name.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -45074,6 +45074,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 "password_type": {"type": str, "default": "7"},
                 "passive": {"type": bool},
                 "default_originate": {"type": DefaultOriginate},
+                "enforce_first_as": {"type": bool},
                 "send_community": {"type": str},
                 "maximum_routes": {"type": int},
                 "maximum_routes_warning_limit": {"type": str},
@@ -45148,6 +45149,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             passive: bool | None
             default_originate: DefaultOriginate
             """Subclass of AvdModel."""
+            enforce_first_as: bool | None
+            """Enforce the first AS for eBGP routes (default)."""
             send_community: str | None
             """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
             maximum_routes: int | None
@@ -45214,6 +45217,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     password_type: PasswordType | UndefinedType = Undefined,
                     passive: bool | None | UndefinedType = Undefined,
                     default_originate: DefaultOriginate | UndefinedType = Undefined,
+                    enforce_first_as: bool | None | UndefinedType = Undefined,
                     send_community: str | None | UndefinedType = Undefined,
                     maximum_routes: int | None | UndefinedType = Undefined,
                     maximum_routes_warning_limit: str | None | UndefinedType = Undefined,
@@ -45277,6 +45281,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         password_type: password_type
                         passive: passive
                         default_originate: Subclass of AvdModel.
+                        enforce_first_as: Enforce the first AS for eBGP routes (default).
                         send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                         maximum_routes: Maximum number of routes (0 means unlimited).
                         maximum_routes_warning_limit:
@@ -45721,6 +45726,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 "peer_tag_in": {"type": str},
                 "peer_tag_out_discard": {"type": str},
                 "default_originate": {"type": DefaultOriginate},
+                "enforce_first_as": {"type": bool},
                 "send_community": {"type": str},
                 "maximum_routes": {"type": int},
                 "maximum_routes_warning_limit": {"type": str},
@@ -45792,6 +45798,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             """Outbound discard peer tag name."""
             default_originate: DefaultOriginate
             """Subclass of AvdModel."""
+            enforce_first_as: bool | None
+            """Enforce the first AS for eBGP routes (default)."""
             send_community: str | None
             """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
             maximum_routes: int | None
@@ -45860,6 +45868,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     peer_tag_in: str | None | UndefinedType = Undefined,
                     peer_tag_out_discard: str | None | UndefinedType = Undefined,
                     default_originate: DefaultOriginate | UndefinedType = Undefined,
+                    enforce_first_as: bool | None | UndefinedType = Undefined,
                     send_community: str | None | UndefinedType = Undefined,
                     maximum_routes: int | None | UndefinedType = Undefined,
                     maximum_routes_warning_limit: str | None | UndefinedType = Undefined,
@@ -45920,6 +45929,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         peer_tag_in: Inbound peer tag name.
                         peer_tag_out_discard: Outbound discard peer tag name.
                         default_originate: Subclass of AvdModel.
+                        enforce_first_as: Enforce the first AS for eBGP routes (default).
                         send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                         maximum_routes: Maximum number of routes (0 means unlimited).
                         maximum_routes_warning_limit:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -45150,7 +45150,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             default_originate: DefaultOriginate
             """Subclass of AvdModel."""
             enforce_first_as: bool | None
-            """Enforce the first AS for eBGP routes (default)."""
+            """Enforce the first AS in eBGP updates. EOS default is true."""
             send_community: str | None
             """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
             maximum_routes: int | None
@@ -45281,7 +45281,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         password_type: password_type
                         passive: passive
                         default_originate: Subclass of AvdModel.
-                        enforce_first_as: Enforce the first AS for eBGP routes (default).
+                        enforce_first_as: Enforce the first AS in eBGP updates. EOS default is true.
                         send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                         maximum_routes: Maximum number of routes (0 means unlimited).
                         maximum_routes_warning_limit:
@@ -45799,7 +45799,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             default_originate: DefaultOriginate
             """Subclass of AvdModel."""
             enforce_first_as: bool | None
-            """Enforce the first AS for eBGP routes (default)."""
+            """Enforce the first AS in eBGP updates. EOS default is true."""
             send_community: str | None
             """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
             maximum_routes: int | None
@@ -45929,7 +45929,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         peer_tag_in: Inbound peer tag name.
                         peer_tag_out_discard: Outbound discard peer tag name.
                         default_originate: Subclass of AvdModel.
-                        enforce_first_as: Enforce the first AS for eBGP routes (default).
+                        enforce_first_as: Enforce the first AS in eBGP updates. EOS default is true.
                         send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                         maximum_routes: Maximum number of routes (0 means unlimited).
                         maximum_routes_warning_limit:
@@ -56500,7 +56500,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 default_originate: DefaultOriginate
                 """Subclass of AvdModel."""
                 enforce_first_as: bool | None
-                """Enforce the first AS for eBGP routes (default)."""
+                """Enforce the first AS in eBGP updates. EOS default is true."""
                 update_source: str | None
                 route_map_in: str | None
                 """Inbound route-map name."""
@@ -56610,7 +56610,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             maximum_routes_warning_only: maximum_routes_warning_only
                             allowas_in: Subclass of AvdModel.
                             default_originate: Subclass of AvdModel.
-                            enforce_first_as: Enforce the first AS for eBGP routes (default).
+                            enforce_first_as: Enforce the first AS in eBGP updates. EOS default is true.
                             update_source: update_source
                             route_map_in: Inbound route-map name.
                             route_map_out: Outbound route-map name.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -21024,6 +21024,7 @@ keys:
                         type: str
                   enforce_first_as:
                     type: bool
+                    description: Enforce the first AS for eBGP routes (default).
                   update_source:
                     type: str
                   route_map_in:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -17150,6 +17150,9 @@ keys:
                 route_map:
                   type: str
                   description: Route-map name.
+            enforce_first_as:
+              type: bool
+              description: Enforce the first AS for eBGP routes (default).
             send_community:
               type: str
               description: '''all'' or a combination of ''standard'', ''extended'',
@@ -17429,6 +17432,9 @@ keys:
                   type: bool
                 route_map:
                   type: str
+            enforce_first_as:
+              type: bool
+              description: Enforce the first AS for eBGP routes (default).
             send_community:
               type: str
               description: '''all'' or a combination of ''standard'', ''extended'',

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -21022,6 +21022,8 @@ keys:
                         type: bool
                       route_map:
                         type: str
+                  enforce_first_as:
+                    type: bool
                   update_source:
                     type: str
                   route_map_in:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -17152,7 +17152,7 @@ keys:
                   description: Route-map name.
             enforce_first_as:
               type: bool
-              description: Enforce the first AS for eBGP routes (default).
+              description: Enforce the first AS in eBGP updates. EOS default is true.
             send_community:
               type: str
               description: '''all'' or a combination of ''standard'', ''extended'',
@@ -17434,7 +17434,7 @@ keys:
                   type: str
             enforce_first_as:
               type: bool
-              description: Enforce the first AS for eBGP routes (default).
+              description: Enforce the first AS in eBGP updates. EOS default is true.
             send_community:
               type: str
               description: '''all'' or a combination of ''standard'', ''extended'',
@@ -21030,7 +21030,8 @@ keys:
                         type: str
                   enforce_first_as:
                     type: bool
-                    description: Enforce the first AS for eBGP routes (default).
+                    description: Enforce the first AS in eBGP updates. EOS default
+                      is true.
                   update_source:
                     type: str
                   route_map_in:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
@@ -4139,6 +4139,7 @@ keys:
                         type: str
                   enforce_first_as:
                     type: bool
+                    description: Enforce the first AS for eBGP routes (default).
                   update_source:
                     type: str
                   route_map_in:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
@@ -4137,6 +4137,8 @@ keys:
                         type: bool
                       route_map:
                         type: str
+                  enforce_first_as:
+                    type: bool
                   update_source:
                     type: str
                   route_map_in:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
@@ -438,6 +438,9 @@ keys:
                 route_map:
                   type: str
                   description: Route-map name.
+            enforce_first_as:
+              type: bool
+              description: Enforce the first AS for eBGP routes (default).
             send_community:
               type: str
               description: "'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."
@@ -702,6 +705,9 @@ keys:
                   type: bool
                 route_map:
                   type: str
+            enforce_first_as:
+              type: bool
+              description: Enforce the first AS for eBGP routes (default).
             send_community:
               type: str
               description: "'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
@@ -440,7 +440,7 @@ keys:
                   description: Route-map name.
             enforce_first_as:
               type: bool
-              description: Enforce the first AS for eBGP routes (default).
+              description: Enforce the first AS in eBGP updates. EOS default is true.
             send_community:
               type: str
               description: "'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."
@@ -707,7 +707,7 @@ keys:
                   type: str
             enforce_first_as:
               type: bool
-              description: Enforce the first AS for eBGP routes (default).
+              description: Enforce the first AS in eBGP updates. EOS default is true.
             send_community:
               type: str
               description: "'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."
@@ -4145,7 +4145,7 @@ keys:
                         type: str
                   enforce_first_as:
                     type: bool
-                    description: Enforce the first AS for eBGP routes (default).
+                    description: Enforce the first AS in eBGP updates. EOS default is true.
                   update_source:
                     type: str
                   route_map_in:

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -29470,7 +29470,7 @@ class EosDesigns(EosDesignsRootModel):
             default_originate: DefaultOriginate
             """Subclass of AvdModel."""
             enforce_first_as: bool | None
-            """Enforce the first AS for eBGP routes (default)."""
+            """Enforce the first AS in eBGP updates. EOS default is true."""
             send_community: str | None
             """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
             maximum_routes: int | None
@@ -29628,7 +29628,7 @@ class EosDesigns(EosDesignsRootModel):
                         password_type: password_type
                         passive: passive
                         default_originate: Subclass of AvdModel.
-                        enforce_first_as: Enforce the first AS for eBGP routes (default).
+                        enforce_first_as: Enforce the first AS in eBGP updates. EOS default is true.
                         send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                         maximum_routes: Maximum number of routes (0 means unlimited).
                         maximum_routes_warning_limit:
@@ -36552,7 +36552,7 @@ class EosDesigns(EosDesignsRootModel):
                 default_originate: DefaultOriginate
                 """Subclass of AvdModel."""
                 enforce_first_as: bool | None
-                """Enforce the first AS for eBGP routes (default)."""
+                """Enforce the first AS in eBGP updates. EOS default is true."""
                 send_community: str | None
                 """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
                 maximum_routes: int | None
@@ -36714,7 +36714,7 @@ class EosDesigns(EosDesignsRootModel):
                             password_type: password_type
                             passive: passive
                             default_originate: Subclass of AvdModel.
-                            enforce_first_as: Enforce the first AS for eBGP routes (default).
+                            enforce_first_as: Enforce the first AS in eBGP updates. EOS default is true.
                             send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                             maximum_routes: Maximum number of routes (0 means unlimited).
                             maximum_routes_warning_limit:
@@ -78684,7 +78684,7 @@ class EosDesigns(EosDesignsRootModel):
                     default_originate: DefaultOriginate
                     """Subclass of AvdModel."""
                     enforce_first_as: bool | None
-                    """Enforce the first AS for eBGP routes (default)."""
+                    """Enforce the first AS in eBGP updates. EOS default is true."""
                     send_community: str | None
                     """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
                     maximum_routes: int | None
@@ -78842,7 +78842,7 @@ class EosDesigns(EosDesignsRootModel):
                                 password_type: password_type
                                 passive: passive
                                 default_originate: Subclass of AvdModel.
-                                enforce_first_as: Enforce the first AS for eBGP routes (default).
+                                enforce_first_as: Enforce the first AS in eBGP updates. EOS default is true.
                                 send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                                 maximum_routes: Maximum number of routes (0 means unlimited).
                                 maximum_routes_warning_limit:
@@ -85803,7 +85803,7 @@ class EosDesigns(EosDesignsRootModel):
                         default_originate: DefaultOriginate
                         """Subclass of AvdModel."""
                         enforce_first_as: bool | None
-                        """Enforce the first AS for eBGP routes (default)."""
+                        """Enforce the first AS in eBGP updates. EOS default is true."""
                         send_community: str | None
                         """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
                         maximum_routes: int | None
@@ -85965,7 +85965,7 @@ class EosDesigns(EosDesignsRootModel):
                                     password_type: password_type
                                     passive: passive
                                     default_originate: Subclass of AvdModel.
-                                    enforce_first_as: Enforce the first AS for eBGP routes (default).
+                                    enforce_first_as: Enforce the first AS in eBGP updates. EOS default is true.
                                     send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                                     maximum_routes: Maximum number of routes (0 means unlimited).
                                     maximum_routes_warning_limit:

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -29362,6 +29362,7 @@ class EosDesigns(EosDesignsRootModel):
                 "password_type": {"type": str, "default": "7"},
                 "passive": {"type": bool},
                 "default_originate": {"type": DefaultOriginate},
+                "enforce_first_as": {"type": bool},
                 "send_community": {"type": str},
                 "maximum_routes": {"type": int},
                 "maximum_routes_warning_limit": {"type": str},
@@ -29468,6 +29469,8 @@ class EosDesigns(EosDesignsRootModel):
             passive: bool | None
             default_originate: DefaultOriginate
             """Subclass of AvdModel."""
+            enforce_first_as: bool | None
+            """Enforce the first AS for eBGP routes (default)."""
             send_community: str | None
             """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
             maximum_routes: int | None
@@ -29539,6 +29542,7 @@ class EosDesigns(EosDesignsRootModel):
                     password_type: PasswordType | UndefinedType = Undefined,
                     passive: bool | None | UndefinedType = Undefined,
                     default_originate: DefaultOriginate | UndefinedType = Undefined,
+                    enforce_first_as: bool | None | UndefinedType = Undefined,
                     send_community: str | None | UndefinedType = Undefined,
                     maximum_routes: int | None | UndefinedType = Undefined,
                     maximum_routes_warning_limit: str | None | UndefinedType = Undefined,
@@ -29624,6 +29628,7 @@ class EosDesigns(EosDesignsRootModel):
                         password_type: password_type
                         passive: passive
                         default_originate: Subclass of AvdModel.
+                        enforce_first_as: Enforce the first AS for eBGP routes (default).
                         send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                         maximum_routes: Maximum number of routes (0 means unlimited).
                         maximum_routes_warning_limit:
@@ -36435,6 +36440,7 @@ class EosDesigns(EosDesignsRootModel):
                     "password_type": {"type": str, "default": "7"},
                     "passive": {"type": bool},
                     "default_originate": {"type": DefaultOriginate},
+                    "enforce_first_as": {"type": bool},
                     "send_community": {"type": str},
                     "maximum_routes": {"type": int},
                     "maximum_routes_warning_limit": {"type": str},
@@ -36545,6 +36551,8 @@ class EosDesigns(EosDesignsRootModel):
                 passive: bool | None
                 default_originate: DefaultOriginate
                 """Subclass of AvdModel."""
+                enforce_first_as: bool | None
+                """Enforce the first AS for eBGP routes (default)."""
                 send_community: str | None
                 """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
                 maximum_routes: int | None
@@ -36616,6 +36624,7 @@ class EosDesigns(EosDesignsRootModel):
                         password_type: PasswordType | UndefinedType = Undefined,
                         passive: bool | None | UndefinedType = Undefined,
                         default_originate: DefaultOriginate | UndefinedType = Undefined,
+                        enforce_first_as: bool | None | UndefinedType = Undefined,
                         send_community: str | None | UndefinedType = Undefined,
                         maximum_routes: int | None | UndefinedType = Undefined,
                         maximum_routes_warning_limit: str | None | UndefinedType = Undefined,
@@ -36705,6 +36714,7 @@ class EosDesigns(EosDesignsRootModel):
                             password_type: password_type
                             passive: passive
                             default_originate: Subclass of AvdModel.
+                            enforce_first_as: Enforce the first AS for eBGP routes (default).
                             send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                             maximum_routes: Maximum number of routes (0 means unlimited).
                             maximum_routes_warning_limit:
@@ -78566,6 +78576,7 @@ class EosDesigns(EosDesignsRootModel):
                         "password_type": {"type": str, "default": "7"},
                         "passive": {"type": bool},
                         "default_originate": {"type": DefaultOriginate},
+                        "enforce_first_as": {"type": bool},
                         "send_community": {"type": str},
                         "maximum_routes": {"type": int},
                         "maximum_routes_warning_limit": {"type": str},
@@ -78672,6 +78683,8 @@ class EosDesigns(EosDesignsRootModel):
                     passive: bool | None
                     default_originate: DefaultOriginate
                     """Subclass of AvdModel."""
+                    enforce_first_as: bool | None
+                    """Enforce the first AS for eBGP routes (default)."""
                     send_community: str | None
                     """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
                     maximum_routes: int | None
@@ -78743,6 +78756,7 @@ class EosDesigns(EosDesignsRootModel):
                             password_type: PasswordType | UndefinedType = Undefined,
                             passive: bool | None | UndefinedType = Undefined,
                             default_originate: DefaultOriginate | UndefinedType = Undefined,
+                            enforce_first_as: bool | None | UndefinedType = Undefined,
                             send_community: str | None | UndefinedType = Undefined,
                             maximum_routes: int | None | UndefinedType = Undefined,
                             maximum_routes_warning_limit: str | None | UndefinedType = Undefined,
@@ -78828,6 +78842,7 @@ class EosDesigns(EosDesignsRootModel):
                                 password_type: password_type
                                 passive: passive
                                 default_originate: Subclass of AvdModel.
+                                enforce_first_as: Enforce the first AS for eBGP routes (default).
                                 send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                                 maximum_routes: Maximum number of routes (0 means unlimited).
                                 maximum_routes_warning_limit:
@@ -85676,6 +85691,7 @@ class EosDesigns(EosDesignsRootModel):
                             "password_type": {"type": str, "default": "7"},
                             "passive": {"type": bool},
                             "default_originate": {"type": DefaultOriginate},
+                            "enforce_first_as": {"type": bool},
                             "send_community": {"type": str},
                             "maximum_routes": {"type": int},
                             "maximum_routes_warning_limit": {"type": str},
@@ -85786,6 +85802,8 @@ class EosDesigns(EosDesignsRootModel):
                         passive: bool | None
                         default_originate: DefaultOriginate
                         """Subclass of AvdModel."""
+                        enforce_first_as: bool | None
+                        """Enforce the first AS for eBGP routes (default)."""
                         send_community: str | None
                         """'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'."""
                         maximum_routes: int | None
@@ -85857,6 +85875,7 @@ class EosDesigns(EosDesignsRootModel):
                                 password_type: PasswordType | UndefinedType = Undefined,
                                 passive: bool | None | UndefinedType = Undefined,
                                 default_originate: DefaultOriginate | UndefinedType = Undefined,
+                                enforce_first_as: bool | None | UndefinedType = Undefined,
                                 send_community: str | None | UndefinedType = Undefined,
                                 maximum_routes: int | None | UndefinedType = Undefined,
                                 maximum_routes_warning_limit: str | None | UndefinedType = Undefined,
@@ -85946,6 +85965,7 @@ class EosDesigns(EosDesignsRootModel):
                                     password_type: password_type
                                     passive: passive
                                     default_originate: Subclass of AvdModel.
+                                    enforce_first_as: Enforce the first AS for eBGP routes (default).
                                     send_community: 'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'.
                                     maximum_routes: Maximum number of routes (0 means unlimited).
                                     maximum_routes_warning_limit:


### PR DESCRIPTION
## Change Summary

Add support for router_bgp.vrfs[].neighbors[].enforce_first_as

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Updated schema and j2 eos config template, no requirements to update doc templates since this is a nerd knob!

## How to test

See the molecule!

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `enforce_first_as` option for BGP peer-groups and neighbors, including VRF-scoped neighbors, to control `enforce-first-as` behavior.
* **Documentation**
  * Updated router BGP tables, documentation, and schema to describe the new `enforce_first_as` field and supported locations.
* **Bug Fixes**
  * EOS CLI generation now renders `enforce-first-as` and explicitly disables it with `no ... enforce-first-as` when set to `false`.
* **Tests**
  * Extended CLI config generation test coverage for both enabled and disabled enforce-first-as scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->