### PR TITLE
Bump: arista.eos Ansible collection to >=12.2.0

### DIFF
--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -35,7 +35,9 @@ tags: ["arista", "network", "networking", "eos", "avd", "cloudvision", "cvp"]
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-  "arista.eos": ">=7.0.0"
+# Test with main branch
+  "git+https://github.com/ansible-collections/arista.eos.git": main
+#  "arista.eos": ">=12.1.3"
 
 # The URL of the originating SCM repository
 repository: https://github.com/aristanetworks/avd

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -35,9 +35,9 @@ tags: ["arista", "network", "networking", "eos", "avd", "cloudvision", "cvp"]
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-# Test with main branch
-  "git+https://github.com/ansible-collections/arista.eos.git": main
-#  "arista.eos": ">=12.1.3"
+  "arista.eos": ">=12.2.0"
+# Test with arista.eos with main branch
+#  "git+https://github.com/ansible-collections/arista.eos.git": main
 
 # The URL of the originating SCM repository
 repository: https://github.com/aristanetworks/avd

--- a/ansible_collections/arista/avd/requirements.yml
+++ b/ansible_collections/arista/avd/requirements.yml
@@ -1,4 +1,8 @@
 # collection requirements leveraged by molecule etc
 collections:
   - name: arista.eos
-    version: ">=7.0.0"
+    # Test with main branch
+    type: git
+    source: https://github.com/ansible-collections/arista.eos
+    version: main
+    # version: ">=12.1.3"

--- a/ansible_collections/arista/avd/requirements.yml
+++ b/ansible_collections/arista/avd/requirements.yml
@@ -1,8 +1,8 @@
 # collection requirements leveraged by molecule etc
 collections:
   - name: arista.eos
+    version: ">=12.2.0"
     # Test with main branch
-    type: git
-    source: https://github.com/ansible-collections/arista.eos
-    version: main
-    # version: ">=12.1.3"
+    # type: git
+    # source: https://github.com/ansible-collections/arista.eos
+    # version: main


### PR DESCRIPTION
## Change Summary

Bump: arista.eos Ansible collection to >=12.2.0

Fixes an issue with multi-line RCF configuration.

## Component(s) name

Ansible Collection requirements

## Proposed changes

Bump Ansible collection requirement for arista.eos to >=12.2.0

## How to test

Test with internal CI

## Checklist

### User Checklist

- [x] Bump collection to released version
- [ ] Add test for multi-line in internal CI
  - [ ] Test with internal CI and link results in PR

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced EVPN `router general` control-functions to detect default-route presence, distinguish IMET vs MAC/IP route types, and apply routed-VLAN route-target matching for both border and leaf scenarios.
  * Added decision logic to gate local data-center vs outbound handling based on EVPN defaults, route type, and (for MAC/IP) specific MAC matching.
* **Documentation**
  * Updated Router General documentation and generated configuration examples to reflect the new EVPN routing control-units.
* **Chores**
  * Increased the minimum required `arista.eos` dependency version to `>=12.2.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->