### PR TITLE
CI: replace pre-commit with prek

### DIFF
--- a/.github/workflows/prek-update.yml
+++ b/.github/workflows/prek-update.yml
@@ -1,0 +1,68 @@
+---
+name: prek update
+
+"on":
+  schedule:
+    - cron: "0 16 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: prek-update
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    # Replaces the former pre-commit.ci autoupdate role.
+    name: Update prek hook revisions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: devel
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install prek
+        run: python -m pip install "prek>=0.4.9"
+
+      - name: Update hook revisions
+        run: prek update
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -z "$(git status --porcelain .pre-commit-config.yaml)" ]; then
+            echo "No prek hook revision updates found."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          branch="ci/prek-update"
+          git switch -c "$branch"
+          git add .pre-commit-config.yaml
+          git commit -m "CI: prek update"
+          git push --force-with-lease origin "$branch"
+
+          if gh pr view "$branch" --json number --jq .number > /dev/null 2>&1; then
+            gh pr edit "$branch" \
+              --title "CI: prek update" \
+              --body "Update pinned prek hook revisions."
+          else
+            gh pr create \
+              --base devel \
+              --head "$branch" \
+              --title "CI: prek update" \
+              --body "Update pinned prek hook revisions."
+          fi

--- a/.github/workflows/pull-request-autofix.yml
+++ b/.github/workflows/pull-request-autofix.yml
@@ -16,7 +16,8 @@ permissions:
 
 jobs:
   autofix:
-    name: Run pre-commit and commit back any changes
+    # Replaces the former PR and push hook execution done with pre-commit/action.
+    name: Run prek and commit back any changes
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
@@ -29,18 +30,18 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Run pre-commit autofix pass
-        id: pre_commit
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - name: Run prek autofix pass
+        id: prek
+        uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d # v2.0.5
         continue-on-error: true
         with:
-          extra_args: --all-files
+          extra-args: --all-files
 
-      - name: Fail if pre-commit failed without fixes
-        if: steps.pre_commit.outcome == 'failure'
+      - name: Fail if prek failed without fixes
+        if: steps.prek.outcome == 'failure'
         run: |
           if [ -z "$(git status --porcelain)" ]; then
-            echo "pre-commit failed and did not produce changes for autofix.ci to commit."
+            echo "prek failed and did not produce changes for autofix.ci to commit."
             exit 1
           fi
 

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -140,10 +140,10 @@ jobs:
           path: ./python-avd/dist/*.whl
 
   # -------------------------------------------- #
-  # Python type checking not covered in pre-commit
+  # Python type checking not covered in prek
   # -------------------------------------------- #
   python_type_checking:
-    name: Python Linting not covered in pre-commit
+    name: Python Linting not covered in prek
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/yamllintrc
+++ b/.github/yamllintrc
@@ -1,5 +1,5 @@
 ---
-# Used by pre-commit. There is a similar file under the Ansible collection used by ansible-lint.
+# Used by prek. There is a similar file under the Ansible collection used by ansible-lint.
 extends: default
 
 yaml-files:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,9 @@
 ---
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
-ci:
-  autoupdate_commit_msg: "CI: pre-commit autoupdate"
-  autofix_prs: false
-  # Keep pre-commit.ci for autoupdate only. Run hooks through autofix.ci.
-  skip:
-    - trailing-whitespace
-    - end-of-file-fixer
-    - check-added-large-files
-    - check-merge-conflict
-    - insert-license
-    - ruff
-    - ruff-format
-    - pyright
-    - pylint
-    - yamllint
-    - j2lint
-    - codespell
-    - zizmor
-    - pdm-export
-    - docs-plugin-modules
-    - docs-plugin-filter
-    - docs-plugin-lookup
-    - docs-plugin-test
-    - docs-plugin-vars
-    - schemas
-    - check-schema-tables-in-docs
-    - sort-hosts-yml
-    - templates
-    - markdownlint-cli2
+# See https://prek.j178.dev/ for more information.
+# This configuration is executed with prek.
 
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+  - repo: builtin
     hooks:
       - id: trailing-whitespace
         name: Trims trailing whitespace.

--- a/ansible_collections/arista/avd/extensions/molecule/README.md
+++ b/ansible_collections/arista/avd/extensions/molecule/README.md
@@ -90,7 +90,7 @@ When you update a template in `eos_cli_config_gen`, you should report a test cas
 git commit -m 'Upload artefact for issue #...' molecule/eos_cli_config_gen
 ```
 
-> If you have `pre-commit` enabled, use `--no-verify` trigger to avoid any content change in your commit
+> If you have `prek` enabled, use `--no-verify` trigger to avoid any content change in your commit
 
 #### If you are updating `eos_designs`
 

--- a/development/find_missing_tables.py
+++ b/development/find_missing_tables.py
@@ -13,7 +13,7 @@ def main() -> int:
         description="Checks that all table markdown files are referenced in global documentation.",
         fromfile_prefix_chars="@",
     )
-    parser.add_argument("--root-path", type=Path, required=True, help="The relative path to the project's root directory from where pre-commit is run.")
+    parser.add_argument("--root-path", type=Path, required=True, help="The relative path to the project's root directory from where prek is run.")
     parser.add_argument("--table-files", nargs="+", required=True, help="Glob pattern for table markdown files.")
     parser.add_argument("--global-docs", nargs="+", required=True, help="Glob pattern for global documentation files.")
     parser.add_argument("--ignore-files", nargs="+", default=[], help="Glob pattern for table files to ignore.")

--- a/development/sort_hosts_yml.py
+++ b/development/sort_hosts_yml.py
@@ -224,7 +224,7 @@ def process_files(files: set[Path]) -> list[Path]:
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(description="Auto-sort host names and group names in Ansible inventory hosts.yml files.")
-    parser.add_argument("files", nargs="*", type=Path, help="Files to sort (passed by pre-commit)")
+    parser.add_argument("files", nargs="*", type=Path, help="Files to sort (passed by prek)")
     args = parser.parse_args()
 
     # Collect files to process

--- a/docs/contribution/authoring_eos_cli_config_gen.md
+++ b/docs/contribution/authoring_eos_cli_config_gen.md
@@ -13,10 +13,10 @@ This document outlines the steps and checklist for contributing to the `eos_cli_
 1. Prepare development environment.
 2. Create the schema.
 3. Develop Jinja2 templates (eos and documentation).
-4. Run pre-commit to build schema and templates
+4. Run prek to build schema and templates
 5. Validate with molecule tests.
 6. Update documentation as needed.
-7. Run pre-commit checks to ensure compliance.
+7. Run prek checks to ensure compliance.
 8. Review all changes before submission.
 9. Raise a PR to the Arista AVD GitHub repository.
 
@@ -82,11 +82,11 @@ When adding a top-level feature, add a new Jinja2 template following the naming 
     ```
 
     An empty `default_originate:` block must not trigger configuration generation. The template should check `default_originate.enabled` rather than just the presence of `default_originate`.
-12. Validate the template using j2lint tool, run `pre-commit run j2lint --all`.
+12. Validate the template using j2lint tool, run `prek run j2lint --all`.
 
-### Run pre-commit to build schemas and documentation
+### Run prek to build schemas and documentation
 
-Run `pre-commit run --all`, this will trigger recompiling the schemas and the templates you have created.
+Run `prek run --all`, this will trigger recompiling the schemas and the templates you have created.
 
 !!! Note
 
@@ -94,8 +94,8 @@ Run `pre-commit run --all`, this will trigger recompiling the schemas and the te
 
     However, if you are using pyavd or need to manually recompile the schemas and templates for any other reason, you can run the following commands:
 
-    `pre-commit run schemas --all` to regenerate the eos_cli_config_gen schema.
-    `pre-commit run templates --all` to regenerate the templates.
+    `prek run schemas --all` to regenerate the eos_cli_config_gen schema.
+    `prek run templates --all` to regenerate the templates.
 
     These commands should be executed whenever the schema or templates are modified, even if only a description is updated.
 
@@ -124,9 +124,9 @@ Run `pre-commit run --all`, this will trigger recompiling the schemas and the te
 1. If the proposed feature requires any changes to the documentation, update the documentation accordingly.
 2. For new top-level feature data models, include a link to the corresponding schema documentation file (e.g., `ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/<data-model>.md`) in the `ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/data-models.md` file.
 
-### Run Pre-commit Checks
+### Run Prek Checks
 
-Run all pre-commit checks `pre-commit run --all` to ensure that all files added or modified are correctly following the coding standards and formatting rules. Running these checks also ensures that the changes pass CI checks.
+Run all prek checks `prek run --all` to ensure that all files added or modified are correctly following the coding standards and formatting rules. Running these checks also ensures that the changes pass CI checks.
 
 !!! Note
 

--- a/docs/contribution/development-tooling.md
+++ b/docs/contribution/development-tooling.md
@@ -8,7 +8,7 @@
 
 - To assist the AVD development community, we provide guidance to develop with two primary methods: VSCode dev containers or local Python environment.
   - You may also choose your own development methodology, however we may not be able to provide assistance in a timely manner.
-- This guide provides additional information about the development tools leveraged in the project: pre-commit, Molecule and ansible-test.
+- This guide provides additional information about the development tools leveraged in the project: prek, Molecule and ansible-test.
 - Please report any issues and optimization suggestions regarding the development workflow via [Github discussions board](https://github.com/aristanetworks/avd/discussions).
 
 !!! note
@@ -93,50 +93,52 @@ TODO: Add picture.
 
 When running from source, the `verify_requirements` action will check if any schema fragment or templates has changed locally and if so, will recompile on the fly either or both as
 required for `eos_cli_config_gen` and `eos_designs`, allowing a seamless development workflow while using Ansible.
-When using pyavd, it is required to run pre-commit to achieve the same.
+When using pyavd, it is required to run prek to achieve the same.
 
-## Pre-commit
+## Prek
 
-- [pre-commit](https://github.com/aristanetworks/avd/blob/devel/.pre-commit-config.yaml) can run standard hooks on every commit to automatically point out issues in code such as missing semicolons, trailing whitespace, and debug statements.
+- [prek](https://github.com/aristanetworks/avd/blob/devel/.pre-commit-config.yaml) can run standard hooks on every commit to automatically point out issues in code such as missing semicolons, trailing whitespace, and debug statements.
 - Pointing these issues out before code review allows a code reviewer to focus on the architecture of a change while not wasting time with trivial style nitpicks.
-- Additionally, the AVD project leverages pre-commit hooks to build and update the AVD schemas, templates and documentation artifacts.
+- Additionally, the AVD project leverages prek hooks to build and update the AVD schemas, templates and documentation artifacts.
 
-### Install pre-commit hook
+The `.pre-commit-config.yaml` file name is retained because `prek` supports this configuration format.
 
-Configure pre-commit git hook, to automatically run pre-commit. This is optional, but highly recommended!
+### Install prek hook
+
+Configure the prek git hook to automatically run prek. This is optional, but highly recommended!
 
 ```shell
 # Change to directory to your cloned avd repository.
 cd avd
 
-# Install pre-commit hooks to run automatically.
-pre-commit install
+# Install prek hooks to run automatically.
+prek install
 ```
 
-### Run pre-commit manually
+### Run prek manually
 
-To run `pre-commit` manually before you commit, use this command:
+To run `prek` manually before you commit, use this command:
 
 ```shell
 # Change to directory to your cloned avd repository.
 cd avd
 
-# Run pre-commit hooks on all staged files.
+# Run prek hooks on all staged files.
 # The command will automatically detect changed files using `git status` and run tests according to their type.
-pre-commit run
+prek run
 
-# Run pre-commit hooks on all un-staged and staged files.
-pre-commit run --all
+# Run prek hooks on all un-staged and staged files.
+prek run --all
 
-# Run specific pre-commit schemas hook on all un-staged and staged files.
-pre-commit run schemas --all
+# Run specific prek schemas hook on all un-staged and staged files.
+prek run schemas --all
 ```
 
 !!! note
     This process is also implemented in the project CI to ensure code quality and compliance.
-    All pre-commit checks must pass, therefore we highly recommend running this workflow before committing changes!
+    All prek checks must pass, therefore we highly recommend running this workflow before committing changes!
 
-    Pre-commit will fail if any files are changed by the pre-commit hooks. Make sure to review the changes, commit them and rerun pre-commit.
+    Prek will fail if any files are changed by the prek hooks. Make sure to review the changes, commit them and rerun prek.
 
 ## Molecule
 

--- a/docs/contribution/style-guide.md
+++ b/docs/contribution/style-guide.md
@@ -14,7 +14,7 @@ For the Ansible collection `arista.avd.`, we are required to follow guidelines f
 
 For PyAVD and other areas we follow common good practices as enforced by Ruff and Pylint.
 
-The CI Pipeline (& pre-commit) for AVD enforces the following:
+The CI Pipeline (& prek) for AVD enforces the following:
 
 - Maximum line length of 160
 - [Ruff](https://docs.astral.sh/ruff/) version >=0.5.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ dev = [
     "docker>=7.1.0",
     "identify>=2.6.18",
     "jsonschema-rs>=0.46.0",
-    "pre-commit-hooks>=6.0.0",
-    "pre-commit>=4.5.1",
+    "prek>=0.4.9",
     "pylint>=4.0.5",
     "ruff==0.15.20",
     "setuptools>=82.0.1", # for pyright check in CI

--- a/python-avd/pyavd/_cv/Makefile
+++ b/python-avd/pyavd/_cv/Makefile
@@ -32,7 +32,7 @@ api-models: api-dir
 
 api: api-dir api-models  ## Build/refresh gRPC bindings in ./api
 	@rm -rf $(VENDORPATH)
-	@pre-commit run insert-license --files $(shell find $(APIPATH)/ -name "*.py") || true
+	@prek run insert-license --files $(shell find $(APIPATH)/ -name "*.py") || true
 	@echo "--- done"
 	@echo "If you got here, everything went well."
-	@echo "All the output above is just because we use pre-commit to insert licenses into the generated files."
+	@echo "All the output above is just because we use prek to insert licenses into the generated files."

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -83,7 +83,7 @@ include = ["pyavd*"]
 version = {attr = "pyavd.__version__"}
 
 [dependency-groups]
-# helping pdm generate the flat list of requirements in pre-commit
+# helping pdm generate the flat list of requirements in prek
 self = [
   "pyavd==6.4.0.dev0"
 ]


### PR DESCRIPTION
## Change Summary

Replace the AVD pre-commit runner workflows with prek while preserving the existing behavior for local checks, pull request checks, push checks, and automated hook revision update pull requests.

## Related Issue(s)

N/A

## Component(s) name

`CI / development tooling`

## Proposed changes

AVD previously used pre-commit for three separate workflows. This PR keeps each workflow in place and changes the implementation to prek:

- Local developer checks were run with `pre-commit install` and `pre-commit run`. They are now run with `prek install` and `prek run`.
- Pull request and push checks were run by `.github/workflows/pull-request-autofix.yml` using `pre-commit/action`. The same workflow now runs hooks with `j178/prek-action`.
- Hook revision update pull requests were handled by pre-commit.ci autoupdate. This is now handled by the new `.github/workflows/prek-update.yml` workflow, which runs `prek update` on a weekly schedule and opens or updates a pull request when hook revisions change.

Additional implementation details:

- `.pre-commit-config.yaml` is retained because `prek` supports the pre-commit configuration format.
- The generic `pre-commit/pre-commit-hooks` dependency is replaced with prek built-in hooks via `repo: builtin`.
- Remaining remote hook repositories are kept where AVD still depends on those hook implementations.
- The previous `ci:` block in `.pre-commit-config.yaml` was specific to pre-commit.ci. Its autoupdate behavior is replaced by the scheduled `prek update` workflow.

## How to test

Focused validation was run with prek:

```bash
uvx prek run yamllint --files .github/workflows/pull-request-autofix.yml .github/workflows/prek-update.yml
uvx prek run markdownlint-cli2 --files docs/contribution/development-tooling.md
```

Additional focused checks were run earlier during the migration:

- prek built-in hooks on changed files
- markdownlint on edited documentation
- ruff and ruff-format on edited Python helper strings
- `git diff --check`

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
