### PR TITLE
Fix(plugins): Update anta_workflow to use apply_defaults in ARGUMENT_SPEC

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/anta_workflow.py
+++ b/ansible_collections/arista/avd/plugins/action/anta_workflow.py
@@ -68,6 +68,7 @@ ARGUMENT_SPEC = {
     "device_list": {"type": "list", "elements": "str", "required": True},
     "avd_catalogs": {
         "type": "dict",
+        "apply_defaults": True,
         "options": {
             "enabled": {"type": "bool", "default": True},
             "output_dir": {"type": "str"},
@@ -87,6 +88,7 @@ ARGUMENT_SPEC = {
     },
     "user_catalogs": {
         "type": "dict",
+        "apply_defaults": True,
         "options": {
             "enabled": {"type": "bool", "default": False},
             "input_dir": {"type": "str"},
@@ -94,6 +96,7 @@ ARGUMENT_SPEC = {
     },
     "runner": {
         "type": "dict",
+        "apply_defaults": True,
         "options": {
             "timeout": {"type": "float", "default": 30.0},
             "batch_size": {"type": "int", "default": 5},
@@ -103,6 +106,7 @@ ARGUMENT_SPEC = {
     },
     "report": {
         "type": "dict",
+        "apply_defaults": True,
         "options": {
             "expand_results": {"type": "bool", "default": False},
             "generate_custom_field": {"type": "bool", "default": False},
@@ -115,6 +119,7 @@ ARGUMENT_SPEC = {
             },
             "sorting": {
                 "type": "dict",
+                "apply_defaults": True,
                 "options": {
                     "status_priority": {
                         "type": "list",

--- a/ansible_collections/arista/avd/tests/unit/action/test_anta_workflow.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_anta_workflow.py
@@ -435,6 +435,34 @@ def test_build_anta_device_raises_when_required_settings_missing(monkeypatch: py
         build_anta_device("leaf1")
 
 
+def test_validate_argument_spec_materializes_runner_defaults(action_module: Callable[..., ActionModule]) -> None:
+    """`apply_defaults` materializes runner defaults even when the runner block is omitted."""
+    module = action_module(ActionModule, task_args={"device_list": ["leaf1"]})
+
+    _validation_result, validated_args = module.validate_argument_spec(anta_module.ARGUMENT_SPEC)
+    validated_args = anta_module.strip_empties_from_dict(validated_args)
+
+    assert validated_args["runner"]["timeout"] == 30.0
+    assert validated_args["runner"]["batch_size"] == 5
+    assert validated_args["runner"]["dry_run"] is False
+
+
+def test_validate_argument_spec_materializes_report_sorting_defaults(action_module: Callable[..., ActionModule]) -> None:
+    """`apply_defaults` materializes report.sorting defaults when report is provided without sorting."""
+    module = action_module(
+        ActionModule,
+        task_args={
+            "device_list": ["leaf1"],
+        },
+    )
+
+    _validation_result, validated_args = module.validate_argument_spec(anta_module.ARGUMENT_SPEC)
+    validated_args = anta_module.strip_empties_from_dict(validated_args)
+
+    assert validated_args["report"]["sorting"]["status_priority"] == ["error", "failure", "skipped", "success", "unset"]
+    assert validated_args["report"]["sorting"]["sort_fields"] == ["device", "categories", "test", "description", "custom_field"]
+
+
 def test_load_one_structured_config_raises_for_missing_file(tmp_path: Path) -> None:
     """FileNotFoundError is raised when the structured config file does not exist."""
     with pytest.raises(FileNotFoundError, match=r"Structured configuration file for device 'leaf1' not found"):

--- a/ansible_collections/arista/avd/tests/unit/action/test_anta_workflow.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_anta_workflow.py
@@ -447,12 +447,24 @@ def test_validate_argument_spec_materializes_runner_defaults(action_module: Call
     assert validated_args["runner"]["dry_run"] is False
 
 
-def test_validate_argument_spec_materializes_report_sorting_defaults(action_module: Callable[..., ActionModule]) -> None:
-    """`apply_defaults` materializes report.sorting defaults when report is provided without sorting."""
+@pytest.mark.parametrize(
+    "task_args_extra",
+    [
+        pytest.param({"report": {}}, id="with_report"),
+        pytest.param({}, id="without_report"),
+    ],
+)
+def test_validate_argument_spec_materializes_report_sorting_defaults(
+    action_module: Callable[..., ActionModule],
+    *,
+    task_args_extra: dict,
+) -> None:
+    """`apply_defaults` materializes report.sorting defaults whether report is omitted or provided without sorting."""
     module = action_module(
         ActionModule,
         task_args={
             "device_list": ["leaf1"],
+            **task_args_extra,
         },
     )
 


### PR DESCRIPTION
## Change Summary

The issue is that when we run the playbook directly and call arista.avd.anta_workflow, the defaults are not mapped, causing the plugin to fail.

Conversely, running the same via the anta_runner role is safe, as the role correctly builds the module input and maps the defaults to anta_report_status_priority and anta_report_sort_fields here.

> [!NOTE]
> This PR is technically breaking for direct usage of the action plugin
> but we don't claim SemVer for this action plugin so we are entitled to do it.
> https://avd.arista.com/6.3/docs/versioning/semantic-versioning.html#plugins

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.anta_workflow`

## Proposed changes

Updated anta_workflow to use use_defaults in ARGUMENT_SPEC

## How to test

Run workflow alone

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ANTA workflow configurations now automatically apply default settings for catalogs, runner options, reporting, and report sorting.
  * Runner defaults (e.g., timeout, batch size, dry-run) are filled in when the runner section is omitted.
  * Report sorting defaults (e.g., status priority and sort fields) are applied when sorting is not explicitly provided.
* **Tests**
  * Added unit coverage to verify automatic default application for runner and report sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->