### PR TITLE
Refactor(eos_designs): Make `ntp_settings.servers.name` primary key

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/time-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/time-configuration.md
@@ -11,7 +11,7 @@
     | [<samp>&nbsp;&nbsp;server_vrf</samp>](## "ntp_settings.server_vrf") | String |  | `use_default_mgmt_method_vrf` |  | EOS only supports NTP servers in one VRF, so this VRF is used for all NTP servers and one local-interface.<br>- `use_mgmt_interface_vrf` will configure the NTP server(s) under the VRF set with `mgmt_interface_vrf` and set the `mgmt_interface` as NTP local-interface.<br>  An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.<br>- `use_inband_mgmt_vrf` will configure the NTP server(s) under the VRF set with `inband_mgmt_vrf` and set the `inband_mgmt_interface` as NTP local-interface.<br>  An error will be raised if inband management is not configured for the device.<br>- `use_default_mgmt_method_vrf` will configure the VRF for NTP server(s) and local-interface for NTP depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the VRF name but local interface must be set with `custom_structured_configuration_ntp` if needed. |
     | [<samp>&nbsp;&nbsp;set_first_ntp_server_as_preferred</samp>](## "ntp_settings.set_first_ntp_server_as_preferred") | Boolean |  | `True` |  | If 'true', AVD marks the first entry under 'ntp_settings.servers' as 'preferred'.<br>Set to 'false' to avoid automatically setting any server as 'preferred'. |
     | [<samp>&nbsp;&nbsp;servers</samp>](## "ntp_settings.servers") | List, items: Dictionary |  |  |  | By default, AVD marks the first server as `preferred`.<br>Set 'ntp_settings.set_first_ntp_server_as_preferred: false' to disable this behavior. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp_settings.servers.[].name") | String |  |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp_settings.servers.[].name") | String | Required, Unique |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;burst</samp>](## "ntp_settings.servers.[].burst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;iburst</samp>](## "ntp_settings.servers.[].iburst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp_settings.servers.[].key") | Integer |  |  | Min: 1<br>Max: 65535 |  |
@@ -53,7 +53,7 @@
       servers:
 
           # IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org.
-        - name: <str>
+        - name: <str; required; unique>
           burst: <bool>
           iburst: <bool>
           key: <int; 1-65535>

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -40107,7 +40107,7 @@ class EosDesigns(EosDesignsRootModel):
                 "minpoll": {"type": int},
                 "version": {"type": int},
             }
-            name: str | None
+            name: str
             """IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org."""
             burst: bool | None
             iburst: bool | None
@@ -40123,7 +40123,7 @@ class EosDesigns(EosDesignsRootModel):
                 def __init__(
                     self,
                     *,
-                    name: str | None | UndefinedType = Undefined,
+                    name: str | UndefinedType = Undefined,
                     burst: bool | None | UndefinedType = Undefined,
                     iburst: bool | None | UndefinedType = Undefined,
                     key: int | None | UndefinedType = Undefined,
@@ -40148,8 +40148,10 @@ class EosDesigns(EosDesignsRootModel):
 
                     """
 
-        class Servers(AvdList[ServersItem]):
-            """Subclass of AvdList with `ServersItem` items."""
+        class Servers(AvdIndexedList[str, ServersItem]):
+            """Subclass of AvdIndexedList with `ServersItem` items. Primary key is `name` (`str`)."""
+
+            _primary_key: ClassVar[str] = "name"
 
         Servers._item_type = ServersItem
 
@@ -40278,7 +40280,7 @@ class EosDesigns(EosDesignsRootModel):
         'ntp_settings.set_first_ntp_server_as_preferred: false' to disable this behavior.
 
         Subclass of
-        AvdList with `ServersItem` items.
+        AvdIndexedList with `ServersItem` items. Primary key is `name` (`str`).
         """
         authenticate: bool | None
         authenticate_servers_only: bool | None
@@ -40334,7 +40336,7 @@ class EosDesigns(EosDesignsRootModel):
                        'ntp_settings.set_first_ntp_server_as_preferred: false' to disable this behavior.
 
                        Subclass of
-                       AvdList with `ServersItem` items.
+                       AvdIndexedList with `ServersItem` items. Primary key is `name` (`str`).
                     authenticate: authenticate
                     authenticate_servers_only: authenticate_servers_only
                     authentication_keys: Subclass of AvdIndexedList with `AuthenticationKeysItem` items. Primary key is `id` (`int`).

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -7637,6 +7637,7 @@ keys:
         default: true
       servers:
         type: list
+        primary_key: name
         description: 'By default, AVD marks the first server as `preferred`.
 
           Set ''ntp_settings.set_first_ntp_server_as_preferred: false'' to disable

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ntp_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ntp_settings.schema.yml
@@ -32,6 +32,7 @@ keys:
         default: true
       servers:
         type: list
+        primary_key: name
         description: |-
           By default, AVD marks the first server as `preferred`.
           Set 'ntp_settings.set_first_ntp_server_as_preferred: false' to disable this behavior.

--- a/python-avd/pyavd/_eos_designs/structured_config/base/ntp.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/ntp.py
@@ -65,11 +65,6 @@ class NtpMixin(Protocol):
             self.structured_config.ntp.local_interface.name = local_interface
             self.structured_config.ntp.local_interface.vrf = server_vrf
 
-        # First server is set as preferred if ntp_settings.set_first_ntp_server_as_preferred set to true
-        first = self.inputs.ntp_settings.set_first_ntp_server_as_preferred
-        for server in ntp_settings.servers:
-            ntp_server = server._cast_as(EosCliConfigGen.Ntp.ServersItem)
-            if first:
-                ntp_server.preferred = True
-                first = False
-            self.structured_config.ntp.servers.append(ntp_server)
+        self.structured_config.ntp.servers = ntp_settings.servers._cast_as(EosCliConfigGen.Ntp.Servers)
+        if ntp_settings.set_first_ntp_server_as_preferred:
+            next(iter(self.structured_config.ntp.servers)).preferred = True


### PR DESCRIPTION
## Change Summary


Make `ntp_settings.servers[].name` the primary key in the eos_designs schema, aligning the AVD Design input model with the generated `eos_cli_config_gen` `ntp.servers` EOS Config model.


## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- Add `primary_key: name` to `ntp_settings.servers`.

This is not considered a user-facing breaking change for valid AVD usage since input validation is required, and any `ntp_settings.servers` entry without `name` could not produce valid EOS Config data because `ntp.servers.name` is already the primary key there.

## How to test

```bash
uv run python-avd/scripts/build_schemas.py
git diff --check
uv run --group pytest pytest python-avd/tests/pyavd/molecule_scenarios/test_get_device_structured_config.py -q -k 'ntp-settings'
```

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the CONTRIBUTING (https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and the documentation has been updated accordingly.
- [x] I have updated molecule CI (https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NTP server entries now require a unique name.
  * NTP server configurations are consistently identified by name, improving reliable updates and merging.
* **Bug Fixes**
  * Improved handling of the “set first NTP server as preferred” option.
  * Prevented invalid unnamed NTP server entries from being accepted.
* **Documentation**
  * Updated NTP configuration guidance and schema examples to reflect the required, unique server name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->