### PR TITLE
Test: Refactor eos_design_negative_unit_tests

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/converge.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/converge.yml
@@ -5,16 +5,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - failure-devices-and-node-key-2
   hosts: failure-devices-and-node-key-2
@@ -22,16 +13,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - failure-devices-mlag-group
   hosts: failure-devices-mlag-group
@@ -39,16 +21,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-underlay-ipv6
   hosts: missing-underlay-ipv6
@@ -56,16 +29,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-devices-profile
   hosts: missing-devices-profile
@@ -73,16 +37,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-devices-parent-profile
   hosts: missing-devices-parent-profile
@@ -90,16 +45,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-devices-type
   hosts: missing-devices-type
@@ -107,16 +53,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-cv-topology-levels
   hosts: missing-cv-topology-levels
@@ -124,33 +61,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
-
-- name: Converge Negative tests for 'eos_designs_facts' - missing-cv-topology-levels
-  hosts: missing-cv-topology-levels
-  gather_facts: false
-  connection: local
-  tasks:
-    - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-cv-topology-levels-type
   hosts: missing-cv-topology-levels-type
@@ -158,16 +69,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-cv-topology
   hosts: missing-cv-topology
@@ -175,16 +77,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - failure-cv-topology-uplink-interfaces
   hosts: failure-cv-topology-uplink-interfaces
@@ -192,16 +85,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-loopback-ipv4-pool
   hosts: missing-loopback-ipv4-pool
@@ -209,16 +93,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-vtep-loopback-ipv4-pool
   hosts: missing-vtep-loopback-ipv4-pool
@@ -226,16 +101,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-mlag-peer
   hosts: missing-mlag-peer
@@ -243,16 +109,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - mlag-odd-id-oddodd1
   hosts: mlag-odd-id-oddodd1
@@ -260,16 +117,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-mlag-peer-ipv4-pool
   hosts: missing-mlag-peer-ipv4-pool1
@@ -277,16 +125,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-mlag-peer-ipv6-pool
   hosts: missing-mlag-peer-ipv6-pool1
@@ -294,16 +133,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-mlag-peer-l3-ipv4-pool
   hosts: missing-mlag-peer-l3-ipv4-pool1
@@ -311,16 +141,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-mlag-interfaces1
   hosts: missing-mlag-interfaces1
@@ -328,16 +149,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-id-for-mlag1
   hosts: missing-id-for-mlag1
@@ -345,16 +157,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - missing-id-for-secondary-mlag2
   hosts: missing-id-for-secondary-mlag2
@@ -362,288 +165,126 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - invalid-schema
   hosts: invalid-schema
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: invalid-schema-connected-endpoints
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: invalid-uplink-port-channel-id-1-l3leaf-1
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: invalid-uplink-port-channel-id-2-l3leaf-1
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: invalid-uplink-port-channel-id-3-l2leaf-1
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: invalid-uplink-type-p2p-vrfs-underlay-router-false
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: downlink-pools-duplicate-spine
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: downlink-pools-missing-spine
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: downlink-pools-missing-spine-ipv6
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: downlink-interfaces-too-small-l3leaf
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: FAILURE_CONNECTED_ENDPOINT_PORT_PROFILE_DOES_NOT_EXIST_IN_FACTS
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: MISSING_BGP_AS_WITH_L3_INTERFACES_BGP_PEERS
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: FABRIC_ID_STATIC_AND_POOL_MANAGER_INVALID
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: id-static-and-pool-manager-collision-a
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: FABRIC_UNDEFINED_PEER
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: FABRIC_UNDERLAY_ROUTER_WITH_PORT_CHANNEL_UPLINK
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: FABRIC_UNDERLAY_ROUTER_WITH_L2_ETHERNET_UPLINK
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: EOS_DESIGNS_FAILURES_INCLUDED
@@ -651,16 +292,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: inband-mgmt-missing-id-with-subnet
@@ -668,16 +300,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: inband-mgmt-missing-id-with-ipv6-subnet
@@ -685,32 +308,14 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: SMALL_BGP_AS_RANGE
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: missing-router-id-pool
@@ -718,16 +323,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: missing-vtep-loopback-ipv6-pool
@@ -735,16 +331,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: missing-mlag-peer-l3-ipv6-pool
@@ -752,16 +339,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: unsupported-wan-router-underlay-ipv6-numbered
@@ -769,16 +347,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: unsupported-underlay-multicast-underlay-ipv6-numbered
@@ -786,16 +355,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: unsupported-rfc5549-underlay-ipv6-numbered
@@ -803,16 +363,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: unsupported-vtep-vvtep-ip-underlay-ipv6-numbered
@@ -820,16 +371,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: unsupported-inband-ztp-ip-underlay-ipv6-numbered
@@ -837,16 +379,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: unsupported-non-ebgp-underlay-routing-protocol-ip-underlay-ipv6-numbered
@@ -854,16 +387,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: missing-wan-interfaces
@@ -871,16 +395,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: missing-wan-carriers
@@ -888,16 +403,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: missing-wan-interfaces-ip-address
@@ -905,16 +411,7 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: wan-server-with-interfaces-as-dhcp-address
@@ -922,253 +419,95 @@
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: FAILURE_OVERLAY_ROUTING_PROTOCOL_ADDRESS_FAMILY_IPV6
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
-
-- name: Converge Negative tests for 'eos_designs_facts'
-  hosts: digital-twin-act-missing-node-type
-  connection: local
-  tasks:
-    - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
-
-- name: Converge Negative tests for 'eos_designs_facts'
-  hosts: digital-twin-act-missing-ip-addr
-  connection: local
-  tasks:
-    - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: wan-unsupported-platform
   gather_facts: false
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: multiple-uplink-interfaces-for-uplink-type-lan
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: missing-underlay-router-and-network-services-for-uplink-type-lan
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: missing-id-on-l2leaf-uplink-switch-interfaces
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: missing-downlink-interfaces-spine
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts'
   hosts: incorrect-uplink-port-channel-id-l2leaf1b
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - FABRIC_MISSING_BGP_AS_ON_UPLINK_SWITCH
   hosts: missing-bgp-as-on-uplink-switch-leaf
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - FABRIC_SMALL_BGP_AS_RANGE_ON_UPLINK_SWITCH
   hosts: small-bgp-as-range-on-uplink-switch-leaf
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - FABRIC_MISSING_UNDERLAY_MULTICAST_FOR_EVPN_MULTICAST
   hosts: evpn-multicast-missing-underlay-multicast
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - FABRIC_UPLINK_TESTS_1
   hosts: uplink-switches-length-less-than-uplink-interfaces
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - FABRIC_UPLINK_TESTS_2
   hosts: uplink-interfaces-length-in-default-interfaces-less-than-uplink-switches
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml
 
 - name: Converge Negative tests for 'eos_designs_facts' - FABRIC_UPLINK_TESTS_3
   hosts: uplink-switches-interfaces-length-not-equal-to-uplink-switches
   connection: local
   tasks:
     - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg.endswith(expected_error_message)
+      ansible.builtin.import_tasks: tasks/run_negative_eos_designs_case.yml

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/tasks/run_negative_eos_designs_case.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_negative_unit_tests/tasks/run_negative_eos_designs_case.yml
@@ -1,0 +1,12 @@
+---
+- name: Run failure scenario Test
+  block:
+    - name: Trigger Error
+      ansible.builtin.import_role:
+        name: arista.avd.eos_designs
+  rescue:
+    - name: Assert eos_designs failed with the expected error message
+      ansible.builtin.assert:
+        that:
+          - ansible_failed_result is defined
+          - ansible_failed_result.msg.endswith(expected_error_message)


### PR DESCRIPTION
## Change Summary

Refactor the `eos_designs_negative_unit_tests` molecule converge playbook to share the repeated negative-test execution logic and remove duplicate play executions without changing production behavior.

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- Extract the repeated `eos_designs` failure `block`/`rescue` assertion into a shared molecule task file.
- Update the converge playbook so each negative-test play imports the shared failure-case runner.
- Remove duplicate negative play executions already covered by grouped inventory entries.
- Leave `eos_designs_facts` and production role/plugin surfaces unchanged.

## How to test

```bash
cd ansible_collections/arista/avd
uv run --group dev molecule test --scenario-name eos_designs_negative_unit_tests
```

```bash
uv run --group pytest pytest python-avd/tests/pyavd/molecule_scenarios/test_negative_eos_designs.py
```

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/devel/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and the documentation has been updated accordingly. No documentation update is required for this molecule test refactor.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated negative test scenarios into a shared test workflow.
  * Preserved validation that expected error messages are returned when scenarios fail.
  * Reduced duplicated test configuration while maintaining existing scenario coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->