### PR TITLE
Refactor(eos_designs): Refactor set_vars AVD action plugin to use the new AvdActionPlugin base class

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/set_vars.py
+++ b/ansible_collections/arista/avd/plugins/action/set_vars.py
@@ -3,14 +3,12 @@
 # that can be found in the LICENSE file.
 from typing import Any
 
-from ansible.plugins.action import ActionBase
+from ansible_collections.arista.avd.plugins.plugin_utils.utils.avd_action_plugin import AVDActionPlugin, AVDLoggingConfig
 
 
-class ActionModule(ActionBase):
-    def run(self, tmp: Any = None, task_vars: dict | None = None) -> dict:  # noqa: ARG002
-        if task_vars is None:
-            task_vars = {}
+class ActionModule(AVDActionPlugin):
+    _logging_config = AVDLoggingConfig(add_hostname_context=True)
 
-        result = {}
-        result["ansible_facts"] = self._task.args
-        return result
+    def main(self, _task_vars: dict[str, Any]) -> None:
+        """Set task arguments as ansible_facts."""
+        self.result["ansible_facts"] = self._task.args


### PR DESCRIPTION
## Change Summary

Refactor set_vars AVD action plugin to use the new AvdActionPlugin base class

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
Refactor set_vars AVD action plugin to use the new AvdActionPlugin base class

## How to test
CI should be green

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the variable-setting action to use the standardized action-plugin framework.
  * Improved logging context by including the device hostname.
  * Preserved task arguments as Ansible facts for consistent downstream use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->