### PR TITLE
Feat(eos_designs): Allow for route_reflector_client to be configured under network_service.vrfs.bgp_peers

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/bgp-from-network-services-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/bgp-from-network-services-1.cfg
@@ -121,6 +121,7 @@ router bgp 65001
    neighbor VALIDATE_BGP_PEERS next-hop-self
    neighbor VALIDATE_BGP_PEERS bfd
    neighbor 10.10.1.2 peer group MYPEERGROUP
+   neighbor 10.10.1.2 route-reflector-client
    neighbor 10.10.1.2 default-originate always
    neighbor 10.10.20.1 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.10.20.1 description bgp-from-network-services-2_Vlan3099
@@ -138,6 +139,7 @@ router bgp 65001
       update wait-install
       timers bgp 42 42
       neighbor 10.10.2.2 peer group VALIDATE_BGP_PEERS
+      neighbor 10.10.2.2 route-reflector-client
       neighbor 10.10.2.2 default-originate always
       neighbor 10.10.20.1 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.10.20.1 description bgp-from-network-services-2_Vlan3100

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/bgp-from-network-services-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/bgp-from-network-services-2.cfg
@@ -126,6 +126,7 @@ router bgp 65001
    neighbor VALIDATE_BGP_PEERS next-hop-self
    neighbor VALIDATE_BGP_PEERS bfd
    neighbor 10.10.1.2 peer group MYPEERGROUP
+   neighbor 10.10.1.2 route-reflector-client
    neighbor 10.10.1.2 default-originate always
    neighbor 10.10.20.0 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.10.20.0 description bgp-from-network-services-1_Vlan3099
@@ -143,6 +144,7 @@ router bgp 65001
       update wait-install
       timers bgp 42 42
       neighbor 10.10.2.2 peer group VALIDATE_BGP_PEERS
+      neighbor 10.10.2.2 route-reflector-client
       neighbor 10.10.2.2 default-originate always
       neighbor 10.10.20.0 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.10.20.0 description bgp-from-network-services-1_Vlan3100

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-from-network-services-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-from-network-services-1.yml
@@ -115,6 +115,7 @@ router_bgp:
     peer_group: MYPEERGROUP
     metadata:
       validate_state: false
+    route_reflector_client: true
     default_originate:
       enabled: true
       always: true
@@ -150,6 +151,7 @@ router_bgp:
         validate_state: true
     - ip_address: 10.10.2.2
       peer_group: VALIDATE_BGP_PEERS
+      route_reflector_client: true
       default_originate:
         always: true
       metadata:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-from-network-services-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-from-network-services-2.yml
@@ -117,6 +117,7 @@ router_bgp:
     peer_group: MYPEERGROUP
     metadata:
       validate_state: false
+    route_reflector_client: true
     default_originate:
       enabled: true
       always: true
@@ -154,6 +155,7 @@ router_bgp:
         validate_state: true
     - ip_address: 10.10.2.2
       peer_group: VALIDATE_BGP_PEERS
+      route_reflector_client: true
       default_originate:
         always: true
       metadata:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_FROM_NETWORK_SERVICES.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_FROM_NETWORK_SERVICES.yml
@@ -84,6 +84,7 @@ tenants:
             # This will render enabled: True in structured config
             default_originate:
               always: true
+            route_reflector_client: true
           - ip_address: 11.11.1.2
             peer_group: MYPEERGROUP
             nodes: [bgp-from-network-services-1]
@@ -129,6 +130,7 @@ tenants:
             # This will not render enabled: True in structured config
             default_originate:
               always: true
+            route_reflector_client: true
         bgp_peer_groups:
           - name: VALIDATE_BGP_PEERS
             remote_as: 65991

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
@@ -145,7 +145,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].bfd_timers.interval") | Integer | Required |  | Min: 50<br>Max: 60000 | Interval in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].bfd_timers.min_rx") | Integer | Required |  | Min: 50<br>Max: 60000 | Rate in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].bfd_timers.multiplier") | Integer | Required |  | Min: 3<br>Max: 50 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_reflector_client</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].route_reflector_client") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_reflector_client</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].route_reflector_client") | Boolean |  |  |  | Configure the peer as a route-reflector-client. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].shutdown") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer_groups</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups") | List, items: Dictionary |  |  |  | List of BGP peer groups definitions.<br>This will configure BGP peer groups to be used inside the tenant VRF for peering with external devices.<br>Since BGP peer groups are configured at higher BGP level, shared between VRFs,<br>peer_group names should not overlap between VRFs.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].name") | String | Required, Unique |  |  | BGP peer group name. |
@@ -389,7 +389,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "network_services.[].vrfs.[].bgp_peers.[].bfd_timers.interval") | Integer | Required |  | Min: 50<br>Max: 60000 | Interval in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "network_services.[].vrfs.[].bgp_peers.[].bfd_timers.min_rx") | Integer | Required |  | Min: 50<br>Max: 60000 | Rate in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "network_services.[].vrfs.[].bgp_peers.[].bfd_timers.multiplier") | Integer | Required |  | Min: 3<br>Max: 50 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_reflector_client</samp>](## "network_services.[].vrfs.[].bgp_peers.[].route_reflector_client") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_reflector_client</samp>](## "network_services.[].vrfs.[].bgp_peers.[].route_reflector_client") | Boolean |  |  |  | Configure the peer as a route-reflector-client. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "network_services.[].vrfs.[].bgp_peers.[].shutdown") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer_groups</samp>](## "network_services.[].vrfs.[].bgp_peer_groups") | List, items: Dictionary |  |  |  | List of BGP peer groups definitions.<br>This will configure BGP peer groups to be used inside the tenant VRF for peering with external devices.<br>Since BGP peer groups are configured at higher BGP level, shared between VRFs,<br>peer_group names should not overlap between VRFs.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].name") | String | Required, Unique |  |  | BGP peer group name. |
@@ -849,6 +849,8 @@
                   # Rate in milliseconds.
                   min_rx: <int; 50-60000; required>
                   multiplier: <int; 3-50; required>
+
+                # Configure the peer as a route-reflector-client.
                 route_reflector_client: <bool>
                 shutdown: <bool>
 
@@ -1450,6 +1452,8 @@
                   # Rate in milliseconds.
                   min_rx: <int; 50-60000; required>
                   multiplier: <int; 3-50; required>
+
+                # Configure the peer as a route-reflector-client.
                 route_reflector_client: <bool>
                 shutdown: <bool>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
@@ -145,6 +145,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].bfd_timers.interval") | Integer | Required |  | Min: 50<br>Max: 60000 | Interval in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].bfd_timers.min_rx") | Integer | Required |  | Min: 50<br>Max: 60000 | Rate in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].bfd_timers.multiplier") | Integer | Required |  | Min: 3<br>Max: 50 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_reflector_client</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].route_reflector_client") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peers.[].shutdown") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer_groups</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups") | List, items: Dictionary |  |  |  | List of BGP peer groups definitions.<br>This will configure BGP peer groups to be used inside the tenant VRF for peering with external devices.<br>Since BGP peer groups are configured at higher BGP level, shared between VRFs,<br>peer_group names should not overlap between VRFs.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<network_services_keys.name>.[].vrfs.[].bgp_peer_groups.[].name") | String | Required, Unique |  |  | BGP peer group name. |
@@ -388,6 +389,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "network_services.[].vrfs.[].bgp_peers.[].bfd_timers.interval") | Integer | Required |  | Min: 50<br>Max: 60000 | Interval in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "network_services.[].vrfs.[].bgp_peers.[].bfd_timers.min_rx") | Integer | Required |  | Min: 50<br>Max: 60000 | Rate in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "network_services.[].vrfs.[].bgp_peers.[].bfd_timers.multiplier") | Integer | Required |  | Min: 3<br>Max: 50 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_reflector_client</samp>](## "network_services.[].vrfs.[].bgp_peers.[].route_reflector_client") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "network_services.[].vrfs.[].bgp_peers.[].shutdown") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer_groups</samp>](## "network_services.[].vrfs.[].bgp_peer_groups") | List, items: Dictionary |  |  |  | List of BGP peer groups definitions.<br>This will configure BGP peer groups to be used inside the tenant VRF for peering with external devices.<br>Since BGP peer groups are configured at higher BGP level, shared between VRFs,<br>peer_group names should not overlap between VRFs.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "network_services.[].vrfs.[].bgp_peer_groups.[].name") | String | Required, Unique |  |  | BGP peer group name. |
@@ -847,6 +849,7 @@
                   # Rate in milliseconds.
                   min_rx: <int; 50-60000; required>
                   multiplier: <int; 3-50; required>
+                route_reflector_client: <bool>
                 shutdown: <bool>
 
             # List of BGP peer groups definitions.
@@ -1447,6 +1450,7 @@
                   # Rate in milliseconds.
                   min_rx: <int; 50-60000; required>
                   multiplier: <int; 3-50; required>
+                route_reflector_client: <bool>
                 shutdown: <bool>
 
             # List of BGP peer groups definitions.

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -35836,6 +35836,7 @@ class EosDesigns(EosDesignsRootModel):
                 bfd_timers: EosCliConfigGen.RouterBgp.VrfsItem.NeighborsItem.BfdTimers
                 """Override default BFD timers. BFD must be enabled with `bfd: true`."""
                 route_reflector_client: bool | None
+                """Configure the peer as a route-reflector-client."""
                 shutdown: bool | None
 
                 if TYPE_CHECKING:
@@ -35937,7 +35938,7 @@ class EosDesigns(EosDesignsRootModel):
                             weight: weight
                             bfd: bfd
                             bfd_timers: Override default BFD timers. BFD must be enabled with `bfd: true`.
-                            route_reflector_client: route_reflector_client
+                            route_reflector_client: Configure the peer as a route-reflector-client.
                             shutdown: shutdown
 
                         """
@@ -85331,6 +85332,7 @@ class EosDesigns(EosDesignsRootModel):
                         bfd_timers: EosCliConfigGen.RouterBgp.VrfsItem.NeighborsItem.BfdTimers
                         """Override default BFD timers. BFD must be enabled with `bfd: true`."""
                         route_reflector_client: bool | None
+                        """Configure the peer as a route-reflector-client."""
                         shutdown: bool | None
 
                         if TYPE_CHECKING:
@@ -85432,7 +85434,7 @@ class EosDesigns(EosDesignsRootModel):
                                     weight: weight
                                     bfd: bfd
                                     bfd_timers: Override default BFD timers. BFD must be enabled with `bfd: true`.
-                                    route_reflector_client: route_reflector_client
+                                    route_reflector_client: Configure the peer as a route-reflector-client.
                                     shutdown: shutdown
 
                                 """

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -35745,6 +35745,7 @@ class EosDesigns(EosDesignsRootModel):
                     "weight": {"type": int},
                     "bfd": {"type": bool},
                     "bfd_timers": {"type": EosCliConfigGen.RouterBgp.VrfsItem.NeighborsItem.BfdTimers},
+                    "route_reflector_client": {"type": bool},
                     "shutdown": {"type": bool},
                 }
                 ip_address: str
@@ -35834,6 +35835,7 @@ class EosDesigns(EosDesignsRootModel):
                 bfd: bool | None
                 bfd_timers: EosCliConfigGen.RouterBgp.VrfsItem.NeighborsItem.BfdTimers
                 """Override default BFD timers. BFD must be enabled with `bfd: true`."""
+                route_reflector_client: bool | None
                 shutdown: bool | None
 
                 if TYPE_CHECKING:
@@ -35866,6 +35868,7 @@ class EosDesigns(EosDesignsRootModel):
                         weight: int | None | UndefinedType = Undefined,
                         bfd: bool | None | UndefinedType = Undefined,
                         bfd_timers: EosCliConfigGen.RouterBgp.VrfsItem.NeighborsItem.BfdTimers | UndefinedType = Undefined,
+                        route_reflector_client: bool | None | UndefinedType = Undefined,
                         shutdown: bool | None | UndefinedType = Undefined,
                     ) -> None:
                         """
@@ -35934,6 +35937,7 @@ class EosDesigns(EosDesignsRootModel):
                             weight: weight
                             bfd: bfd
                             bfd_timers: Override default BFD timers. BFD must be enabled with `bfd: true`.
+                            route_reflector_client: route_reflector_client
                             shutdown: shutdown
 
                         """
@@ -85236,6 +85240,7 @@ class EosDesigns(EosDesignsRootModel):
                             "weight": {"type": int},
                             "bfd": {"type": bool},
                             "bfd_timers": {"type": EosCliConfigGen.RouterBgp.VrfsItem.NeighborsItem.BfdTimers},
+                            "route_reflector_client": {"type": bool},
                             "shutdown": {"type": bool},
                         }
                         ip_address: str
@@ -85325,6 +85330,7 @@ class EosDesigns(EosDesignsRootModel):
                         bfd: bool | None
                         bfd_timers: EosCliConfigGen.RouterBgp.VrfsItem.NeighborsItem.BfdTimers
                         """Override default BFD timers. BFD must be enabled with `bfd: true`."""
+                        route_reflector_client: bool | None
                         shutdown: bool | None
 
                         if TYPE_CHECKING:
@@ -85357,6 +85363,7 @@ class EosDesigns(EosDesignsRootModel):
                                 weight: int | None | UndefinedType = Undefined,
                                 bfd: bool | None | UndefinedType = Undefined,
                                 bfd_timers: EosCliConfigGen.RouterBgp.VrfsItem.NeighborsItem.BfdTimers | UndefinedType = Undefined,
+                                route_reflector_client: bool | None | UndefinedType = Undefined,
                                 shutdown: bool | None | UndefinedType = Undefined,
                             ) -> None:
                                 """
@@ -85425,6 +85432,7 @@ class EosDesigns(EosDesignsRootModel):
                                     weight: weight
                                     bfd: bfd
                                     bfd_timers: Override default BFD timers. BFD must be enabled with `bfd: true`.
+                                    route_reflector_client: route_reflector_client
                                     shutdown: shutdown
 
                                 """

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -7019,6 +7019,7 @@ keys:
                       $ref: eos_cli_config_gen#/keys/router_bgp/keys/vrfs/items/keys/neighbors/items/keys/bfd_timers
                     route_reflector_client:
                       type: bool
+                      description: Configure the peer as a route-reflector-client.
                     shutdown:
                       type: bool
               bgp:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -7017,6 +7017,8 @@ keys:
                     bfd_timers:
                       type: dict
                       $ref: eos_cli_config_gen#/keys/router_bgp/keys/vrfs/items/keys/neighbors/items/keys/bfd_timers
+                    route_reflector_client:
+                      type: bool
                     shutdown:
                       type: bool
               bgp:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services.schema.yml
@@ -1642,6 +1642,7 @@ keys:
                       $ref: "eos_cli_config_gen#/keys/router_bgp/keys/vrfs/items/keys/neighbors/items/keys/bfd_timers"
                     route_reflector_client:
                       type: bool
+                      description: Configure the peer as a route-reflector-client.
                     shutdown:
                       type: bool
               bgp:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services.schema.yml
@@ -1640,6 +1640,8 @@ keys:
                     bfd_timers:
                       type: dict
                       $ref: "eos_cli_config_gen#/keys/router_bgp/keys/vrfs/items/keys/neighbors/items/keys/bfd_timers"
+                    route_reflector_client:
+                      type: bool
                     shutdown:
                       type: bool
               bgp:


### PR DESCRIPTION
## Change Summary

Allow for route_reflector_client to be configured under network_service.vrfs.bgp_peers

## Related Issue(s)

Fixes #7283 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Allow for route_reflector_client to be configured under network_service.vrfs.bgp_peers

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring BGP neighbors as route reflector clients in network services VRFs.
  - The setting can be defined per peer and is rendered into the resulting BGP configuration.

- **Documentation**
  - Updated BGP peer settings documentation to include the new `route_reflector_client` option in schema tables and YAML examples.

- **Tests**
  - Updated intended structured configurations and configs to validate `route_reflector_client` across relevant peer groups and VRFs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->