### PR TITLE
Fix(eos_cli_config_gen): Align BGP IPv6 additional-paths prefix-list schema and EOS template

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -10995,7 +10995,7 @@ router bgp 65101
       neighbor baz prefix-list PL-BAR-v6-IN in
       neighbor baz prefix-list PL-BAR-v6-OUT out
       neighbor baz default-originate route-map RM-FOO always
-      neighbor baz additional-paths send ecmp limit 20
+      neighbor baz additional-paths send ecmp limit 20 prefix-list PL2
       no neighbor FOOBAR activate
       neighbor FOOBAR1 activate
       neighbor FOOBAR1 default-originate
@@ -11020,7 +11020,7 @@ router bgp 65101
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
       neighbor 2001:db8::1 default-originate route-map RM-FOO-MATCH3 always
-      neighbor 2001:db8::1 additional-paths send ecmp limit 20
+      neighbor 2001:db8::1 additional-paths send ecmp limit 20 prefix-list PL-IPV6-ADDITIONAL-PATHS
       neighbor 2001:db8::1 peer-tag in PEER_TAG_IN_IPV6
       neighbor 2001:db8::1 peer-tag out discard PEER_TAG_DISCARD_OUT_IPV6
       neighbor 2001:db8::2 activate

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -6783,7 +6783,7 @@ router bgp 65101
       neighbor baz prefix-list PL-BAR-v6-IN in
       neighbor baz prefix-list PL-BAR-v6-OUT out
       neighbor baz default-originate route-map RM-FOO always
-      neighbor baz additional-paths send ecmp limit 20
+      neighbor baz additional-paths send ecmp limit 20 prefix-list PL2
       no neighbor FOOBAR activate
       neighbor FOOBAR1 activate
       neighbor FOOBAR1 default-originate
@@ -6808,7 +6808,7 @@ router bgp 65101
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-IN in
       neighbor 2001:db8::1 prefix-list PL-FOO-v6-OUT out
       neighbor 2001:db8::1 default-originate route-map RM-FOO-MATCH3 always
-      neighbor 2001:db8::1 additional-paths send ecmp limit 20
+      neighbor 2001:db8::1 additional-paths send ecmp limit 20 prefix-list PL-IPV6-ADDITIONAL-PATHS
       neighbor 2001:db8::1 peer-tag in PEER_TAG_IN_IPV6
       neighbor 2001:db8::1 peer-tag out discard PEER_TAG_DISCARD_OUT_IPV6
       neighbor 2001:db8::2 activate

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
@@ -758,6 +758,7 @@ router_bgp:
           receive: true
           send: ecmp
           send_limit: 20
+          prefix_list: PL-IPV6-ADDITIONAL-PATHS
       - ip_address: 2001:db8::2
         activate: true
         additional_paths:

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -2022,7 +2022,7 @@ router bgp {{ router_bgp.as }}
 {%                     else %}
 {%                         set add_path_cli = 'neighbor ' ~ peer_group.name ~ ' additional-paths send ' ~ peer_group.additional_paths.send %}
 {%                     endif %}
-{%                     if peer_group.additional_paths.prefix_list is arista.avd.defined and add_path_cli is arista.avd.defined %}
+{%                     if peer_group.additional_paths.prefix_list is arista.avd.defined %}
 {%                         set add_path_cli = add_path_cli ~ ' prefix-list ' ~ peer_group.additional_paths.prefix_list %}
 {%                     endif %}
 {%                     if add_path_cli is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -2022,8 +2022,8 @@ router bgp {{ router_bgp.as }}
 {%                     else %}
 {%                         set add_path_cli = 'neighbor ' ~ peer_group.name ~ ' additional-paths send ' ~ peer_group.additional_paths.send %}
 {%                     endif %}
-{%                     if router_bgp.address_family_ipv6.bgp.additional_paths.prefix_list is arista.avd.defined %}
-{%                         set add_path_cli = add_path_cli ~ ' prefix-list ' ~ router_bgp.address_family_ipv6.bgp.additional_paths.prefix_list %}
+{%                     if peer_group.additional_paths.prefix_list is arista.avd.defined and add_path_cli is arista.avd.defined %}
+{%                         set add_path_cli = add_path_cli ~ ' prefix-list ' ~ peer_group.additional_paths.prefix_list %}
 {%                     endif %}
 {%                     if add_path_cli is arista.avd.defined %}
       {{ add_path_cli }}
@@ -2087,8 +2087,8 @@ router bgp {{ router_bgp.as }}
 {%                     else %}
 {%                         set add_path_cli = 'neighbor ' ~ neighbor.ip_address ~ ' additional-paths send ' ~ neighbor.additional_paths.send %}
 {%                     endif %}
-{%                     if router_bgp.address_family_ipv6.bgp.additional_paths.prefix_list is arista.avd.defined %}
-{%                         set add_path_cli = add_path_cli ~ ' prefix-list ' ~ router_bgp.address_family_ipv6.bgp.additional_paths.prefix_list %}
+{%                     if neighbor.additional_paths.prefix_list is arista.avd.defined %}
+{%                         set add_path_cli = add_path_cli ~ ' prefix-list ' ~ neighbor.additional_paths.prefix_list %}
 {%                     endif %}
 {%                     if add_path_cli is arista.avd.defined %}
       {{ add_path_cli }}


### PR DESCRIPTION
## Change Summary
Align BGP IPv6 additional-paths prefix-list schema and EOS template

## Related Issue(s)

Fixes #7130

## Component(s) name

`arista.avd.eos_cli_config_gen `

## Proposed changes
Fix schema mismatch: replace invalid router_bgp.address_family_ipv6.bgp.additional_paths.prefix_list with peer-group/neighbor-specific prefix_list fields.

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IPv6 BGP additional-paths configuration to apply the appropriate prefix list for each neighbor or peer group.
  * Added support for distinct prefix-list filters on configured IPv6 neighbors, ensuring generated device configurations match their intended settings.
  * Improved generated routing configurations by preserving neighbor-specific additional-paths policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->