### PR TITLE
CI: Added integration tests for eos_designs_documentation plugin action

### DIFF
--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_documentation/tests/test_missing_facts_file.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_documentation/tests/test_missing_facts_file.yml
@@ -1,0 +1,20 @@
+---
+- name: Test missing eos_designs facts file
+  ignore_errors: true
+  register: result
+  arista.avd.eos_designs_documentation:
+    structured_config_dir: "{{ actual_output_dir }}"
+    fabric_documentation_file: "{{ actual_output_dir }}/eos_designs_documentation_missing_facts_file.md"
+    topology_csv_file: "{{ actual_output_dir }}/eos_designs_documentation_missing_facts_file_topology.csv"
+    p2p_links_csv_file: "{{ actual_output_dir }}/eos_designs_documentation_missing_facts_file_p2p.csv"
+    tmp_dir: "{{ actual_output_dir }}/tmp_missing_eos_designs_facts_for_documentation"
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is failed
+      - >-
+        "Missing AVD eos_designs facts to generate documentation" in result.msg

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_documentation/tests/test_with_existing_structured_cfg_json.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_documentation/tests/test_with_existing_structured_cfg_json.yml
@@ -1,0 +1,53 @@
+---
+- name: Validate eos_designs inputs
+  arista.avd.validate_inputs:
+    schema_name: avd_design
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation_json"
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Set eos_designs facts
+  arista.avd.eos_designs_facts:
+    template_output: true
+    output_dir: "{{ actual_output_dir }}"
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation_json"
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Create structured config for testhost in JSON format
+  arista.avd.eos_designs_structured_config:
+    dest: "{{ actual_output_dir }}/testhost.json"
+    return_structured_config: true
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation_json"
+  check_mode: false
+  run_once: true
+
+- name: Remove prior documentation output file
+  ansible.builtin.file:
+    path: "{{ actual_output_dir }}/eos_designs_documentation_json_structured_config.md"
+    state: absent
+
+- name: Run eos_designs_documentation using JSON structured config
+  register: result
+  arista.avd.eos_designs_documentation:
+    structured_config_dir: "{{ actual_output_dir }}"
+    structured_config_suffix: json
+    fabric_documentation_file: "{{ actual_output_dir }}/eos_designs_documentation_json_structured_config.md"
+    topology_csv_file: "{{ actual_output_dir }}/not_used_topology.csv"
+    p2p_links_csv_file: "{{ actual_output_dir }}/not_used_p2p.csv"
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation_json"
+    fabric_documentation: true
+    topology_csv: false
+    p2p_links_csv: false
+    digital_twin: false
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is success
+      - result.changed == true

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_documentation/tests/test_with_existing_structured_cfg_yml_all_outputs.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_documentation/tests/test_with_existing_structured_cfg_yml_all_outputs.yml
@@ -1,0 +1,88 @@
+---
+- name: Validate eos_designs inputs
+  arista.avd.validate_inputs:
+    schema_name: avd_design
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation"
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Set eos_designs facts
+  arista.avd.eos_designs_facts:
+    template_output: true
+    output_dir: "{{ actual_output_dir }}"
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation"
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Create structured config for testhost in YAML format
+  arista.avd.eos_designs_structured_config:
+    dest: "{{ actual_output_dir }}/testhost.yml"
+    return_structured_config: true
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation"
+  check_mode: false
+  run_once: true
+
+- name: Enable ACT digital twin metadata in structured config
+  ansible.builtin.replace:
+    path: "{{ actual_output_dir }}/testhost.yml"
+    regexp: |
+      metadata:
+        is_deployed: true
+        fabric_name: testgroup
+    replace: |
+      metadata:
+        is_deployed: true
+        fabric_name: testgroup
+        digital_twin:
+          environment: act
+          node_type: veos
+          username: cvpadmin
+          password: cvpadmin
+          version: 4.32.3F
+
+- name: Remove prior documentation output files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ actual_output_dir }}/eos_designs_documentation_all_outputs.md"
+    - "{{ actual_output_dir }}/eos_designs_documentation_all_outputs_topology.csv"
+    - "{{ actual_output_dir }}/eos_designs_documentation_all_outputs_p2p.csv"
+    - "{{ actual_output_dir }}/eos_designs_documentation_all_outputs_digital_twin.yml"
+
+- name: Run eos_designs_documentation with all outputs enabled
+  register: result
+  arista.avd.eos_designs_documentation:
+    structured_config_dir: "{{ actual_output_dir }}"
+    structured_config_suffix: yml
+    fabric_documentation_file: "{{ actual_output_dir }}/eos_designs_documentation_all_outputs.md"
+    topology_csv_file: "{{ actual_output_dir }}/eos_designs_documentation_all_outputs_topology.csv"
+    p2p_links_csv_file: "{{ actual_output_dir }}/eos_designs_documentation_all_outputs_p2p.csv"
+    digital_twin_file: "{{ actual_output_dir }}/eos_designs_documentation_all_outputs_digital_twin.yml"
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation"
+    fabric_documentation: true
+    topology_csv: true
+    p2p_links_csv: true
+    digital_twin: true
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Stat mandatory generated output files
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - "{{ actual_output_dir }}/eos_designs_documentation_all_outputs.md"
+    - "{{ actual_output_dir }}/eos_designs_documentation_all_outputs_topology.csv"
+    - "{{ actual_output_dir }}/eos_designs_documentation_all_outputs_p2p.csv"
+    - "{{ actual_output_dir }}/eos_designs_documentation_all_outputs_digital_twin.yml"
+  register: generated_files
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is success
+      - result.changed == true
+      - generated_files.results | map(attribute='stat.exists') | min

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_documentation/tests/test_without_fabric_documentation_output.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_documentation/tests/test_without_fabric_documentation_output.yml
@@ -1,0 +1,59 @@
+---
+- name: Validate eos_designs inputs
+  arista.avd.validate_inputs:
+    schema_name: avd_design
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation_no_fabric_doc"
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Set eos_designs facts
+  arista.avd.eos_designs_facts:
+    template_output: true
+    output_dir: "{{ actual_output_dir }}"
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation_no_fabric_doc"
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Create structured config for testhost in YAML format
+  arista.avd.eos_designs_structured_config:
+    dest: "{{ actual_output_dir }}/testhost.yml"
+    return_structured_config: true
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation_no_fabric_doc"
+  check_mode: false
+  run_once: true
+
+- name: Remove prior documentation output files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ actual_output_dir }}/eos_designs_documentation_no_fabric_doc.md"
+    - "{{ actual_output_dir }}/eos_designs_documentation_no_fabric_doc_topology.csv"
+    - "{{ actual_output_dir }}/eos_designs_documentation_no_fabric_doc_p2p.csv"
+    - "{{ actual_output_dir }}/eos_designs_documentation_no_fabric_doc_digital_twin.yml"
+
+- name: Run eos_designs_documentation with all outputs disabled
+  register: result
+  arista.avd.eos_designs_documentation:
+    structured_config_dir: "{{ actual_output_dir }}"
+    structured_config_suffix: yml
+    fabric_documentation_file: "{{ actual_output_dir }}/eos_designs_documentation_no_fabric_doc.md"
+    topology_csv_file: "{{ actual_output_dir }}/eos_designs_documentation_no_fabric_doc_topology.csv"
+    p2p_links_csv_file: "{{ actual_output_dir }}/eos_designs_documentation_no_fabric_doc_p2p.csv"
+    digital_twin_file: "{{ actual_output_dir }}/eos_designs_documentation_no_fabric_doc_digital_twin.yml"
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_documentation_no_fabric_doc"
+    fabric_documentation: false
+    topology_csv: false
+    p2p_links_csv: false
+    digital_twin: false
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is success
+      - result.changed == false


### PR DESCRIPTION
## Change Summary

Added integration tests for eos_designs_documentation plugin action.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
Added integration tests for eos_designs_documentation plugin action

## How to test
Coverage from devel
```
Name                                          Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------------------
plugins/action/eos_designs_documentation.py      75     18     22      9    70%   31-32, 62-63, 94->100, 101-106,109-114, 117-125, 140, 143->146, 153-158, 170-171
-----------------------------------------------------------------------------------------
TOTAL                                            75     18     22      9    70%
```

Coverage from this PR
```
Name                                          Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------------------
plugins/action/eos_designs_documentation.py      75      4     22      1    95%   31-32, 62-63
-----------------------------------------------------------------------------------------
TOTAL                                            75      4     22      1    95%
(avd_env) mahesh.kumar-ext@mahesh49RVC7m avd % 
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage for EOS Designs documentation generation.
  * Added validation for clear failure handling when required design facts are missing.
  * Added successful-generation scenarios using existing JSON and YAML configuration.
  * Verified fabric documentation, topology, point-to-point, and digital twin outputs, including fully enabled and selectively disabled configurations.
  * Confirmed generated documentation files and no-change behavior where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->