### PR TITLE
Feat(eos_designs): Add peer_ipv6 substitution for IPv6 ACLs on network services l3_interfaces and l3_port_channels 

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/network-services-l3-interfaces.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/network-services-l3-interfaces.cfg
@@ -36,6 +36,22 @@ interface Ethernet12
    ipv6 address 2001:db8:12::1/64
    ipv6 access-group TEST-IPV6-ACL-WITH-IP-FIELDS-OUT_Ethernet12 out
 !
+interface Ethernet13
+   description peer-ipv6-acl-test
+   no shutdown
+   no switchport
+   vrf L3INTF_TEST
+   ipv6 address 2001:db8:13::1/64
+   ipv6 access-group TEST-IPV6-ACL-WITH-PEER-IPV6-IN_Ethernet13 in
+!
+interface Ethernet14
+   description ipv6-acl-on-ipv4-only-interface
+   no shutdown
+   no switchport
+   vrf L3INTF_TEST
+   ip address 10.0.14.1/31
+   ipv6 access-group TEST-IPV6-ACL-STATIC-IN in
+!
 interface Loopback0
    description ROUTER_ID
    no shutdown
@@ -60,6 +76,9 @@ ipv6 access-list TEST-IPV6-ACL-STATIC-IN
 !
 ipv6 access-list TEST-IPV6-ACL-WITH-IP-FIELDS-OUT_Ethernet12
    10 permit ipv6 host 2001:db8:12::1 any
+!
+ipv6 access-list TEST-IPV6-ACL-WITH-PEER-IPV6-IN_Ethernet13
+   10 permit ipv6 host 2001:db8:13::2 any
 !
 ip routing
 ip routing vrf L3INTF_TEST

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/network-services-l3-port-channels.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/network-services-l3-port-channels.cfg
@@ -172,6 +172,20 @@ interface Port-Channel2000
    ipv6 address 2001:db8:3::1/64
    ipv6 access-group out6ACL_Port-Channel2000 out
 !
+interface Port-Channel3000
+   description ipv6-peer-cloud_Po3000
+   no shutdown
+   no switchport
+   vrf TESTING
+   ipv6 address 2001:db8:5::1/64
+   ipv6 access-group peer6ACL_Port-Channel3000 in
+!
+interface Port-Channel3001
+   no shutdown
+   no switchport
+   vrf TESTING
+   ipv6 access-group in6ACL in
+!
 interface Ethernet4
    description man descr inet-clout eth8
    no shutdown
@@ -230,6 +244,15 @@ interface Ethernet46
    no shutdown
    channel-group 2000 mode active
 !
+interface Ethernet47
+   description ipv6-peer-cloud_Ethernet47
+   no shutdown
+   channel-group 3000 mode active
+!
+interface Ethernet48
+   no shutdown
+   channel-group 3001 mode active
+!
 interface Ethernet77
    description underlay-peer_Ethernet77
    no shutdown
@@ -270,6 +293,9 @@ ipv6 access-list in6ACL
 !
 ipv6 access-list out6ACL_Port-Channel2000
    10 permit ipv6 host 2001:db8:3::1 any
+!
+ipv6 access-list peer6ACL_Port-Channel3000
+   10 permit ipv6 host 2001:db8:5::2 any
 !
 ip access-list inACL
    10 deny ip any any

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-l3-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-l3-interfaces.yml
@@ -35,6 +35,27 @@ ethernet_interfaces:
     peer_type: l3_interface
   switchport:
     enabled: false
+- name: Ethernet13
+  description: peer-ipv6-acl-test
+  shutdown: false
+  vrf: L3INTF_TEST
+  ipv6_addresses:
+  - 2001:db8:13::1/64
+  ipv6_access_group_in: TEST-IPV6-ACL-WITH-PEER-IPV6-IN_Ethernet13
+  metadata:
+    peer_type: l3_interface
+  switchport:
+    enabled: false
+- name: Ethernet14
+  description: ipv6-acl-on-ipv4-only-interface
+  shutdown: false
+  vrf: L3INTF_TEST
+  ip_address: 10.0.14.1/31
+  ipv6_access_group_in: TEST-IPV6-ACL-STATIC-IN
+  metadata:
+    peer_type: l3_interface
+  switchport:
+    enabled: false
 hostname: network-services-l3-interfaces
 ip_igmp_snooping:
   globally_enabled: true
@@ -52,6 +73,13 @@ ipv6_access_lists:
   entries:
   - protocol: ipv6
     source: 2001:db8:12::1
+    destination: any
+    sequence: 10
+    action: permit
+- name: TEST-IPV6-ACL-WITH-PEER-IPV6-IN_Ethernet13
+  entries:
+  - protocol: ipv6
+    source: 2001:db8:13::2
     destination: any
     sequence: 10
     action: permit

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-l3-port-channels.yml
@@ -144,6 +144,23 @@ ethernet_interfaces:
     peer: ipv6-cloud-testing
     peer_interface: Ethernet46
     peer_type: l3_port_channel_member
+- name: Ethernet47
+  description: ipv6-peer-cloud_Ethernet47
+  shutdown: false
+  channel_group:
+    id: 3000
+    mode: active
+  metadata:
+    peer: ipv6-peer-cloud
+    peer_interface: Ethernet47
+    peer_type: l3_port_channel_member
+- name: Ethernet48
+  shutdown: false
+  channel_group:
+    id: 3001
+    mode: active
+  metadata:
+    peer_type: l3_port_channel_member
 flow_tracking:
   sampled:
     sample: 10000
@@ -201,6 +218,13 @@ ipv6_access_lists:
   entries:
   - protocol: ipv6
     source: 2001:db8:3::1
+    destination: any
+    sequence: 10
+    action: permit
+- name: peer6ACL_Port-Channel3000
+  entries:
+  - protocol: ipv6
+    source: 2001:db8:5::2
     destination: any
     sequence: 10
     action: permit
@@ -416,6 +440,27 @@ port_channel_interfaces:
   metadata:
     peer: ipv6-cloud-testing
     peer_interface: Po2000
+    peer_type: l3_port_channel
+  switchport:
+    enabled: false
+- name: Port-Channel3000
+  description: ipv6-peer-cloud_Po3000
+  shutdown: false
+  vrf: TESTING
+  ipv6_addresses:
+  - 2001:db8:5::1/64
+  ipv6_access_group_in: peer6ACL_Port-Channel3000
+  metadata:
+    peer: ipv6-peer-cloud
+    peer_interface: Po3000
+    peer_type: l3_port_channel
+  switchport:
+    enabled: false
+- name: Port-Channel3001
+  shutdown: false
+  vrf: TESTING
+  ipv6_access_group_in: in6ACL
+  metadata:
     peer_type: l3_port_channel
   switchport:
     enabled: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/network-services-l3-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/network-services-l3-interfaces.yml
@@ -9,13 +9,21 @@ ipv6_acls:
         protocol: ipv6
         source: any
         destination: any
-  # ACL with interface_ip substitution - name will be suffixed with the interface name.
+  # ACL with interface_ipv6 substitution - name will be suffixed with the interface name.
   - name: TEST-IPV6-ACL-WITH-IP-FIELDS-OUT
     entries:
       - sequence: 10
         action: permit
         protocol: ipv6
-        source: interface_ip
+        source: interface_ipv6
+        destination: any
+  # ACL with peer_ipv6 substitution - name will be suffixed with the interface name.
+  - name: TEST-IPV6-ACL-WITH-PEER-IPV6-IN
+    entries:
+      - sequence: 10
+        action: permit
+        protocol: ipv6
+        source: peer_ipv6
         destination: any
 
 type: l3leaf
@@ -56,10 +64,26 @@ tenants:
         vrf_id: 2
         l3_interfaces:
           # IPv6-only in non-default VRF: tests VRF-level ipv6_routing set and ipv6_unicast_routing global flag also set.
-          # Also exercises the ipv6_acl_out path with `interface_ip` substitution (name gets suffixed with the interface name).
+          # Also exercises the ipv6_acl_out path with `interface_ipv6` substitution (name gets suffixed with the interface name).
           - interfaces: [Ethernet12]
             nodes: [network-services-l3-interfaces]
             ipv6_addresses: ["2001:db8:12::1/64"]
             enabled: true
             description: "ipv6-only-non-default-vrf"
             ipv6_acl_out: TEST-IPV6-ACL-WITH-IP-FIELDS-OUT
+          # peer_ipv6 substitution: ACL source "peer_ipv6" token is replaced with the peer's IPv6 address.
+          # ACL name gets suffixed with the interface name because substitution occurs.
+          - interfaces: [Ethernet13]
+            nodes: [network-services-l3-interfaces]
+            ipv6_addresses: ["2001:db8:13::1/64"]
+            peer_ipv6: "2001:db8:13::2"
+            enabled: true
+            description: "peer-ipv6-acl-test"
+            ipv6_acl_in: TEST-IPV6-ACL-WITH-PEER-IPV6-IN
+          # Logic fix: verifies IPv6 ACL is applied on an IPv4-only interface (no ipv6_addresses).
+          - interfaces: [Ethernet14]
+            nodes: [network-services-l3-interfaces]
+            ip_addresses: ["10.0.14.1/31"]
+            enabled: true
+            description: "ipv6-acl-on-ipv4-only-interface"
+            ipv6_acl_in: TEST-IPV6-ACL-STATIC-IN

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/network-services-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/network-services-l3-port-channels.yml
@@ -25,13 +25,21 @@ ipv6_acls:
         protocol: ipv6
         source: any
         destination: any
-  # ACL with interface_ip substitution - name will be suffixed with the port-channel name.
+  # ACL with interface_ipv6 substitution - name will be suffixed with the port-channel name.
   - name: out6ACL
     entries:
       - sequence: 10
         action: permit
         protocol: ipv6
-        source: interface_ip
+        source: interface_ipv6
+        destination: any
+  # ACL with peer_ipv6 substitution - name will be suffixed with the port-channel name.
+  - name: peer6ACL
+    entries:
+      - sequence: 10
+        action: permit
+        protocol: ipv6
+        source: peer_ipv6
         destination: any
 
 flow_tracking_settings:
@@ -272,7 +280,7 @@ tenants:
           # IPv6-only in non-default VRF: exercises VRF-level ipv6_routing.
           # This entry alone does NOT trigger global ipv6_unicast_routing (only default-VRF IPv6 interfaces do);
           # the global flag is already enabled in this test by Port-Channel33/44 above.
-          # Also exercises the ipv6_acl_out path with `interface_ip` substitution (name gets suffixed with the port-channel name).
+          # Also exercises the ipv6_acl_out path with `interface_ipv6` substitution (name gets suffixed with the port-channel name).
           - name: Port-Channel2000
             mode: active
             peer: ipv6-cloud-testing
@@ -286,6 +294,30 @@ tenants:
               - name: Ethernet46
                 peer_interface: Ethernet46
                 peer: ipv6-cloud-testing
+          # peer_ipv6 substitution: ACL source "peer_ipv6" token is replaced with the peer's IPv6 address.
+          # ACL name gets suffixed with the port-channel name because substitution occurs.
+          - name: Port-Channel3000
+            mode: active
+            peer: ipv6-peer-cloud
+            peer_port_channel: Po3000
+            enabled: true
+            node: network-services-l3-port-channels
+            ipv6_addresses:
+              - 2001:db8:5::1/64
+            peer_ipv6: "2001:db8:5::2"
+            ipv6_acl_in: peer6ACL
+            member_interfaces:
+              - name: Ethernet47
+                peer_interface: Ethernet47
+                peer: ipv6-peer-cloud
+          # Logic fix: verifies ACL is applied even when no ipv6_addresses is set on the port-channel.
+          - name: Port-Channel3001
+            mode: active
+            enabled: true
+            node: network-services-l3-port-channels
+            ipv6_acl_in: in6ACL
+            member_interfaces:
+              - name: Ethernet48
 
   - name: Subinterface
     mac_vrf_vni_base: 20000

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
@@ -48,8 +48,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].mtu") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv4_acl_in") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv4_acl_out") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the interface for this node.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the interface for this node.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ipv6</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].peer_ipv6") | String |  |  |  | The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ospf") | Dictionary |  |  |  | OSPF interface configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ospf.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;point_to_point</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ospf.point_to_point") | Boolean |  | `False` |  |  |
@@ -135,8 +136,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].mtu") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].ipv4_acl_in") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].ipv4_acl_out") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the interface for this node.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the interface for this node.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ipv6</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].peer_ipv6") | String |  |  |  | The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].ospf") | Dictionary |  |  |  | OSPF interface configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].ospf.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;point_to_point</samp>](## "network_services.[].vrfs.[].l3_interfaces.[].ospf.point_to_point") | Boolean |  | `False` |  |  |
@@ -274,15 +276,18 @@
                 ipv4_acl_in: <str>
                 ipv4_acl_out: <str>
 
+                # The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token.
+                peer_ipv6: <str>
+
                 # Name of the IPv6 access-list to be assigned in the ingress direction.
                 # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                # resolved from the IPv6 address set on the interface for this node.
+                # resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
                 # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                 ipv6_acl_in: <str>
 
                 # Name of the IPv6 access-list to be assigned in the egress direction.
                 # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                # resolved from the IPv6 address set on the interface for this node.
+                # resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
                 # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                 ipv6_acl_out: <str>
 
@@ -488,15 +493,18 @@
                 ipv4_acl_in: <str>
                 ipv4_acl_out: <str>
 
+                # The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token.
+                peer_ipv6: <str>
+
                 # Name of the IPv6 access-list to be assigned in the ingress direction.
                 # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                # resolved from the IPv6 address set on the interface for this node.
+                # resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
                 # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                 ipv6_acl_in: <str>
 
                 # Name of the IPv6 access-list to be assigned in the egress direction.
                 # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                # resolved from the IPv6 address set on the interface for this node.
+                # resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
                 # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                 ipv6_acl_out: <str>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
@@ -36,8 +36,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].mtu") | Integer |  |  |  | MTU can only be set on the parent Port-Channel. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the first IPv6 address set on the interface.<br>Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the first IPv6 address set on the interface.<br>Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ipv6</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].peer_ipv6") | String |  |  |  | The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).<br>Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).<br>Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on the device where this Port-channel interface is configured. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].next_hop") | String |  |  |  |  |
@@ -103,8 +104,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].mtu") | Integer |  |  |  | MTU can only be set on the parent Port-Channel. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the first IPv6 address set on the interface.<br>Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the first IPv6 address set on the interface.<br>Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ipv6</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].peer_ipv6") | String |  |  |  | The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).<br>Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).<br>Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on the device where this Port-channel interface is configured. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "network_services.[].vrfs.[].l3_port_channels.[].static_routes.[].next_hop") | String |  |  |  |  |
@@ -246,15 +248,18 @@
                 # Name of the IPv4 Access-list to be assigned in the egress direction.
                 ipv4_acl_out: <str>
 
+                # The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token.
+                peer_ipv6: <str>
+
                 # Name of the IPv6 access-list to be assigned in the ingress direction.
                 # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                # resolved from the first IPv6 address set on the interface.
+                # resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
                 # Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                 ipv6_acl_in: <str>
 
                 # Name of the IPv6 access-list to be assigned in the egress direction.
                 # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                # resolved from the first IPv6 address set on the interface.
+                # resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
                 # Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                 ipv6_acl_out: <str>
 
@@ -436,15 +441,18 @@
                 # Name of the IPv4 Access-list to be assigned in the egress direction.
                 ipv4_acl_out: <str>
 
+                # The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token.
+                peer_ipv6: <str>
+
                 # Name of the IPv6 access-list to be assigned in the ingress direction.
                 # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                # resolved from the first IPv6 address set on the interface.
+                # resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
                 # Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                 ipv6_acl_in: <str>
 
                 # Name of the IPv6 access-list to be assigned in the egress direction.
                 # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                # resolved from the first IPv6 address set on the interface.
+                # resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
                 # Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                 ipv6_acl_out: <str>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
@@ -61,8 +61,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server.<br>The value will be interpreted according to these rules:<br>- `use_mgmt_interface` will configure the OOB management interface as the source interface.<br>- `use_inband_mgmt_interface` will configure the `inband_mgmt_interface` as the source interface.<br>- `use_default_mgmt_method_interface` will configure the source interface for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the source interface. |
@@ -135,8 +135,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server.<br>The value will be interpreted according to these rules:<br>- `use_mgmt_interface` will configure the OOB management interface as the source interface.<br>- `use_inband_mgmt_interface` will configure the `inband_mgmt_interface` as the source interface.<br>- `use_default_mgmt_method_interface` will configure the source interface for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the source interface. |
@@ -228,8 +228,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "network_services.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server.<br>The value will be interpreted according to these rules:<br>- `use_mgmt_interface` will configure the OOB management interface as the source interface.<br>- `use_inband_mgmt_interface` will configure the `inband_mgmt_interface` as the source interface.<br>- `use_default_mgmt_method_interface` will configure the source interface for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the source interface. |
@@ -302,8 +302,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "network_services.[].vrfs.[].svis.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "network_services.[].vrfs.[].svis.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "network_services.[].vrfs.[].svis.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "network_services.[].vrfs.[].svis.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "network_services.[].vrfs.[].svis.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "network_services.[].vrfs.[].svis.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "network_services.[].vrfs.[].svis.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "network_services.[].vrfs.[].svis.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "network_services.[].vrfs.[].svis.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "network_services.[].vrfs.[].svis.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server.<br>The value will be interpreted according to these rules:<br>- `use_mgmt_interface` will configure the OOB management interface as the source interface.<br>- `use_inband_mgmt_interface` will configure the `inband_mgmt_interface` as the source interface.<br>- `use_default_mgmt_method_interface` will configure the source interface for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the source interface. |
@@ -534,11 +534,15 @@
                     ipv4_acl_out: <str>
 
                     # Name of the IPv6 access-list to be assigned in the ingress direction.
-                    # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                    # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                    # resolved from the IPv6 address set on the SVI.
+                    # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                     ipv6_acl_in: <str>
 
                     # Name of the IPv6 access-list to be assigned in the egress direction.
-                    # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                    # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                    # resolved from the IPv6 address set on the SVI.
+                    # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                     ipv6_acl_out: <str>
 
                     # IP helper for DHCP relay.
@@ -772,11 +776,15 @@
                 ipv4_acl_out: <str>
 
                 # Name of the IPv6 access-list to be assigned in the ingress direction.
-                # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                # resolved from the IPv6 address set on the SVI.
+                # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                 ipv6_acl_in: <str>
 
                 # Name of the IPv6 access-list to be assigned in the egress direction.
-                # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                # resolved from the IPv6 address set on the SVI.
+                # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                 ipv6_acl_out: <str>
 
                 # IP helper for DHCP relay.
@@ -1081,11 +1089,15 @@
                     ipv4_acl_out: <str>
 
                     # Name of the IPv6 access-list to be assigned in the ingress direction.
-                    # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                    # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                    # resolved from the IPv6 address set on the SVI.
+                    # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                     ipv6_acl_in: <str>
 
                     # Name of the IPv6 access-list to be assigned in the egress direction.
-                    # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                    # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                    # resolved from the IPv6 address set on the SVI.
+                    # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                     ipv6_acl_out: <str>
 
                     # IP helper for DHCP relay.
@@ -1319,11 +1331,15 @@
                 ipv4_acl_out: <str>
 
                 # Name of the IPv6 access-list to be assigned in the ingress direction.
-                # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                # resolved from the IPv6 address set on the SVI.
+                # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                 ipv6_acl_in: <str>
 
                 # Name of the IPv6 access-list to be assigned in the egress direction.
-                # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                # resolved from the IPv6 address set on the SVI.
+                # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                 ipv6_acl_out: <str>
 
                 # IP helper for DHCP relay.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
@@ -48,8 +48,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].nodes.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "svi_profiles.[].nodes.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "svi_profiles.[].nodes.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "svi_profiles.[].nodes.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "svi_profiles.[].nodes.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "svi_profiles.[].nodes.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "svi_profiles.[].nodes.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "svi_profiles.[].nodes.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "svi_profiles.[].nodes.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "svi_profiles.[].nodes.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server.<br>The value will be interpreted according to these rules:<br>- `use_mgmt_interface` will configure the OOB management interface as the source interface.<br>- `use_inband_mgmt_interface` will configure the `inband_mgmt_interface` as the source interface.<br>- `use_default_mgmt_method_interface` will configure the source interface for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the source interface. |
@@ -123,8 +123,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "svi_profiles.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "svi_profiles.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "svi_profiles.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "svi_profiles.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_in</samp>](## "svi_profiles.[].ipv6_acl_in") | String |  |  |  | Name of the IPv6 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl_out</samp>](## "svi_profiles.[].ipv6_acl_out") | String |  |  |  | Name of the IPv6 access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",<br>resolved from the IPv6 address set on the SVI.<br>Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "svi_profiles.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "svi_profiles.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "svi_profiles.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server.<br>The value will be interpreted according to these rules:<br>- `use_mgmt_interface` will configure the OOB management interface as the source interface.<br>- `use_inband_mgmt_interface` will configure the `inband_mgmt_interface` as the source interface.<br>- `use_default_mgmt_method_interface` will configure the source interface for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the source interface. |
@@ -311,11 +311,15 @@
             ipv4_acl_out: <str>
 
             # Name of the IPv6 access-list to be assigned in the ingress direction.
-            # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+            # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+            # resolved from the IPv6 address set on the SVI.
+            # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
             ipv6_acl_in: <str>
 
             # Name of the IPv6 access-list to be assigned in the egress direction.
-            # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+            # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+            # resolved from the IPv6 address set on the SVI.
+            # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
             ipv6_acl_out: <str>
 
             # IP helper for DHCP relay.
@@ -552,11 +556,15 @@
         ipv4_acl_out: <str>
 
         # Name of the IPv6 access-list to be assigned in the ingress direction.
-        # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+        # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+        # resolved from the IPv6 address set on the SVI.
+        # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
         ipv6_acl_in: <str>
 
         # Name of the IPv6 access-list to be assigned in the egress direction.
-        # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+        # The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+        # resolved from the IPv6 address set on the SVI.
+        # Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
         ipv6_acl_out: <str>
 
         # IP helper for DHCP relay.

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -32596,13 +32596,21 @@ class EosDesigns(EosDesignsRootModel):
                     """
                     Name of the IPv6 access-list to be assigned in the ingress direction.
                     The access-list must be
-                    defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                    defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                    resolved from the
+                    IPv6 address set on the SVI.
+                    Deprecated token "interface_ip" is also accepted as an alias for
+                    "interface_ipv6" and will be removed in AVD 7.0.0.
                     """
                     ipv6_acl_out: str | None
                     """
                     Name of the IPv6 access-list to be assigned in the egress direction.
                     The access-list must be defined
-                    under `ipv6_acls` and supports substitution of the field "interface_ip".
+                    under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                    resolved from the IPv6
+                    address set on the SVI.
+                    Deprecated token "interface_ip" is also accepted as an alias for
+                    "interface_ipv6" and will be removed in AVD 7.0.0.
                     """
                     ip_helpers: IpHelpers
                     """
@@ -32857,11 +32865,19 @@ class EosDesigns(EosDesignsRootModel):
                                 ipv6_acl_in:
                                    Name of the IPv6 access-list to be assigned in the ingress direction.
                                    The access-list must be
-                                   defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                                   defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                                   resolved from the
+                                   IPv6 address set on the SVI.
+                                   Deprecated token "interface_ip" is also accepted as an alias for
+                                   "interface_ipv6" and will be removed in AVD 7.0.0.
                                 ipv6_acl_out:
                                    Name of the IPv6 access-list to be assigned in the egress direction.
                                    The access-list must be defined
-                                   under `ipv6_acls` and supports substitution of the field "interface_ip".
+                                   under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                                   resolved from the IPv6
+                                   address set on the SVI.
+                                   Deprecated token "interface_ip" is also accepted as an alias for
+                                   "interface_ipv6" and will be removed in AVD 7.0.0.
                                 ip_helpers:
                                    IP helper for DHCP relay.
 
@@ -34035,13 +34051,21 @@ class EosDesigns(EosDesignsRootModel):
                 """
                 Name of the IPv6 access-list to be assigned in the ingress direction.
                 The access-list must be
-                defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                resolved from the
+                IPv6 address set on the SVI.
+                Deprecated token "interface_ip" is also accepted as an alias for
+                "interface_ipv6" and will be removed in AVD 7.0.0.
                 """
                 ipv6_acl_out: str | None
                 """
                 Name of the IPv6 access-list to be assigned in the egress direction.
                 The access-list must be defined
-                under `ipv6_acls` and supports substitution of the field "interface_ip".
+                under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                resolved from the IPv6
+                address set on the SVI.
+                Deprecated token "interface_ip" is also accepted as an alias for
+                "interface_ipv6" and will be removed in AVD 7.0.0.
                 """
                 ip_helpers: IpHelpers
                 """
@@ -34322,11 +34346,19 @@ class EosDesigns(EosDesignsRootModel):
                             ipv6_acl_in:
                                Name of the IPv6 access-list to be assigned in the ingress direction.
                                The access-list must be
-                               defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                               defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                               resolved from the
+                               IPv6 address set on the SVI.
+                               Deprecated token "interface_ip" is also accepted as an alias for
+                               "interface_ipv6" and will be removed in AVD 7.0.0.
                             ipv6_acl_out:
                                Name of the IPv6 access-list to be assigned in the egress direction.
                                The access-list must be defined
-                               under `ipv6_acls` and supports substitution of the field "interface_ip".
+                               under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                               resolved from the IPv6
+                               address set on the SVI.
+                               Deprecated token "interface_ip" is also accepted as an alias for
+                               "interface_ipv6" and will be removed in AVD 7.0.0.
                             ip_helpers:
                                IP helper for DHCP relay.
 
@@ -35047,6 +35079,7 @@ class EosDesigns(EosDesignsRootModel):
                     "mtu": {"type": int},
                     "ipv4_acl_in": {"type": str},
                     "ipv4_acl_out": {"type": str},
+                    "peer_ipv6": {"type": str},
                     "ipv6_acl_in": {"type": str},
                     "ipv6_acl_out": {"type": str},
                     "ospf": {"type": Ospf},
@@ -35108,15 +35141,20 @@ class EosDesigns(EosDesignsRootModel):
                 mtu: int | None
                 ipv4_acl_in: str | None
                 ipv4_acl_out: str | None
+                peer_ipv6: str | None
+                """
+                The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the
+                "peer_ipv6" token.
+                """
                 ipv6_acl_in: str | None
                 """
                 Name of the IPv6 access-list to be assigned in the ingress direction.
                 The access-list must be
                 defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                 resolved from the
-                IPv6 address set on the interface for this node.
-                Deprecated token "interface_ip" is also accepted as
-                an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
+                IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
+                Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be
+                removed in AVD 7.0.0.
                 """
                 ipv6_acl_out: str | None
                 """
@@ -35124,9 +35162,10 @@ class EosDesigns(EosDesignsRootModel):
                 The access-list must be defined
                 under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                 resolved from the IPv6
-                address set on the interface for this node.
-                Deprecated token "interface_ip" is also accepted as an
-                alias for "interface_ipv6" and will be removed in AVD 7.0.0.
+                address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
+                Deprecated
+                token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD
+                7.0.0.
                 """
                 ospf: Ospf
                 """
@@ -35201,6 +35240,7 @@ class EosDesigns(EosDesignsRootModel):
                         mtu: int | UndefinedType | None = Undefined,
                         ipv4_acl_in: str | UndefinedType | None = Undefined,
                         ipv4_acl_out: str | UndefinedType | None = Undefined,
+                        peer_ipv6: str | UndefinedType | None = Undefined,
                         ipv6_acl_in: str | UndefinedType | None = Undefined,
                         ipv6_acl_out: str | UndefinedType | None = Undefined,
                         ospf: Ospf | UndefinedType = Undefined,
@@ -35254,22 +35294,26 @@ class EosDesigns(EosDesignsRootModel):
                             mtu: mtu
                             ipv4_acl_in: ipv4_acl_in
                             ipv4_acl_out: ipv4_acl_out
+                            peer_ipv6:
+                               The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the
+                               "peer_ipv6" token.
                             ipv6_acl_in:
                                Name of the IPv6 access-list to be assigned in the ingress direction.
                                The access-list must be
                                defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                                resolved from the
-                               IPv6 address set on the interface for this node.
-                               Deprecated token "interface_ip" is also accepted as
-                               an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
+                               IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
+                               Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be
+                               removed in AVD 7.0.0.
                             ipv6_acl_out:
                                Name of the IPv6 access-list to be assigned in the egress direction.
                                The access-list must be defined
                                under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                                resolved from the IPv6
-                               address set on the interface for this node.
-                               Deprecated token "interface_ip" is also accepted as an
-                               alias for "interface_ipv6" and will be removed in AVD 7.0.0.
+                               address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
+                               Deprecated
+                               token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD
+                               7.0.0.
                             ospf:
                                OSPF interface configuration.
 
@@ -35811,6 +35855,7 @@ class EosDesigns(EosDesignsRootModel):
                     "mtu": {"type": int},
                     "ipv4_acl_in": {"type": str},
                     "ipv4_acl_out": {"type": str},
+                    "peer_ipv6": {"type": str},
                     "ipv6_acl_in": {"type": str},
                     "ipv6_acl_out": {"type": str},
                     "static_routes": {"type": StaticRoutes},
@@ -35884,15 +35929,20 @@ class EosDesigns(EosDesignsRootModel):
                 """Name of the IPv4 access-list to be assigned in the ingress direction."""
                 ipv4_acl_out: str | None
                 """Name of the IPv4 Access-list to be assigned in the egress direction."""
+                peer_ipv6: str | None
+                """
+                The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the
+                "peer_ipv6" token.
+                """
                 ipv6_acl_in: str | None
                 """
                 Name of the IPv6 access-list to be assigned in the ingress direction.
                 The access-list must be
                 defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                 resolved from the
-                first IPv6 address set on the interface.
-                Token "interface_ip" is also accepted but deprecated and
-                will be removed in AVD 7.0.0.
+                first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
+                Token
+                "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                 """
                 ipv6_acl_out: str | None
                 """
@@ -35900,9 +35950,9 @@ class EosDesigns(EosDesignsRootModel):
                 The access-list must be defined
                 under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                 resolved from the first
-                IPv6 address set on the interface.
-                Token "interface_ip" is also accepted but deprecated and will be
-                removed in AVD 7.0.0.
+                IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
+                Token "interface_ip"
+                is also accepted but deprecated and will be removed in AVD 7.0.0.
                 """
                 static_routes: StaticRoutes
                 """
@@ -35956,6 +36006,7 @@ class EosDesigns(EosDesignsRootModel):
                         mtu: int | UndefinedType | None = Undefined,
                         ipv4_acl_in: str | UndefinedType | None = Undefined,
                         ipv4_acl_out: str | UndefinedType | None = Undefined,
+                        peer_ipv6: str | UndefinedType | None = Undefined,
                         ipv6_acl_in: str | UndefinedType | None = Undefined,
                         ipv6_acl_out: str | UndefinedType | None = Undefined,
                         static_routes: StaticRoutes | UndefinedType = Undefined,
@@ -36008,22 +36059,25 @@ class EosDesigns(EosDesignsRootModel):
                             mtu: MTU can only be set on the parent Port-Channel.
                             ipv4_acl_in: Name of the IPv4 access-list to be assigned in the ingress direction.
                             ipv4_acl_out: Name of the IPv4 Access-list to be assigned in the egress direction.
+                            peer_ipv6:
+                               The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the
+                               "peer_ipv6" token.
                             ipv6_acl_in:
                                Name of the IPv6 access-list to be assigned in the ingress direction.
                                The access-list must be
                                defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                                resolved from the
-                               first IPv6 address set on the interface.
-                               Token "interface_ip" is also accepted but deprecated and
-                               will be removed in AVD 7.0.0.
+                               first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
+                               Token
+                               "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                             ipv6_acl_out:
                                Name of the IPv6 access-list to be assigned in the egress direction.
                                The access-list must be defined
                                under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                                resolved from the first
-                               IPv6 address set on the interface.
-                               Token "interface_ip" is also accepted but deprecated and will be
-                               removed in AVD 7.0.0.
+                               IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
+                               Token "interface_ip"
+                               is also accepted but deprecated and will be removed in AVD 7.0.0.
                             static_routes:
                                Static routes to be configured on the device where this Port-channel interface is configured.
                                Subclass of AvdList with `StaticRoutesItem` items.
@@ -49739,13 +49793,21 @@ class EosDesigns(EosDesignsRootModel):
             """
             Name of the IPv6 access-list to be assigned in the ingress direction.
             The access-list must be
-            defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+            defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+            resolved from the
+            IPv6 address set on the SVI.
+            Deprecated token "interface_ip" is also accepted as an alias for
+            "interface_ipv6" and will be removed in AVD 7.0.0.
             """
             ipv6_acl_out: str | None
             """
             Name of the IPv6 access-list to be assigned in the egress direction.
             The access-list must be defined
-            under `ipv6_acls` and supports substitution of the field "interface_ip".
+            under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+            resolved from the IPv6
+            address set on the SVI.
+            Deprecated token "interface_ip" is also accepted as an alias for
+            "interface_ipv6" and will be removed in AVD 7.0.0.
             """
             ip_helpers: IpHelpers
             """
@@ -49993,11 +50055,19 @@ class EosDesigns(EosDesignsRootModel):
                         ipv6_acl_in:
                            Name of the IPv6 access-list to be assigned in the ingress direction.
                            The access-list must be
-                           defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                           defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                           resolved from the
+                           IPv6 address set on the SVI.
+                           Deprecated token "interface_ip" is also accepted as an alias for
+                           "interface_ipv6" and will be removed in AVD 7.0.0.
                         ipv6_acl_out:
                            Name of the IPv6 access-list to be assigned in the egress direction.
                            The access-list must be defined
-                           under `ipv6_acls` and supports substitution of the field "interface_ip".
+                           under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                           resolved from the IPv6
+                           address set on the SVI.
+                           Deprecated token "interface_ip" is also accepted as an alias for
+                           "interface_ipv6" and will be removed in AVD 7.0.0.
                         ip_helpers:
                            IP helper for DHCP relay.
 
@@ -51137,13 +51207,21 @@ class EosDesigns(EosDesignsRootModel):
         """
         Name of the IPv6 access-list to be assigned in the ingress direction.
         The access-list must be
-        defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+        defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+        resolved from the
+        IPv6 address set on the SVI.
+        Deprecated token "interface_ip" is also accepted as an alias for
+        "interface_ipv6" and will be removed in AVD 7.0.0.
         """
         ipv6_acl_out: str | None
         """
         Name of the IPv6 access-list to be assigned in the egress direction.
         The access-list must be defined
-        under `ipv6_acls` and supports substitution of the field "interface_ip".
+        under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+        resolved from the IPv6
+        address set on the SVI.
+        Deprecated token "interface_ip" is also accepted as an alias for
+        "interface_ipv6" and will be removed in AVD 7.0.0.
         """
         ip_helpers: IpHelpers
         """
@@ -51405,11 +51483,19 @@ class EosDesigns(EosDesignsRootModel):
                     ipv6_acl_in:
                        Name of the IPv6 access-list to be assigned in the ingress direction.
                        The access-list must be
-                       defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                       defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                       resolved from the
+                       IPv6 address set on the SVI.
+                       Deprecated token "interface_ip" is also accepted as an alias for
+                       "interface_ipv6" and will be removed in AVD 7.0.0.
                     ipv6_acl_out:
                        Name of the IPv6 access-list to be assigned in the egress direction.
                        The access-list must be defined
-                       under `ipv6_acls` and supports substitution of the field "interface_ip".
+                       under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                       resolved from the IPv6
+                       address set on the SVI.
+                       Deprecated token "interface_ip" is also accepted as an alias for
+                       "interface_ipv6" and will be removed in AVD 7.0.0.
                     ip_helpers:
                        IP helper for DHCP relay.
 
@@ -83176,13 +83262,21 @@ class EosDesigns(EosDesignsRootModel):
                             """
                             Name of the IPv6 access-list to be assigned in the ingress direction.
                             The access-list must be
-                            defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                            defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                            resolved from the
+                            IPv6 address set on the SVI.
+                            Deprecated token "interface_ip" is also accepted as an alias for
+                            "interface_ipv6" and will be removed in AVD 7.0.0.
                             """
                             ipv6_acl_out: str | None
                             """
                             Name of the IPv6 access-list to be assigned in the egress direction.
                             The access-list must be defined
-                            under `ipv6_acls` and supports substitution of the field "interface_ip".
+                            under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                            resolved from the IPv6
+                            address set on the SVI.
+                            Deprecated token "interface_ip" is also accepted as an alias for
+                            "interface_ipv6" and will be removed in AVD 7.0.0.
                             """
                             ip_helpers: IpHelpers
                             """
@@ -83437,11 +83531,19 @@ class EosDesigns(EosDesignsRootModel):
                                         ipv6_acl_in:
                                            Name of the IPv6 access-list to be assigned in the ingress direction.
                                            The access-list must be
-                                           defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                                           defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                                           resolved from the
+                                           IPv6 address set on the SVI.
+                                           Deprecated token "interface_ip" is also accepted as an alias for
+                                           "interface_ipv6" and will be removed in AVD 7.0.0.
                                         ipv6_acl_out:
                                            Name of the IPv6 access-list to be assigned in the egress direction.
                                            The access-list must be defined
-                                           under `ipv6_acls` and supports substitution of the field "interface_ip".
+                                           under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                                           resolved from the IPv6
+                                           address set on the SVI.
+                                           Deprecated token "interface_ip" is also accepted as an alias for
+                                           "interface_ipv6" and will be removed in AVD 7.0.0.
                                         ip_helpers:
                                            IP helper for DHCP relay.
 
@@ -84617,13 +84719,21 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         Name of the IPv6 access-list to be assigned in the ingress direction.
                         The access-list must be
-                        defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                        defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                        resolved from the
+                        IPv6 address set on the SVI.
+                        Deprecated token "interface_ip" is also accepted as an alias for
+                        "interface_ipv6" and will be removed in AVD 7.0.0.
                         """
                         ipv6_acl_out: str | None
                         """
                         Name of the IPv6 access-list to be assigned in the egress direction.
                         The access-list must be defined
-                        under `ipv6_acls` and supports substitution of the field "interface_ip".
+                        under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                        resolved from the IPv6
+                        address set on the SVI.
+                        Deprecated token "interface_ip" is also accepted as an alias for
+                        "interface_ipv6" and will be removed in AVD 7.0.0.
                         """
                         ip_helpers: IpHelpers
                         """
@@ -84904,11 +85014,19 @@ class EosDesigns(EosDesignsRootModel):
                                     ipv6_acl_in:
                                        Name of the IPv6 access-list to be assigned in the ingress direction.
                                        The access-list must be
-                                       defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+                                       defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                                       resolved from the
+                                       IPv6 address set on the SVI.
+                                       Deprecated token "interface_ip" is also accepted as an alias for
+                                       "interface_ipv6" and will be removed in AVD 7.0.0.
                                     ipv6_acl_out:
                                        Name of the IPv6 access-list to be assigned in the egress direction.
                                        The access-list must be defined
-                                       under `ipv6_acls` and supports substitution of the field "interface_ip".
+                                       under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+                                       resolved from the IPv6
+                                       address set on the SVI.
+                                       Deprecated token "interface_ip" is also accepted as an alias for
+                                       "interface_ipv6" and will be removed in AVD 7.0.0.
                                     ip_helpers:
                                        IP helper for DHCP relay.
 
@@ -85633,6 +85751,7 @@ class EosDesigns(EosDesignsRootModel):
                             "mtu": {"type": int},
                             "ipv4_acl_in": {"type": str},
                             "ipv4_acl_out": {"type": str},
+                            "peer_ipv6": {"type": str},
                             "ipv6_acl_in": {"type": str},
                             "ipv6_acl_out": {"type": str},
                             "ospf": {"type": Ospf},
@@ -85694,15 +85813,20 @@ class EosDesigns(EosDesignsRootModel):
                         mtu: int | None
                         ipv4_acl_in: str | None
                         ipv4_acl_out: str | None
+                        peer_ipv6: str | None
+                        """
+                        The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the
+                        "peer_ipv6" token.
+                        """
                         ipv6_acl_in: str | None
                         """
                         Name of the IPv6 access-list to be assigned in the ingress direction.
                         The access-list must be
                         defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                         resolved from the
-                        IPv6 address set on the interface for this node.
-                        Deprecated token "interface_ip" is also accepted as
-                        an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
+                        IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
+                        Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be
+                        removed in AVD 7.0.0.
                         """
                         ipv6_acl_out: str | None
                         """
@@ -85710,9 +85834,10 @@ class EosDesigns(EosDesignsRootModel):
                         The access-list must be defined
                         under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                         resolved from the IPv6
-                        address set on the interface for this node.
-                        Deprecated token "interface_ip" is also accepted as an
-                        alias for "interface_ipv6" and will be removed in AVD 7.0.0.
+                        address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
+                        Deprecated
+                        token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD
+                        7.0.0.
                         """
                         ospf: Ospf
                         """
@@ -85787,6 +85912,7 @@ class EosDesigns(EosDesignsRootModel):
                                 mtu: int | UndefinedType | None = Undefined,
                                 ipv4_acl_in: str | UndefinedType | None = Undefined,
                                 ipv4_acl_out: str | UndefinedType | None = Undefined,
+                                peer_ipv6: str | UndefinedType | None = Undefined,
                                 ipv6_acl_in: str | UndefinedType | None = Undefined,
                                 ipv6_acl_out: str | UndefinedType | None = Undefined,
                                 ospf: Ospf | UndefinedType = Undefined,
@@ -85840,22 +85966,26 @@ class EosDesigns(EosDesignsRootModel):
                                     mtu: mtu
                                     ipv4_acl_in: ipv4_acl_in
                                     ipv4_acl_out: ipv4_acl_out
+                                    peer_ipv6:
+                                       The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the
+                                       "peer_ipv6" token.
                                     ipv6_acl_in:
                                        Name of the IPv6 access-list to be assigned in the ingress direction.
                                        The access-list must be
                                        defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                                        resolved from the
-                                       IPv6 address set on the interface for this node.
-                                       Deprecated token "interface_ip" is also accepted as
-                                       an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
+                                       IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
+                                       Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be
+                                       removed in AVD 7.0.0.
                                     ipv6_acl_out:
                                        Name of the IPv6 access-list to be assigned in the egress direction.
                                        The access-list must be defined
                                        under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                                        resolved from the IPv6
-                                       address set on the interface for this node.
-                                       Deprecated token "interface_ip" is also accepted as an
-                                       alias for "interface_ipv6" and will be removed in AVD 7.0.0.
+                                       address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
+                                       Deprecated
+                                       token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD
+                                       7.0.0.
                                     ospf:
                                        OSPF interface configuration.
 
@@ -86397,6 +86527,7 @@ class EosDesigns(EosDesignsRootModel):
                             "mtu": {"type": int},
                             "ipv4_acl_in": {"type": str},
                             "ipv4_acl_out": {"type": str},
+                            "peer_ipv6": {"type": str},
                             "ipv6_acl_in": {"type": str},
                             "ipv6_acl_out": {"type": str},
                             "static_routes": {"type": StaticRoutes},
@@ -86470,15 +86601,20 @@ class EosDesigns(EosDesignsRootModel):
                         """Name of the IPv4 access-list to be assigned in the ingress direction."""
                         ipv4_acl_out: str | None
                         """Name of the IPv4 Access-list to be assigned in the egress direction."""
+                        peer_ipv6: str | None
+                        """
+                        The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the
+                        "peer_ipv6" token.
+                        """
                         ipv6_acl_in: str | None
                         """
                         Name of the IPv6 access-list to be assigned in the ingress direction.
                         The access-list must be
                         defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                         resolved from the
-                        first IPv6 address set on the interface.
-                        Token "interface_ip" is also accepted but deprecated and
-                        will be removed in AVD 7.0.0.
+                        first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
+                        Token
+                        "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                         """
                         ipv6_acl_out: str | None
                         """
@@ -86486,9 +86622,9 @@ class EosDesigns(EosDesignsRootModel):
                         The access-list must be defined
                         under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                         resolved from the first
-                        IPv6 address set on the interface.
-                        Token "interface_ip" is also accepted but deprecated and will be
-                        removed in AVD 7.0.0.
+                        IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
+                        Token "interface_ip"
+                        is also accepted but deprecated and will be removed in AVD 7.0.0.
                         """
                         static_routes: StaticRoutes
                         """
@@ -86542,6 +86678,7 @@ class EosDesigns(EosDesignsRootModel):
                                 mtu: int | UndefinedType | None = Undefined,
                                 ipv4_acl_in: str | UndefinedType | None = Undefined,
                                 ipv4_acl_out: str | UndefinedType | None = Undefined,
+                                peer_ipv6: str | UndefinedType | None = Undefined,
                                 ipv6_acl_in: str | UndefinedType | None = Undefined,
                                 ipv6_acl_out: str | UndefinedType | None = Undefined,
                                 static_routes: StaticRoutes | UndefinedType = Undefined,
@@ -86594,22 +86731,25 @@ class EosDesigns(EosDesignsRootModel):
                                     mtu: MTU can only be set on the parent Port-Channel.
                                     ipv4_acl_in: Name of the IPv4 access-list to be assigned in the ingress direction.
                                     ipv4_acl_out: Name of the IPv4 Access-list to be assigned in the egress direction.
+                                    peer_ipv6:
+                                       The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the
+                                       "peer_ipv6" token.
                                     ipv6_acl_in:
                                        Name of the IPv6 access-list to be assigned in the ingress direction.
                                        The access-list must be
                                        defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                                        resolved from the
-                                       first IPv6 address set on the interface.
-                                       Token "interface_ip" is also accepted but deprecated and
-                                       will be removed in AVD 7.0.0.
+                                       first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
+                                       Token
+                                       "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                                     ipv6_acl_out:
                                        Name of the IPv6 access-list to be assigned in the egress direction.
                                        The access-list must be defined
                                        under `ipv6_acls` and supports substitution of the field "interface_ipv6",
                                        resolved from the first
-                                       IPv6 address set on the interface.
-                                       Token "interface_ip" is also accepted but deprecated and will be
-                                       removed in AVD 7.0.0.
+                                       IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
+                                       Token "interface_ip"
+                                       is also accepted but deprecated and will be removed in AVD 7.0.0.
                                     static_routes:
                                        Static routes to be configured on the device where this Port-channel interface is configured.
                                        Subclass of AvdList with `StaticRoutesItem` items.

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -6327,6 +6327,11 @@ keys:
                       type: str
                       convert_types:
                       - int
+                    peer_ipv6:
+                      type: str
+                      description: The peer device IPv6 address (no mask). Used for
+                        field substitution in `ipv6_acls` entries with the "peer_ipv6"
+                        token.
                     ipv6_acl_in:
                       description: 'Name of the IPv6 access-list to be assigned in
                         the ingress direction.
@@ -6335,7 +6340,7 @@ keys:
                         substitution of the field "interface_ipv6",
 
                         resolved from the IPv6 address set on the interface for this
-                        node.
+                        node, and "peer_ipv6" (resolved from `peer_ipv6`).
 
                         Deprecated token "interface_ip" is also accepted as an alias
                         for "interface_ipv6" and will be removed in AVD 7.0.0.'
@@ -6350,7 +6355,7 @@ keys:
                         substitution of the field "interface_ipv6",
 
                         resolved from the IPv6 address set on the interface for this
-                        node.
+                        node, and "peer_ipv6" (resolved from `peer_ipv6`).
 
                         Deprecated token "interface_ip" is also accepted as an alias
                         for "interface_ipv6" and will be removed in AVD 7.0.0.'
@@ -6631,6 +6636,11 @@ keys:
                       type: str
                       convert_types:
                       - int
+                    peer_ipv6:
+                      type: str
+                      description: The peer device IPv6 address (no mask). Used for
+                        field substitution in `ipv6_acls` entries with the "peer_ipv6"
+                        token.
                     ipv6_acl_in:
                       description: 'Name of the IPv6 access-list to be assigned in
                         the ingress direction.
@@ -6638,7 +6648,8 @@ keys:
                         The access-list must be defined under `ipv6_acls` and supports
                         substitution of the field "interface_ipv6",
 
-                        resolved from the first IPv6 address set on the interface.
+                        resolved from the first IPv6 address set on the interface,
+                        and "peer_ipv6" (resolved from `peer_ipv6`).
 
                         Token "interface_ip" is also accepted but deprecated and will
                         be removed in AVD 7.0.0.'
@@ -6652,7 +6663,8 @@ keys:
                         The access-list must be defined under `ipv6_acls` and supports
                         substitution of the field "interface_ipv6",
 
-                        resolved from the first IPv6 address set on the interface.
+                        resolved from the first IPv6 address set on the interface,
+                        and "peer_ipv6" (resolved from `peer_ipv6`).
 
                         Token "interface_ip" is also accepted but deprecated and will
                         be removed in AVD 7.0.0.'
@@ -17372,7 +17384,12 @@ $defs:
         description: 'Name of the IPv6 access-list to be assigned in the ingress direction.
 
           The access-list must be defined under `ipv6_acls` and supports substitution
-          of the field "interface_ip".'
+          of the field "interface_ipv6",
+
+          resolved from the IPv6 address set on the SVI.
+
+          Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6"
+          and will be removed in AVD 7.0.0.'
         type: str
         convert_types:
         - int
@@ -17380,7 +17397,12 @@ $defs:
         description: 'Name of the IPv6 access-list to be assigned in the egress direction.
 
           The access-list must be defined under `ipv6_acls` and supports substitution
-          of the field "interface_ip".'
+          of the field "interface_ipv6",
+
+          resolved from the IPv6 address set on the SVI.
+
+          Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6"
+          and will be removed in AVD 7.0.0.'
         type: str
         convert_types:
         - int

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
@@ -156,14 +156,18 @@ $defs:
       ipv6_acl_in:
         description: |-
           Name of the IPv6 access-list to be assigned in the ingress direction.
-          The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+          The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+          resolved from the IPv6 address set on the SVI.
+          Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
         type: str
         convert_types:
           - int
       ipv6_acl_out:
         description: |-
           Name of the IPv6 access-list to be assigned in the egress direction.
-          The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ip".
+          The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
+          resolved from the IPv6 address set on the SVI.
+          Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
         type: str
         convert_types:
           - int

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services.schema.yml
@@ -1010,11 +1010,15 @@ keys:
                       type: str
                       convert_types:
                         - int
+                    peer_ipv6:
+                      type: str
+                      description: |-
+                        The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token.
                     ipv6_acl_in:
                       description: |-
                         Name of the IPv6 access-list to be assigned in the ingress direction.
                         The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                        resolved from the IPv6 address set on the interface for this node.
+                        resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
                         Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                       type: str
                       convert_types:
@@ -1023,7 +1027,7 @@ keys:
                       description: |-
                         Name of the IPv6 access-list to be assigned in the egress direction.
                         The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                        resolved from the IPv6 address set on the interface for this node.
+                        resolved from the IPv6 address set on the interface for this node, and "peer_ipv6" (resolved from `peer_ipv6`).
                         Deprecated token "interface_ip" is also accepted as an alias for "interface_ipv6" and will be removed in AVD 7.0.0.
                       type: str
                       convert_types:
@@ -1269,11 +1273,15 @@ keys:
                       type: str
                       convert_types:
                         - int
+                    peer_ipv6:
+                      type: str
+                      description: |-
+                        The peer device IPv6 address (no mask). Used for field substitution in `ipv6_acls` entries with the "peer_ipv6" token.
                     ipv6_acl_in:
                       description: |-
                         Name of the IPv6 access-list to be assigned in the ingress direction.
                         The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                        resolved from the first IPv6 address set on the interface.
+                        resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
                         Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                       type: str
                       convert_types:
@@ -1282,7 +1290,7 @@ keys:
                       description: |-
                         Name of the IPv6 access-list to be assigned in the egress direction.
                         The access-list must be defined under `ipv6_acls` and supports substitution of the field "interface_ipv6",
-                        resolved from the first IPv6 address set on the interface.
+                        resolved from the first IPv6 address set on the interface, and "peer_ipv6" (resolved from `peer_ipv6`).
                         Token "interface_ip" is also accepted but deprecated and will be removed in AVD 7.0.0.
                       type: str
                       convert_types:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -244,18 +244,28 @@ class EthernetInterfacesMixin(Protocol):
     ) -> None:
         """Set the IPv6-only configuration on an EthernetInterface from the matching l3_interface entry for this node."""
         ipv6_address = l3_interface.ipv6_addresses[node_index] if l3_interface.ipv6_addresses else None
-        if not ipv6_address:
-            return
-        interface.ipv6_addresses.append(ipv6_address)
-        if vrf.name == "default":
-            self.structured_config.ipv6_unicast_routing = True
-        ipv6_interface_ip = get_ip_from_ip_prefix(ipv6_address) if "/" in ipv6_address else ipv6_address
+        ipv6_interface_ip = None
+        if ipv6_address:
+            interface.ipv6_addresses.append(ipv6_address)
+            if vrf.name == "default":
+                self.structured_config.ipv6_unicast_routing = True
+            ipv6_interface_ip = get_ip_from_ip_prefix(ipv6_address) if "/" in ipv6_address else ipv6_address
         if l3_interface.ipv6_acl_in:
-            acl = self.shared_utils.get_ipv6_acl(name=l3_interface.ipv6_acl_in, interface_name=interface.name, interface_ipv6=ipv6_interface_ip)
+            acl = self.shared_utils.get_ipv6_acl(
+                name=l3_interface.ipv6_acl_in,
+                interface_name=interface.name,
+                interface_ipv6=ipv6_interface_ip,
+                peer_ipv6=l3_interface.peer_ipv6,
+            )
             interface.ipv6_access_group_in = acl.name
             self.structured_config_utils._set_ipv6_acl(acl)
         if l3_interface.ipv6_acl_out:
-            acl = self.shared_utils.get_ipv6_acl(name=l3_interface.ipv6_acl_out, interface_name=interface.name, interface_ipv6=ipv6_interface_ip)
+            acl = self.shared_utils.get_ipv6_acl(
+                name=l3_interface.ipv6_acl_out,
+                interface_name=interface.name,
+                interface_ipv6=ipv6_interface_ip,
+                peer_ipv6=l3_interface.peer_ipv6,
+            )
             interface.ipv6_access_group_out = acl.name
             self.structured_config_utils._set_ipv6_acl(acl)
 

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/port_channel_interfaces.py
@@ -173,21 +173,31 @@ class PortChannelInterfacesMixin(Protocol):
         vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem,
     ) -> None:
         """Set the IPv6-only configuration on a PortChannelInterface from its l3_port_channel."""
-        if not l3_port_channel.ipv6_addresses:
-            return
-        port_channel_interface.ipv6_addresses.extend(l3_port_channel.ipv6_addresses)
-        if vrf.name == "default":
-            self.structured_config.ipv6_unicast_routing = True
-        # Use the first IPv6 address for "interface_ip" substitution in ACLs, matching the IPv4 behavior.
-        ipv6_interface_ip = next(iter(l3_port_channel.ipv6_addresses), None)
-        if ipv6_interface_ip and "/" in ipv6_interface_ip:
-            ipv6_interface_ip = get_ip_from_ip_prefix(ipv6_interface_ip)
+        ipv6_interface_ip = None
+        if l3_port_channel.ipv6_addresses:
+            port_channel_interface.ipv6_addresses.extend(l3_port_channel.ipv6_addresses)
+            if vrf.name == "default":
+                self.structured_config.ipv6_unicast_routing = True
+            # Use the first IPv6 address for "interface_ipv6" substitution in ACLs.
+            ipv6_interface_ip = next(iter(l3_port_channel.ipv6_addresses), None)
+            if ipv6_interface_ip and "/" in ipv6_interface_ip:
+                ipv6_interface_ip = get_ip_from_ip_prefix(ipv6_interface_ip)
         if l3_port_channel.ipv6_acl_in:
-            acl = self.shared_utils.get_ipv6_acl(name=l3_port_channel.ipv6_acl_in, interface_name=l3_port_channel.name, interface_ipv6=ipv6_interface_ip)
+            acl = self.shared_utils.get_ipv6_acl(
+                name=l3_port_channel.ipv6_acl_in,
+                interface_name=l3_port_channel.name,
+                interface_ipv6=ipv6_interface_ip,
+                peer_ipv6=l3_port_channel.peer_ipv6,
+            )
             port_channel_interface.ipv6_access_group_in = acl.name
             self.structured_config_utils._set_ipv6_acl(acl)
         if l3_port_channel.ipv6_acl_out:
-            acl = self.shared_utils.get_ipv6_acl(name=l3_port_channel.ipv6_acl_out, interface_name=l3_port_channel.name, interface_ipv6=ipv6_interface_ip)
+            acl = self.shared_utils.get_ipv6_acl(
+                name=l3_port_channel.ipv6_acl_out,
+                interface_name=l3_port_channel.name,
+                interface_ipv6=ipv6_interface_ip,
+                peer_ipv6=l3_port_channel.peer_ipv6,
+            )
             port_channel_interface.ipv6_access_group_out = acl.name
             self.structured_config_utils._set_ipv6_acl(acl)
 


### PR DESCRIPTION
## Change Summary

Add peer_ipv6 field substitution support to IPv6 ACLs on l3_interfaces, l3_port_channels. Updating description SVIs in eos_designs network services. Also fixes a logic bug where IPv6 ACLs were silently skipped when no ipv6_addresses was configured on the interface, and updates schema descriptions for ipv6_acl_in/ipv6_acl_out across all three interface types to document the current interface_ipv6 token (replacing stale references to the deprecated interface_ip alias).

## Related Issue(s)

Fixes #6833 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- peer_ipv6 (type: str) added to VRF l3_interfaces under network_services, the peer device's IPv6 address used for peer_ipv6 token substitution in ipv6_acls entries
- peer_ipv6 (type: str) added to VRF l3_port_channels under network_services

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional peer IPv6 address configuration for L3 interfaces and port-channels.
  - IPv6 ACL entries can now substitute both local interface and peer IPv6 addresses.
  - IPv6 ACLs can be applied to interfaces and port-channels even without a configured IPv6 address.

- **Bug Fixes**
  - Corrected IPv6 ACL processing for IPv4-only interfaces and unaddressed port-channels.

- **Documentation**
  - Updated schema and configuration documentation, including continued support and deprecation guidance for the `interface_ip` alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->