### PR TITLE
CI: Added integration tests for eos_designs_facts plugin action

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -558,6 +558,7 @@ jobs:
         working-directory: ansible_collections/arista/avd
         run: |
           ansible-test integration --coverage --requirements -vv ${{ matrix.integration_args }}
+          ansible-test coverage report --show-missing
           ansible-test coverage xml
           mv tests/output/reports/coverage.xml "./integration-coverage-${{ matrix.ansible_version }}.xml"
       - name: Upload coverage from ansible-test integration

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/aliases
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/aliases
@@ -1,0 +1,1 @@
+gather_facts/no

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/defaults/main.yaml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/defaults/main.yaml
@@ -1,0 +1,16 @@
+---
+testcase: '*'
+collection_path: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}/ansible_collections/arista/avd/tests"
+actual_output_dir: "{{ collection_path }}/output"
+
+fabric_name: testgroup
+type: l2leaf
+l2leaf:
+  nodes:
+    - name: testhost
+      id: 1
+avd_switch_facts:
+  testhost:
+    id: 1
+    vlans: ""
+    uplinks: []

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tasks/main.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Include test.yml
+  ansible.builtin.include_tasks: test.yml

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tasks/test.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tasks/test.yml
@@ -1,0 +1,16 @@
+- name: Collect all test cases
+  ansible.builtin.find:
+    paths: '{{ role_path }}/tests/'
+    patterns: '{{ testcase }}.yml'
+  register: test_cases
+  delegate_to: localhost
+
+- name: Set test_items
+  ansible.builtin.set_fact:
+    test_items: "{{ test_cases.files | map(attribute='path') | sort | list }}"
+
+- name: Run test cases
+  ansible.builtin.include_tasks: '{{ test_case_to_run }}'
+  with_items: '{{ test_items }}'
+  loop_control:
+    loop_var: test_case_to_run

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_invalid_fabric_name.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_invalid_fabric_name.yml
@@ -1,0 +1,30 @@
+---
+- name: Validate eos_designs inputs for invalid fabric_name test
+  arista.avd.validate_inputs:
+    schema_name: avd_design
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_facts_invalid_fabric"
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Test with invalid fabric_name
+  vars:
+    fabric_name: invalid_fabric_group
+  ignore_errors: true
+  register: result
+  arista.avd.eos_designs_facts:
+    output_dir: "{{ actual_output_dir }}"
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_facts_invalid_fabric"
+  check_mode: false
+  run_once: true
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is failed
+      - result.msg == expected_error
+  vars:
+    expected_error: >-
+      Error during plugin 'arista.avd.eos_designs_facts' execution: Invalid/missing 'fabric_name' variable.
+      All hosts in the play must have the same 'fabric_name' value which must point to an Ansible Group
+      containing the hosts.play_hosts: ['testhost']

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_missing_validated_inputs.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_missing_validated_inputs.yml
@@ -1,0 +1,31 @@
+---
+- name: Clear temporary directory for missing validated inputs test
+  ansible.builtin.file:
+    path: "{{ actual_output_dir }}/tmp_missing_validated_inputs_eos_designs_facts"
+    state: absent
+
+- name: Ensure temporary directory exists for missing validated inputs test
+  ansible.builtin.file:
+    path: "{{ actual_output_dir }}/tmp_missing_validated_inputs_eos_designs_facts"
+    state: directory
+    mode: "0700"
+
+- name: Test with missing validated inputs
+  ignore_errors: true
+  register: result
+  arista.avd.eos_designs_facts:
+    output_dir: "{{ actual_output_dir }}"
+    tmp_dir: "{{ actual_output_dir }}/tmp_missing_validated_inputs_eos_designs_facts"
+  check_mode: false
+  run_once: true
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is failed
+      - result.msg == expected_error
+  vars:
+    expected_error: >-
+      Error during plugin 'arista.avd.eos_designs_facts' execution: Missing validated inputs for host
+      'testhost'. Ensure the 'arista.avd.validate_inputs' task ran successfully for this host and that no
+      validation errors occurred.

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_false.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_false.yml
@@ -1,0 +1,50 @@
+---
+- name: Test template_output false behavior with inline Jinja value on ansible-core < 2.19
+  when: ansible_version.major == 2 and ansible_version.minor < 19
+  vars:
+    _inline_rendered_value: "l2leaf"
+    _inline_jinja_value: "{{'{{ _inline_rendered_value }}'}}"
+    l2leaf:
+      nodes:
+        - name: testhost
+          id: 1
+          mgmt_interface: "{{ _inline_jinja_value }}"
+  block:
+    - name: Validate eos_designs inputs for template_output false test
+      arista.avd.validate_inputs:
+        schema_name: avd_design
+        tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_facts_template_output_false"
+      delegate_to: localhost
+      check_mode: false
+      run_once: true
+
+    - name: Set eos_designs facts with template_output false
+      register: result
+      arista.avd.eos_designs_facts:
+        output_dir: "{{ actual_output_dir }}"
+        tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_facts_template_output_false"
+        template_output: false
+      check_mode: false
+      run_once: true
+
+    - name: Load generated eos_designs facts file
+      ansible.builtin.slurp:
+        src: "{{ actual_output_dir }}/tmp_eos_designs_facts_template_output_false/eos_designs_facts.json"
+      register: dumped_facts
+
+    - name: Parse generated eos_designs facts file
+      ansible.builtin.set_fact:
+        parsed_facts: "{{ dumped_facts.content | b64decode | from_json }}"
+
+    - name: Validate common result checks
+      ansible.builtin.assert:
+        that:
+          - result is success
+          - parsed_facts.testhost is defined
+          - parsed_facts.testhost.id == 1
+          - parsed_facts.testhost.mgmt_interface is defined
+
+    - name: Validate inline Jinja is not resolved when template_output is false
+      ansible.builtin.assert:
+        that:
+          - parsed_facts.testhost.mgmt_interface == _inline_jinja_value

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_true.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_true.yml
@@ -1,0 +1,33 @@
+---
+- name: Validate eos_designs inputs for template_output test
+  arista.avd.validate_inputs:
+    schema_name: avd_design
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_facts_template_output"
+  delegate_to: localhost
+  check_mode: false
+  run_once: true
+
+- name: Set eos_designs facts with template_output true
+  register: result
+  arista.avd.eos_designs_facts:
+    output_dir: "{{ actual_output_dir }}"
+    tmp_dir: "{{ actual_output_dir }}/tmp_eos_designs_facts_template_output"
+    template_output: true
+  check_mode: false
+  run_once: true
+
+- name: Load generated eos_designs facts file
+  ansible.builtin.slurp:
+    src: "{{ actual_output_dir }}/tmp_eos_designs_facts_template_output/eos_designs_facts.json"
+  register: dumped_facts
+
+- name: Parse generated eos_designs facts file
+  ansible.builtin.set_fact:
+    parsed_facts: "{{ dumped_facts.content | b64decode | from_json }}"
+
+- name: Validate result
+  ansible.builtin.assert:
+    that:
+      - result is success
+      - parsed_facts.testhost is defined
+      - parsed_facts.testhost.id == 1

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_true.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_true.yml
@@ -2,7 +2,8 @@
 - name: Test template_output behavior with inline Jinja value on ansible-core < 2.19
   when: ansible_version.major == 2 and ansible_version.minor < 19
   vars:
-    _inline_jinja_value: "{{'{{ switch.type }}'}}"
+    _inline_rendered_value: "l2leaf"
+    _inline_jinja_value: "{{'{{ _inline_rendered_value }}'}}"
     l2leaf:
       nodes:
         - name: testhost
@@ -46,4 +47,4 @@
     - name: Validate inline Jinja is resolved
       ansible.builtin.assert:
         that:
-          - parsed_facts.testhost.mgmt_interface == parsed_facts.testhost.type
+          - parsed_facts.testhost.mgmt_interface == _inline_rendered_value

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_true_ansible_2_19_and_above.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_true_ansible_2_19_and_above.yml
@@ -2,7 +2,8 @@
 - name: Test template_output ignored behavior with inline Jinja value on ansible-core >= 2.19
   when: ansible_version.major > 2 or (ansible_version.major == 2 and ansible_version.minor >= 19)
   vars:
-    _inline_jinja_value: "{{'{{ switch.type }}'}}"
+    _inline_rendered_value: "l2leaf"
+    _inline_jinja_value: "{{'{{ _inline_rendered_value }}'}}"
     l2leaf:
       nodes:
         - name: testhost

--- a/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_true_ansible_2_19_and_above.yml
+++ b/ansible_collections/arista/avd/tests/integration/targets/eos_designs_facts/tests/test_with_template_output_true_ansible_2_19_and_above.yml
@@ -1,6 +1,6 @@
 ---
-- name: Test template_output behavior with inline Jinja value on ansible-core < 2.19
-  when: ansible_version.major == 2 and ansible_version.minor < 19
+- name: Test template_output ignored behavior with inline Jinja value on ansible-core >= 2.19
+  when: ansible_version.major > 2 or (ansible_version.major == 2 and ansible_version.minor >= 19)
   vars:
     _inline_jinja_value: "{{'{{ switch.type }}'}}"
     l2leaf:
@@ -43,7 +43,7 @@
           - parsed_facts.testhost.id == 1
           - parsed_facts.testhost.mgmt_interface is defined
 
-    - name: Validate inline Jinja is resolved
+    - name: Validate inline Jinja is not resolved
       ansible.builtin.assert:
         that:
-          - parsed_facts.testhost.mgmt_interface == parsed_facts.testhost.type
+          - parsed_facts.testhost.mgmt_interface == _inline_jinja_value


### PR DESCRIPTION
## Change Summary

Added integration tests for eos_designs_facts plugin action

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
Added integration tests for eos_designs_facts plugin action

## How to test
Coverage before PR

```
Name                                                                Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------------------------------------------------
plugins/action/eos_designs_facts.py                                    86     11     12      4    85%   41-42, 64-65, 90-96, 148-152, 188-190
```

Coverage with this PR

```
Name                                                                Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------------------------------------------------
plugins/__init__.py                                                    14      0      2      1    94%   18->exit
plugins/action/eos_designs_facts.py                                    86      7     12      2    91%   41-42, 64-65, 188-190

```

The 41-42 and 64-65 are about pyavd import error and 188-190 is more about ansible version. It should be covered in version 2.18.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for `eos_designs_facts`.
  - Verifies clear errors for invalid fabric names and missing validated inputs.
  - Confirms expected facts content and template output behavior across supported Ansible versions.
  - Added automatic discovery and execution of test cases with configurable test settings.
- **Chores**
  - Enhanced pull request checks with a coverage report showing missing lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->