### PR TITLE
Refactor(eos_designs): Make 'logging_settings.hosts' not required

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/loggings-settings-without-hosts.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/loggings-settings-without-hosts.cfg
@@ -1,0 +1,62 @@
+!
+no enable password
+no aaa root
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+logging buffered 1000000 warnings
+logging console errors
+no logging monitor
+!
+hostname loggings-settings-without-hosts
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 192.168.255.23/32
+!
+interface Loopback1
+   description VXLAN_TUNNEL_SOURCE
+   no shutdown
+   ip address 192.168.254.23/32
+!
+interface Management1
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 1.1.10.15
+!
+interface Vxlan1
+   description loggings-settings-without-hosts_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 15
+   router-id 192.168.255.23
+   update wait-install
+   no bgp default ipv4-unicast
+   maximum-paths 4
+   redistribute connected route-map RM-CONN-2-BGP
+!
+end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/monitor-layer1-minimal.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/monitor-layer1-minimal.cfg
@@ -10,9 +10,6 @@ service routing protocols model multi-agent
 !
 monitor layer1
 !
-logging vrf MGMT host syslog.minimal.example.com
-logging vrf MGMT source-interface Management1
-!
 hostname monitor-layer1-minimal
 !
 vrf instance MGMT

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/loggings-settings-without-hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/loggings-settings-without-hosts.yml
@@ -1,0 +1,84 @@
+aaa_root:
+  disabled: true
+config_end: true
+enable_password:
+  disabled: true
+hostname: loggings-settings-without-hosts
+ip_igmp_snooping:
+  globally_enabled: true
+ip_routing: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+logging:
+  console: errors
+  monitor: disabled
+  buffered:
+    size: 1000000
+    level: warnings
+loopback_interfaces:
+- name: Loopback0
+  description: ROUTER_ID
+  shutdown: false
+  ip_address: 192.168.255.23/32
+- name: Loopback1
+  description: VXLAN_TUNNEL_SOURCE
+  shutdown: false
+  ip_address: 192.168.254.23/32
+management_interfaces:
+- name: Management1
+  description: OOB_MANAGEMENT
+  shutdown: false
+  vrf: MGMT
+  ip_address: 1.1.10.15
+  type: oob
+metadata:
+  is_deployed: true
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_bgp:
+  as: '15'
+  router_id: 192.168.255.23
+  maximum_paths:
+    paths: 4
+  updates:
+    wait_install: true
+  bgp:
+    default:
+      ipv4_unicast: false
+  redistribute:
+    connected:
+      enabled: true
+      route_map: RM-CONN-2-BGP
+service_routing_protocols_model: multi-agent
+transceiver_qsfp_default_mode_4x10: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+vxlan_interface:
+  vxlan1:
+    description: loggings-settings-without-hosts_VTEP
+    vxlan:
+      source_interface: Loopback1
+      udp_port: 4789

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/monitor-layer1-minimal.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/monitor-layer1-minimal.yml
@@ -8,13 +8,6 @@ ip_igmp_snooping:
   globally_enabled: true
 ip_routing: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
-logging:
-  vrfs:
-  - name: MGMT
-    source_interface: Management1
-    hosts:
-    - name: syslog.minimal.example.com
-      protocol: udp
 loopback_interfaces:
 - name: Loopback0
   description: ROUTER_ID

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/loggings-settings-without-hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/loggings-settings-without-hosts.yml
@@ -1,0 +1,20 @@
+---
+type: l3leaf
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 192.168.255.0/24
+    loopback_ipv4_offset: 8
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    virtual_router_mac_address: 00:dc:00:00:00:0a
+    mgmt_ip: 1.1.10.15
+  nodes:
+    - name: loggings-settings-without-hosts
+      id: 15
+      bgp_as: 15
+
+logging_settings:
+  console: errors
+  monitor: disabled
+  buffered:
+    size: 1000000
+    level: warnings

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/monitor-layer1-minimal.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/monitor-layer1-minimal.yml
@@ -14,7 +14,5 @@ l3leaf:
       bgp_as: 153
 
 logging_settings:
-  hosts:
-    - name: syslog.minimal.example.com
   monitor_layer1:
     enabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -266,6 +266,7 @@ all:
             l2vlan-profiles:
             logging-settings:
             logging-settings-local-interface:
+            loggings-settings-without-hosts:
             management-eapi-vrfs:
             management-eapi-vrfs-2:
             management-eapi-vrfs-3:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/logging-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/logging-settings.md
@@ -9,7 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>logging_settings</samp>](## "logging_settings") | Dictionary |  |  |  | Logging settings |
     | [<samp>&nbsp;&nbsp;use_local_interface_cli</samp>](## "logging_settings.use_local_interface_cli") | Boolean |  | `False` |  | Use `logging local-interface <interface>` CLI instead of the deprecated `logging source-interface <interface>` CLI.<br>The new CLI was introduced in EOS version 4.33.4. |
-    | [<samp>&nbsp;&nbsp;hosts</samp>](## "logging_settings.hosts") | List, items: Dictionary | Required |  | Min Length: 1 |  |
+    | [<samp>&nbsp;&nbsp;hosts</samp>](## "logging_settings.hosts") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "logging_settings.hosts.[].name") | String | Required |  |  | Syslog server name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "logging_settings.hosts.[].vrf") | String |  | `use_default_mgmt_method_vrf` |  | The value of `vrf` will be interpreted according to these rules:<br>- `use_mgmt_interface_vrf` will configure the logging destination under the VRF set with `mgmt_interface_vrf` and set the `mgmt_interface` as logging source-interface.<br>  An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.<br>- `use_inband_mgmt_vrf` will configure the logging destination under the VRF set with `inband_mgmt_vrf` and set the `inband_mgmt_interface` as logging source-interface.<br>  An error will be raised if inband management is not configured for the device.<br>- `use_default_mgmt_method_vrf` will configure the VRF and source-interface for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the VRF name. Remember to set the `logging_settings.vrfs[].source_interface` if needed. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "logging_settings.hosts.[].protocol") | String |  | `udp` | Valid Values:<br>- <code>tcp</code><br>- <code>udp</code><br>- <code>tls</code> |  |
@@ -66,7 +66,7 @@
       # Use `logging local-interface <interface>` CLI instead of the deprecated `logging source-interface <interface>` CLI.
       # The new CLI was introduced in EOS version 4.33.4.
       use_local_interface_cli: <bool; default=False>
-      hosts: # >=1 items; required
+      hosts: # >=1 items
 
           # Syslog server name.
         - name: <str; required>

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -4323,7 +4323,6 @@ keys:
         default: false
       hosts:
         type: list
-        required: true
         min_length: 1
         items:
           type: dict

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/logging_settings.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/logging_settings.yml
@@ -19,7 +19,6 @@ keys:
         default: false
       hosts:
         type: list
-        required: true
         min_length: 1
         items:
           type: dict


### PR DESCRIPTION
## Change Summary

Relax requirement for logging_settings.hosts

## Related Issue(s)

Fixes #7353

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Relax requirement for logging_settings.hosts. Removed required: true for hosts 

## How to test
Removed hosts from logging settings and still render other configs.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logging host configuration is now optional under `logging_settings`.
  * Configurations can omit syslog hosts when remote logging is not required.
  * Local logging options, such as console, monitor, and buffered logging, remain available without a remote host.

* **Documentation**
  * Updated logging settings documentation and examples to reflect that hosts are optional.

* **Bug Fixes**
  * Minimal monitoring configurations no longer generate unintended management VRF syslog settings when no logging host is defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->