### PR TITLE
Feat(eos_designs): Support ACT digital twin instance type

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/digital_twin/digital_twin/documentation/fabric/DIGITAL_TWIN-topology.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/digital_twin/digital_twin/documentation/fabric/DIGITAL_TWIN-topology.yml
@@ -75,6 +75,7 @@ nodes:
     node_type: third-party
     ip_addr: 192.169.3.3/32
     version: byod
+    instance_type: xlarge
 - digital-twin-veos-no-mgmt:
     node_type: veos
     version: 4.33.1.1F

--- a/ansible_collections/arista/avd/extensions/molecule/digital_twin/digital_twin/intended/structured_configs/digital-twin-ethernet-ports-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/digital_twin/digital_twin/intended/structured_configs/digital-twin-ethernet-ports-3.yml
@@ -48,6 +48,7 @@ metadata:
     node_type: third-party
     ip_addr: 192.169.3.3/32
     version: byod
+    instance_type: xlarge
     username: cvpadmin
     password: cvp123!
 prefix_lists:

--- a/ansible_collections/arista/avd/extensions/molecule/digital_twin/inventory/group_vars/DIGITAL_TWIN_ETHERNET_PORTS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/digital_twin/inventory/group_vars/DIGITAL_TWIN_ETHERNET_PORTS.yml
@@ -80,6 +80,7 @@ custom_platform_settings:
       - custom-platform
     digital_twin:
       act_node_type: third-party
+      act_node_size: xlarge
 
 firewalls:
   - name: firewall-1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/metadata.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/metadata.md
@@ -140,6 +140,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;node_type</samp>](## "metadata.digital_twin.node_type") | String |  |  |  | Digital Twin's internal device type used for deploying a replica of the fabric device.<br>Possible values depend on the target Digital Twin environment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_addr</samp>](## "metadata.digital_twin.ip_addr") | String |  |  |  | Management IPv4_address/Mask assigned to a replica of the fabric device within the Digital Twin environment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "metadata.digital_twin.version") | String |  |  |  | OS version used for deploying a replica of the fabric device within the Digital Twin environment. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;instance_type</samp>](## "metadata.digital_twin.instance_type") | String |  |  |  | ACT instance type used for deploying a replica of the fabric device within the Digital Twin environment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;username</samp>](## "metadata.digital_twin.username") | String |  |  |  | Local username assigned to a replica of the fabric device within the Digital Twin environment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "metadata.digital_twin.password") | String |  |  |  | Local password assigned to a replica of the fabric device within the Digital Twin environment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;internet_access</samp>](## "metadata.digital_twin.internet_access") | Boolean |  |  |  | Specifies if the ACT Digital Twin device is deployed with direct access to the Internet.<br>This option applies only to the `cloudeos` and `veos` node types and will be ignored for all other ACT node types.<br>ACT does not provide direct Internet access to `cloudeos` or `veos` devices by default. |
@@ -337,6 +338,9 @@
 
         # OS version used for deploying a replica of the fabric device within the Digital Twin environment.
         version: <str>
+
+        # ACT instance type used for deploying a replica of the fabric device within the Digital Twin environment.
+        instance_type: <str>
 
         # Local username assigned to a replica of the fabric device within the Digital Twin environment.
         username: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/custom-platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/custom-platform-settings.md
@@ -176,6 +176,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;digital_twin</samp>](## "custom_platform_settings.[].digital_twin") | Dictionary |  |  |  | PREVIEW: This option is marked as "preview", meaning the data models or generated configuration can change at any time.<br>Digital Twin settings applied when `avd_digital_twin_mode` is `true`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "custom_platform_settings.[].digital_twin.platform") | String |  |  |  | Name of an alternate `platform_settings` platform used when running in Digital Twin mode.<br>The `platform_settings` for the regular `platform` is used if this is not set. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;act_node_type</samp>](## "custom_platform_settings.[].digital_twin.act_node_type") | String |  |  | Valid Values:<br>- <code>cloudeos</code><br>- <code>cvp</code><br>- <code>generic</code><br>- <code>third-party</code><br>- <code>tools-server</code><br>- <code>veos</code> | ACT node type. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;act_node_size</samp>](## "custom_platform_settings.[].digital_twin.act_node_size") | String |  |  |  | ACT node size to use for the ACT `instance_type`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "custom_platform_settings.[].structured_config") | Dictionary |  |  |  | Custom structured config for the EOS Config schema. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "custom_platform_settings.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
 
@@ -483,6 +484,9 @@
 
           # ACT node type.
           act_node_type: <str; "cloudeos" | "cvp" | "generic" | "third-party" | "tools-server" | "veos">
+
+          # ACT node size to use for the ACT `instance_type`.
+          act_node_size: <str>
 
         # Custom structured config for the EOS Config schema.
         structured_config: <dict>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
@@ -176,6 +176,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;digital_twin</samp>](## "platform_settings.[].digital_twin") | Dictionary |  |  |  | PREVIEW: This option is marked as "preview", meaning the data models or generated configuration can change at any time.<br>Digital Twin settings applied when `avd_digital_twin_mode` is `true`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;platform</samp>](## "platform_settings.[].digital_twin.platform") | String |  |  |  | Name of an alternate `platform_settings` platform used when running in Digital Twin mode.<br>The `platform_settings` for the regular `platform` is used if this is not set. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;act_node_type</samp>](## "platform_settings.[].digital_twin.act_node_type") | String |  |  | Valid Values:<br>- <code>cloudeos</code><br>- <code>cvp</code><br>- <code>generic</code><br>- <code>third-party</code><br>- <code>tools-server</code><br>- <code>veos</code> | ACT node type. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;act_node_size</samp>](## "platform_settings.[].digital_twin.act_node_size") | String |  |  |  | ACT node size to use for the ACT `instance_type`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "platform_settings.[].structured_config") | Dictionary |  |  |  | Custom structured config for the EOS Config schema. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "platform_settings.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the root level of the final EOS configuration. |
 
@@ -487,6 +488,9 @@
 
           # ACT node type.
           act_node_type: <str; "cloudeos" | "cvp" | "generic" | "third-party" | "tools-server" | "veos">
+
+          # ACT node size to use for the ACT `instance_type`.
+          act_node_size: <str>
 
         # Custom structured config for the EOS Config schema.
         structured_config: <dict>

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -29455,6 +29455,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 "node_type": {"type": str},
                 "ip_addr": {"type": str},
                 "version": {"type": str},
+                "instance_type": {"type": str},
                 "username": {"type": str},
                 "password": {"type": str},
                 "internet_access": {"type": bool},
@@ -29474,6 +29475,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             """
             version: str | None
             """OS version used for deploying a replica of the fabric device within the Digital Twin environment."""
+            instance_type: str | None
+            """
+            ACT instance type used for deploying a replica of the fabric device within the Digital Twin
+            environment.
+            """
             username: str | None
             """Local username assigned to a replica of the fabric device within the Digital Twin environment."""
             password: str | None
@@ -29496,6 +29502,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     node_type: str | UndefinedType | None = Undefined,
                     ip_addr: str | UndefinedType | None = Undefined,
                     version: str | UndefinedType | None = Undefined,
+                    instance_type: str | UndefinedType | None = Undefined,
                     username: str | UndefinedType | None = Undefined,
                     password: str | UndefinedType | None = Undefined,
                     internet_access: bool | UndefinedType | None = Undefined,
@@ -29516,6 +29523,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                            Management IPv4_address/Mask assigned to a replica of the fabric device within the Digital Twin
                            environment.
                         version: OS version used for deploying a replica of the fabric device within the Digital Twin environment.
+                        instance_type:
+                           ACT instance type used for deploying a replica of the fabric device within the Digital Twin
+                           environment.
                         username: Local username assigned to a replica of the fabric device within the Digital Twin environment.
                         password: Local password assigned to a replica of the fabric device within the Digital Twin environment.
                         internet_access:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -11319,6 +11319,10 @@ keys:
             type: str
             description: OS version used for deploying a replica of the fabric device
               within the Digital Twin environment.
+          instance_type:
+            type: str
+            description: ACT instance type used for deploying a replica of the fabric
+              device within the Digital Twin environment.
           username:
             type: str
             description: Local username assigned to a replica of the fabric device

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/metadata.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/metadata.schema.yml
@@ -445,6 +445,9 @@ keys:
           version:
             type: str
             description: OS version used for deploying a replica of the fabric device within the Digital Twin environment.
+          instance_type:
+            type: str
+            description: ACT instance type used for deploying a replica of the fabric device within the Digital Twin environment.
           username:
             type: str
             description: Local username assigned to a replica of the fabric device within the Digital Twin environment.

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -44397,7 +44397,7 @@ class EosDesigns(EosDesignsRootModel):
             """Subclass of AvdModel."""
 
             ActNodeType: TypeAlias = Literal["cloudeos", "cvp", "generic", "third-party", "tools-server", "veos"]
-            _fields: ClassVar[dict] = {"platform": {"type": str}, "act_node_type": {"type": str}}
+            _fields: ClassVar[dict] = {"platform": {"type": str}, "act_node_type": {"type": str}, "act_node_size": {"type": str}}
             platform: str | None
             """
             Name of an alternate `platform_settings` platform used when running in Digital Twin mode.
@@ -44406,10 +44406,18 @@ class EosDesigns(EosDesignsRootModel):
             """
             act_node_type: ActNodeType | None
             """ACT node type."""
+            act_node_size: str | None
+            """ACT node size to use for the ACT `instance_type`."""
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, platform: str | UndefinedType | None = Undefined, act_node_type: ActNodeType | UndefinedType | None = Undefined) -> None:
+                def __init__(
+                    self,
+                    *,
+                    platform: str | UndefinedType | None = Undefined,
+                    act_node_type: ActNodeType | UndefinedType | None = Undefined,
+                    act_node_size: str | UndefinedType | None = Undefined,
+                ) -> None:
                     """
                     DigitalTwin.
 
@@ -44422,6 +44430,7 @@ class EosDesigns(EosDesignsRootModel):
                            The
                            `platform_settings` for the regular `platform` is used if this is not set.
                         act_node_type: ACT node type.
+                        act_node_size: ACT node size to use for the ACT `instance_type`.
 
                     """
 
@@ -46243,7 +46252,7 @@ class EosDesigns(EosDesignsRootModel):
             """Subclass of AvdModel."""
 
             ActNodeType: TypeAlias = Literal["cloudeos", "cvp", "generic", "third-party", "tools-server", "veos"]
-            _fields: ClassVar[dict] = {"platform": {"type": str}, "act_node_type": {"type": str}}
+            _fields: ClassVar[dict] = {"platform": {"type": str}, "act_node_type": {"type": str}, "act_node_size": {"type": str}}
             platform: str | None
             """
             Name of an alternate `platform_settings` platform used when running in Digital Twin mode.
@@ -46252,10 +46261,18 @@ class EosDesigns(EosDesignsRootModel):
             """
             act_node_type: ActNodeType | None
             """ACT node type."""
+            act_node_size: str | None
+            """ACT node size to use for the ACT `instance_type`."""
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, platform: str | UndefinedType | None = Undefined, act_node_type: ActNodeType | UndefinedType | None = Undefined) -> None:
+                def __init__(
+                    self,
+                    *,
+                    platform: str | UndefinedType | None = Undefined,
+                    act_node_type: ActNodeType | UndefinedType | None = Undefined,
+                    act_node_size: str | UndefinedType | None = Undefined,
+                ) -> None:
                     """
                     DigitalTwin.
 
@@ -46268,6 +46285,7 @@ class EosDesigns(EosDesignsRootModel):
                            The
                            `platform_settings` for the regular `platform` is used if this is not set.
                         act_node_type: ACT node type.
+                        act_node_size: ACT node size to use for the ACT `instance_type`.
 
                     """
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -17219,6 +17219,9 @@ $defs:
               - third-party
               - tools-server
               - veos
+            act_node_size:
+              type: str
+              description: ACT node size to use for the ACT `instance_type`.
         structured_config:
           type: dict
           relaxed_validation: true

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_platform_settings.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_platform_settings.yml
@@ -648,6 +648,9 @@ $defs:
                 - third-party
                 - tools-server
                 - veos
+            act_node_size:
+              type: str
+              description: ACT node size to use for the ACT `instance_type`.
         structured_config:
           type: dict
           relaxed_validation: true

--- a/python-avd/pyavd/_eos_designs/structured_config/metadata/digital_twin.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/metadata/digital_twin.py
@@ -72,6 +72,7 @@ class DigitalTwinMixin(Protocol):
                     node_type=digital_twin_node_type,
                     ip_addr=ip_addr,
                     version=version,
+                    instance_type=self.shared_utils.platform_settings.digital_twin.act_node_size,
                     username=username,
                     password=password,
                 )

--- a/python-avd/pyavd/api/fabric_documentation/__init__.py
+++ b/python-avd/pyavd/api/fabric_documentation/__init__.py
@@ -21,10 +21,10 @@ class ActNodeSettings:
     node_type: str
     ip_addr: str | None
     version: str
-    instance_type: str | None
     # internet_access attribute is only applicable to cloudeos and veos node types and is ignored by ACT for all other node types
     internet_access: bool | None
     ports: tuple[str, ...] | None
+    instance_type: str | None = None
 
 
 @dataclass(frozen=True)

--- a/python-avd/pyavd/api/fabric_documentation/__init__.py
+++ b/python-avd/pyavd/api/fabric_documentation/__init__.py
@@ -21,6 +21,7 @@ class ActNodeSettings:
     node_type: str
     ip_addr: str | None
     version: str
+    instance_type: str | None
     # internet_access attribute is only applicable to cloudeos and veos node types and is ignored by ACT for all other node types
     internet_access: bool | None
     ports: tuple[str, ...] | None

--- a/python-avd/pyavd/get_fabric_documentation.py
+++ b/python-avd/pyavd/get_fabric_documentation.py
@@ -237,6 +237,7 @@ def _get_digital_twin_act(fabric_documentation_facts: FabricDocumentationFacts) 
                     node_type=digital_twin_node_type,
                     ip_addr=get(fabric_documentation_facts.structured_configs, f"{device}..metadata..digital_twin..ip_addr", separator=".."),
                     version=get(fabric_documentation_facts.structured_configs, f"{device}..metadata..digital_twin..version", separator=".."),
+                    instance_type=get(fabric_documentation_facts.structured_configs, f"{device}..metadata..digital_twin..instance_type", separator=".."),
                     # Set internet_access to None unless it is a cloudeos or veos node and its metadata.digital_twin.internet_access is True
                     internet_access=internet_access
                     if (


### PR DESCRIPTION
## Summary
- Add platform setting `digital_twin.act_node_size` for ACT Digital Twin nodes
- Store the value as `metadata.digital_twin.instance_type` in structured config
- Include `instance_type` in generated ACT topology data

Fixes #7377

## Tests
- `pre-commit run` under Python 3.11 via uv
- `molecule converge --scenario-name digital_twin -- --forks 5`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Digital Twin deployments now support selecting an ACT instance type and node size.
  * Fabric documentation includes the configured Digital Twin instance type for each device.
  * Configuration schemas and settings now expose the new Digital Twin sizing options.

* **Documentation**
  * Added reference documentation and examples for Digital Twin instance type and ACT node size settings.
  * Updated validation references for BGP metadata configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->