### PR TITLE
Feat(eos_designs): Support ACT legacy EOS versioning

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/digital_twin/digital_twin/documentation/fabric/DIGITAL_TWIN_SINGLE_SWITCH_FABRIC-topology.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/digital_twin/digital_twin/documentation/fabric/DIGITAL_TWIN_SINGLE_SWITCH_FABRIC-topology.yml
@@ -1,3 +1,5 @@
+settings:
+  legacy_eos_versioning: false
 nodes:
 - digital-twin-single-switch-fabric-1:
     node_type: veos

--- a/ansible_collections/arista/avd/extensions/molecule/digital_twin/inventory/group_vars/DIGITAL_TWIN_SINGLE_SWITCH_FABRIC.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/digital_twin/inventory/group_vars/DIGITAL_TWIN_SINGLE_SWITCH_FABRIC.yml
@@ -1,6 +1,10 @@
 ---
 fabric_name: DIGITAL_TWIN_SINGLE_SWITCH_FABRIC
 
+digital_twin:
+  fabric:
+    act_legacy_eos_versioning: false
+
 l2leaf:
   nodes:
     - name: digital-twin-single-switch-fabric-1

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_documentation.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_documentation.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from pyavd._eos_designs.eos_designs_facts.schema import EosDesignsFacts
     from pyavd._utils.get import get
     from pyavd._utils.strip_empties import strip_empties_from_dict
-    from pyavd.api.fabric_documentation import ActSettings
     from pyavd.get_fabric_documentation import get_fabric_documentation
     from pyavd.j2filters import natural_sort
 
@@ -27,7 +26,6 @@ try:
     from pyavd._eos_designs.eos_designs_facts.schema import EosDesignsFacts
     from pyavd._utils.get import get
     from pyavd._utils.strip_empties import strip_empties_from_dict
-    from pyavd.api.fabric_documentation import ActSettings
     from pyavd.get_fabric_documentation import get_fabric_documentation
     from pyavd.j2filters import natural_sort
 
@@ -81,7 +79,6 @@ class ActionModule(AVDActionPlugin):
             structured_config_suffix=validated_args["structured_config_suffix"],
         )
         fabric_name = get(task_vars, "fabric_name", required=True)
-        act_legacy_eos_versioning = get(task_vars, "digital_twin.fabric.act_legacy_eos_versioning")
         output = get_fabric_documentation(
             avd_facts=all_facts,
             structured_configs=structured_configs,
@@ -92,7 +89,6 @@ class ActionModule(AVDActionPlugin):
             p2p_links_csv=validated_args["p2p_links_csv"],
             toc=validated_args["toc"],
             digital_twin=validated_args["digital_twin"],
-            digital_twin_settings=ActSettings(legacy_eos_versioning=act_legacy_eos_versioning) if act_legacy_eos_versioning is not None else None,
         )
 
         self.result["changed"] = False

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_documentation.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_documentation.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pyavd._eos_designs.eos_designs_facts.schema import EosDesignsFacts
     from pyavd._utils.get import get
     from pyavd._utils.strip_empties import strip_empties_from_dict
+    from pyavd.api.fabric_documentation import ActSettings
     from pyavd.get_fabric_documentation import get_fabric_documentation
     from pyavd.j2filters import natural_sort
 
@@ -26,6 +27,7 @@ try:
     from pyavd._eos_designs.eos_designs_facts.schema import EosDesignsFacts
     from pyavd._utils.get import get
     from pyavd._utils.strip_empties import strip_empties_from_dict
+    from pyavd.api.fabric_documentation import ActSettings
     from pyavd.get_fabric_documentation import get_fabric_documentation
     from pyavd.j2filters import natural_sort
 
@@ -79,6 +81,7 @@ class ActionModule(AVDActionPlugin):
             structured_config_suffix=validated_args["structured_config_suffix"],
         )
         fabric_name = get(task_vars, "fabric_name", required=True)
+        act_legacy_eos_versioning = get(task_vars, "digital_twin.fabric.act_legacy_eos_versioning")
         output = get_fabric_documentation(
             avd_facts=all_facts,
             structured_configs=structured_configs,
@@ -89,6 +92,7 @@ class ActionModule(AVDActionPlugin):
             p2p_links_csv=validated_args["p2p_links_csv"],
             toc=validated_args["toc"],
             digital_twin=validated_args["digital_twin"],
+            digital_twin_settings=ActSettings(legacy_eos_versioning=act_legacy_eos_versioning) if act_legacy_eos_versioning is not None else None,
         )
 
         self.result["changed"] = False

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/digital-twin-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/digital-twin-configuration.md
@@ -14,6 +14,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;act_username</samp>](## "digital_twin.fabric.act_username") | String |  | `cvpadmin` |  | Username for ACT Digital Twin fabric devices. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;act_password</samp>](## "digital_twin.fabric.act_password") | String |  | `cvp123!` |  | Cleartext password for ACT Digital Twin fabric devices. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;act_internet_access</samp>](## "digital_twin.fabric.act_internet_access") | Boolean |  | `False` |  | Specifies if the ACT Digital Twin device is deployed with direct access to the Internet.<br>This option applies only to the 'cloudeos' and 'veos' node types and will be ignored for all other ACT node types.<br>ACT does not provide direct Internet access to cloudeos or veos devices by default. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;act_legacy_eos_versioning</samp>](## "digital_twin.fabric.act_legacy_eos_versioning") | Boolean |  |  |  | Set the ACT `legacy_eos_versioning` topology setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;act_ensure_eapi_access</samp>](## "digital_twin.fabric.act_ensure_eapi_access") | Boolean |  | `False` |  | Ensures eAPI remains accessible for automation and testing via ACT.<br>Clients connecting to device eAPI though ACT rely on access in the default VRF. If eAPI is reconfigured for a dedicated management VRF, this primary eAPI connectivity can be unintentionally broken.<br>Set this to `true` to enforce the required EOS configuration, guaranteeing eAPI over HTTPS is always enabled in the default VRF and preserving this connectivity.<br>This setting is only applicable to ACT `veos` and `cloudeos` node types. |
     | [<samp>&nbsp;&nbsp;use_default_interfaces_of_digital_twin_platform</samp>](## "digital_twin.use_default_interfaces_of_digital_twin_platform") | Boolean |  | `False` |  | In Digital Twin mode, AVD can either use the default interfaces of the original or the digital twin platform (as set in `platform_settings.[].digital_twin.platform`). |
 
@@ -43,6 +44,9 @@
         # This option applies only to the 'cloudeos' and 'veos' node types and will be ignored for all other ACT node types.
         # ACT does not provide direct Internet access to cloudeos or veos devices by default.
         act_internet_access: <bool; default=False>
+
+        # Set the ACT `legacy_eos_versioning` topology setting.
+        act_legacy_eos_versioning: <bool>
 
         # Ensures eAPI remains accessible for automation and testing via ACT.
         # Clients connecting to device eAPI though ACT rely on access in the default VRF. If eAPI is reconfigured for a dedicated management VRF, this primary eAPI connectivity can be unintentionally broken.

--- a/docs/contribution/eos_designs_facts_internal/tables/eos_designs_facts.md
+++ b/docs/contribution/eos_designs_facts_internal/tables/eos_designs_facts.md
@@ -11,6 +11,8 @@
     | [<samp>type</samp>](## "type") | String | Required |  |  |  |
     | [<samp>platform</samp>](## "platform") | String |  |  |  |  |
     | [<samp>is_deployed</samp>](## "is_deployed") | Boolean | Required |  |  |  |
+    | [<samp>digital_twin</samp>](## "digital_twin") | Dictionary |  |  |  | Digital Twin fabric facts. |
+    | [<samp>&nbsp;&nbsp;act_legacy_eos_versioning</samp>](## "digital_twin.act_legacy_eos_versioning") | Boolean |  |  |  | ACT legacy EOS versioning fabric setting. |
     | [<samp>serial_number</samp>](## "serial_number") | String |  |  |  |  |
     | [<samp>mgmt_interface</samp>](## "mgmt_interface") | String |  |  |  |  |
     | [<samp>mgmt_ip</samp>](## "mgmt_ip") | String |  |  |  |  |
@@ -182,6 +184,12 @@
     type: <str; required>
     platform: <str>
     is_deployed: <bool; required>
+
+    # Digital Twin fabric facts.
+    digital_twin:
+
+      # ACT legacy EOS versioning fabric setting.
+      act_legacy_eos_versioning: <bool>
     serial_number: <str>
     mgmt_interface: <str>
     mgmt_ip: <str>

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/generator.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/generator.py
@@ -76,6 +76,12 @@ class EosDesignsFactsGeneratorProtocol(
 
     @remove_cached_property_type
     @cached_property
+    def digital_twin(self) -> EosDesignsFactsProtocol.DigitalTwin:
+        """Exposed in avd_switch_facts."""
+        return EosDesignsFactsProtocol.DigitalTwin(act_legacy_eos_versioning=self.inputs.digital_twin.fabric.act_legacy_eos_versioning)
+
+    @remove_cached_property_type
+    @cached_property
     def serial_number(self) -> str | None:
         """Exposed in avd_switch_facts."""
         return self.shared_utils.serial_number

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/schema/eos_designs_facts.schema.yml
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/schema/eos_designs_facts.schema.yml
@@ -21,6 +21,13 @@ keys:
   is_deployed:
     type: bool
     required: true
+  digital_twin:
+    type: dict
+    description: Digital Twin fabric facts.
+    keys:
+      act_legacy_eos_versioning:
+        type: bool
+        description: ACT legacy EOS versioning fabric setting.
   serial_number:
     type: str
   mgmt_interface:

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/schema/protocol.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/schema/protocol.py
@@ -19,6 +19,27 @@ if TYPE_CHECKING:
 class EosDesignsFactsProtocol(Protocol):
     """Subclass of Protocol."""
 
+    class DigitalTwin(AvdModel):
+        """Subclass of AvdModel."""
+
+        _fields: ClassVar[dict] = {"act_legacy_eos_versioning": {"type": bool}}
+        act_legacy_eos_versioning: bool | None
+        """ACT legacy EOS versioning fabric setting."""
+
+        if TYPE_CHECKING:
+
+            def __init__(self, *, act_legacy_eos_versioning: bool | UndefinedType | None = Undefined) -> None:
+                """
+                DigitalTwin.
+
+
+                Subclass of AvdModel.
+
+                Args:
+                    act_legacy_eos_versioning: ACT legacy EOS versioning fabric setting.
+
+                """
+
     class DownlinkPoolsItem(AvdModel):
         """Subclass of AvdModel."""
 
@@ -1104,6 +1125,7 @@ class EosDesignsFactsProtocol(Protocol):
         "type": {"type": str},
         "platform": {"type": str},
         "is_deployed": {"type": bool},
+        "digital_twin": {"type": DigitalTwin},
         "serial_number": {"type": str},
         "mgmt_interface": {"type": str},
         "mgmt_ip": {"type": str},
@@ -1164,6 +1186,12 @@ class EosDesignsFactsProtocol(Protocol):
     type: str
     platform: str | None
     is_deployed: bool
+    digital_twin: DigitalTwin
+    """
+    Digital Twin fabric facts.
+
+    Subclass of AvdModel.
+    """
     serial_number: str | None
     mgmt_interface: str | None
     mgmt_ip: str | None
@@ -1336,6 +1364,7 @@ class EosDesignsFactsProtocol(Protocol):
             type: str | UndefinedType = Undefined,
             platform: str | UndefinedType | None = Undefined,
             is_deployed: bool | UndefinedType = Undefined,
+            digital_twin: DigitalTwin | UndefinedType = Undefined,
             serial_number: str | UndefinedType | None = Undefined,
             mgmt_interface: str | UndefinedType | None = Undefined,
             mgmt_ip: str | UndefinedType | None = Undefined,
@@ -1403,6 +1432,10 @@ class EosDesignsFactsProtocol(Protocol):
                 type: type
                 platform: platform
                 is_deployed: is_deployed
+                digital_twin:
+                   Digital Twin fabric facts.
+
+                   Subclass of AvdModel.
                 serial_number: serial_number
                 mgmt_interface: mgmt_interface
                 mgmt_ip: mgmt_ip

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -18956,6 +18956,7 @@ class EosDesigns(EosDesignsRootModel):
                 "act_username": {"type": str, "default": "cvpadmin"},
                 "act_password": {"type": str, "default": "cvp123!"},
                 "act_internet_access": {"type": bool, "default": False},
+                "act_legacy_eos_versioning": {"type": bool},
                 "act_ensure_eapi_access": {"type": bool, "default": False},
             }
             act_os_version: str | None
@@ -18982,6 +18983,8 @@ class EosDesigns(EosDesignsRootModel):
 
             Default value: `False`
             """
+            act_legacy_eos_versioning: bool | None
+            """Set the ACT `legacy_eos_versioning` topology setting."""
             act_ensure_eapi_access: bool
             """
             Ensures eAPI remains accessible for automation and testing via ACT.
@@ -19006,6 +19009,7 @@ class EosDesigns(EosDesignsRootModel):
                     act_username: str | UndefinedType = Undefined,
                     act_password: str | UndefinedType = Undefined,
                     act_internet_access: bool | UndefinedType = Undefined,
+                    act_legacy_eos_versioning: bool | UndefinedType | None = Undefined,
                     act_ensure_eapi_access: bool | UndefinedType = Undefined,
                 ) -> None:
                     """
@@ -19024,6 +19028,7 @@ class EosDesigns(EosDesignsRootModel):
                            applies only to the 'cloudeos' and 'veos' node types and will be ignored for all other ACT node
                            types.
                            ACT does not provide direct Internet access to cloudeos or veos devices by default.
+                        act_legacy_eos_versioning: Set the ACT `legacy_eos_versioning` topology setting.
                         act_ensure_eapi_access:
                            Ensures eAPI remains accessible for automation and testing via ACT.
                            Clients connecting to device

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -2359,6 +2359,9 @@ keys:
 
               ACT does not provide direct Internet access to cloudeos or veos devices
               by default.'
+          act_legacy_eos_versioning:
+            type: bool
+            description: Set the ACT `legacy_eos_versioning` topology setting.
           act_ensure_eapi_access:
             type: bool
             description: 'Ensures eAPI remains accessible for automation and testing

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/digital_twin.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/digital_twin.schema.yml
@@ -48,6 +48,9 @@ keys:
               Specifies if the ACT Digital Twin device is deployed with direct access to the Internet.
               This option applies only to the 'cloudeos' and 'veos' node types and will be ignored for all other ACT node types.
               ACT does not provide direct Internet access to cloudeos or veos devices by default.
+          act_legacy_eos_versioning:
+            type: bool
+            description: Set the ACT `legacy_eos_versioning` topology setting.
           act_ensure_eapi_access:
             type: bool
             description: |-

--- a/python-avd/pyavd/api/fabric_documentation/__init__.py
+++ b/python-avd/pyavd/api/fabric_documentation/__init__.py
@@ -17,6 +17,11 @@ class ActNodeTypeSettings:
 
 
 @dataclass(frozen=True)
+class ActSettings:
+    legacy_eos_versioning: bool | None
+
+
+@dataclass(frozen=True)
 class ActNodeSettings:
     node_type: str
     ip_addr: str | None
@@ -30,6 +35,7 @@ class ActNodeSettings:
 class ACTDigitalTwin:
     """ACT Digital Twin fabric documentation dataclass."""
 
+    settings: ActSettings | None
     nodes: tuple[dict[str, ActNodeSettings], ...]
     cloudeos: ActNodeTypeSettings | None = None
     cvp: ActNodeTypeSettings | None = None

--- a/python-avd/pyavd/get_fabric_documentation.py
+++ b/python-avd/pyavd/get_fabric_documentation.py
@@ -12,6 +12,7 @@ from pyavd.api.fabric_documentation import (
     ActLinkSettings,
     ActNodeSettings,
     ActNodeTypeSettings,
+    ActSettings,
     FabricDocumentation,
 )
 
@@ -31,6 +32,7 @@ def get_fabric_documentation(
     p2p_links_csv: bool = False,
     toc: bool = True,
     digital_twin: bool = False,
+    digital_twin_settings: ActSettings | None = None,
 ) -> FabricDocumentation:
     """
     Build and return the AVD fabric documentation.
@@ -52,6 +54,7 @@ def get_fabric_documentation(
         p2p_links_csv: Returns P2P links CSV when set to True.
         toc: Skip TOC when set to False.
         digital_twin: PREVIEW: Returns Digital Twin topology when set to True.
+        digital_twin_settings: PREVIEW: Settings for the Digital Twin topology.
 
     Returns:
         FabricDocumentation object containing the requested documentation areas.
@@ -88,7 +91,7 @@ def get_fabric_documentation(
     if p2p_links_csv:
         result.p2p_links_csv = _get_p2p_links_csv(fabric_documentation_facts)
     if digital_twin:
-        result.digital_twin = _get_digital_twin(fabric_documentation_facts)
+        result.digital_twin = _get_digital_twin(fabric_documentation_facts, digital_twin_settings)
 
     return result
 
@@ -147,7 +150,7 @@ def _get_p2p_links_csv(fabric_documentation_facts: FabricDocumentationFacts) -> 
     return csv_content.read()
 
 
-def _get_digital_twin(fabric_documentation_facts: FabricDocumentationFacts) -> ACTDigitalTwin | None:
+def _get_digital_twin(fabric_documentation_facts: FabricDocumentationFacts, digital_twin_settings: ActSettings | None = None) -> ACTDigitalTwin | None:
     digital_twin_env = next(
         (
             environment
@@ -158,12 +161,12 @@ def _get_digital_twin(fabric_documentation_facts: FabricDocumentationFacts) -> A
     )
     match digital_twin_env:
         case "act":
-            return _get_digital_twin_act(fabric_documentation_facts)
+            return _get_digital_twin_act(fabric_documentation_facts, digital_twin_settings)
         case _:
             return None
 
 
-def _get_digital_twin_act(fabric_documentation_facts: FabricDocumentationFacts) -> ACTDigitalTwin:
+def _get_digital_twin_act(fabric_documentation_facts: FabricDocumentationFacts, digital_twin_settings: ActSettings | None = None) -> ACTDigitalTwin:
     """
     Build and return the ACT topology data.
 
@@ -174,6 +177,7 @@ def _get_digital_twin_act(fabric_documentation_facts: FabricDocumentationFacts) 
 
     Args:
         fabric_documentation_facts: FabricDocumentationFacts object holding facts used for generating Fabric Documentation.
+        digital_twin_settings: Settings for the Digital Twin topology.
 
     Returns:
         ACTDigitalTwin object containing information to render ACT topology file.
@@ -272,6 +276,7 @@ def _get_digital_twin_act(fabric_documentation_facts: FabricDocumentationFacts) 
         )
 
     return ACTDigitalTwin(
+        settings=digital_twin_settings,
         nodes=tuple(digital_twin_devices),
         links=tuple(
             ActLinkSettings(

--- a/python-avd/pyavd/get_fabric_documentation.py
+++ b/python-avd/pyavd/get_fabric_documentation.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from re import findall as re_findall
 from typing import TYPE_CHECKING, cast
 
+from pyavd._errors import AristaAvdError
 from pyavd._utils.get import get
 from pyavd.api.fabric_documentation import (
     ACTDigitalTwin,
@@ -32,7 +33,6 @@ def get_fabric_documentation(
     p2p_links_csv: bool = False,
     toc: bool = True,
     digital_twin: bool = False,
-    digital_twin_settings: ActSettings | None = None,
 ) -> FabricDocumentation:
     """
     Build and return the AVD fabric documentation.
@@ -54,7 +54,6 @@ def get_fabric_documentation(
         p2p_links_csv: Returns P2P links CSV when set to True.
         toc: Skip TOC when set to False.
         digital_twin: PREVIEW: Returns Digital Twin topology when set to True.
-        digital_twin_settings: PREVIEW: Settings for the Digital Twin topology.
 
     Returns:
         FabricDocumentation object containing the requested documentation areas.
@@ -91,7 +90,7 @@ def get_fabric_documentation(
     if p2p_links_csv:
         result.p2p_links_csv = _get_p2p_links_csv(fabric_documentation_facts)
     if digital_twin:
-        result.digital_twin = _get_digital_twin(fabric_documentation_facts, digital_twin_settings)
+        result.digital_twin = _get_digital_twin(fabric_documentation_facts)
 
     return result
 
@@ -150,7 +149,7 @@ def _get_p2p_links_csv(fabric_documentation_facts: FabricDocumentationFacts) -> 
     return csv_content.read()
 
 
-def _get_digital_twin(fabric_documentation_facts: FabricDocumentationFacts, digital_twin_settings: ActSettings | None = None) -> ACTDigitalTwin | None:
+def _get_digital_twin(fabric_documentation_facts: FabricDocumentationFacts) -> ACTDigitalTwin | None:
     digital_twin_env = next(
         (
             environment
@@ -161,12 +160,12 @@ def _get_digital_twin(fabric_documentation_facts: FabricDocumentationFacts, digi
     )
     match digital_twin_env:
         case "act":
-            return _get_digital_twin_act(fabric_documentation_facts, digital_twin_settings)
+            return _get_digital_twin_act(fabric_documentation_facts)
         case _:
             return None
 
 
-def _get_digital_twin_act(fabric_documentation_facts: FabricDocumentationFacts, digital_twin_settings: ActSettings | None = None) -> ACTDigitalTwin:
+def _get_digital_twin_act(fabric_documentation_facts: FabricDocumentationFacts) -> ACTDigitalTwin:
     """
     Build and return the ACT topology data.
 
@@ -177,7 +176,6 @@ def _get_digital_twin_act(fabric_documentation_facts: FabricDocumentationFacts, 
 
     Args:
         fabric_documentation_facts: FabricDocumentationFacts object holding facts used for generating Fabric Documentation.
-        digital_twin_settings: Settings for the Digital Twin topology.
 
     Returns:
         ACTDigitalTwin object containing information to render ACT topology file.
@@ -199,6 +197,15 @@ def _get_digital_twin_act(fabric_documentation_facts: FabricDocumentationFacts, 
             for device_structured_config in fabric_documentation_facts.structured_configs.values()
         ),
     )
+    act_legacy_eos_versioning_values = {
+        act_legacy_eos_versioning
+        for avd_facts in fabric_documentation_facts.avd_facts.values()
+        if (act_legacy_eos_versioning := avd_facts.digital_twin.act_legacy_eos_versioning if avd_facts.digital_twin else None) is not None
+    }
+    if len(act_legacy_eos_versioning_values) > 1:
+        msg = "Found conflicting values for 'digital_twin.fabric.act_legacy_eos_versioning'. The ACT topology only supports one global value."
+        raise AristaAvdError(msg)
+    digital_twin_settings = ActSettings(legacy_eos_versioning=next(iter(act_legacy_eos_versioning_values))) if act_legacy_eos_versioning_values else None
 
     digital_twin_node_types: dict[str, ActNodeTypeSettings | None] = {
         "cloudeos": None,


### PR DESCRIPTION
Fixes #7121
## Summary
- Add fabric-level digital_twin.fabric.act_legacy_eos_versioning input.
- Render ACT topology settings.legacy_eos_versioning when set.
- Add molecule coverage for the generated ACT topology setting.
 
## Tests
- molecule converge --scenario-name digital_twin -- --forks 5
- pre-commit run --files <changed files>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring ACT Digital Twin topology settings through `digital_twin.fabric.act_legacy_eos_versioning`.
  * Added documentation and schema validation for the new Boolean option.
  * Digital Twin fabric documentation now carries the configured legacy EOS versioning setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->