### PR TITLE
Fix(eos_designs): Honor platform support for dot1x BPDU bypass

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-6.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/dot1x-settings-6.cfg
@@ -30,7 +30,6 @@ ip radius vrf MGMT source-interface Management1
 !
 dot1x system-auth-control
 dot1x protocol lldp bypass
-dot1x protocol bpdu bypass
 dot1x dynamic-authorization
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-6.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dot1x-settings-6.yml
@@ -15,7 +15,6 @@ config_end: true
 dot1x:
   system_auth_control: true
   protocol_lldp_bypass: true
-  protocol_bpdu_bypass: true
   dynamic_authorization: true
   radius_av_pair:
     dhcp:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-6.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/dot1x-settings-6.yml
@@ -15,6 +15,8 @@ custom_platform_settings:
     feature_support:
       address_locking:
         supported: false
+      dot1x:
+        protocol_bpdu_bypass: false
 
 address_locking_settings:
   dhcp_servers_ipv4:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/custom-platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/custom-platform-settings.md
@@ -19,6 +19,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_interface_mtu</samp>](## "custom_platform_settings.[].default_interface_mtu") | Integer |  |  | Min: 68<br>Max: 65535 | Default interface MTU configured on EOS under "interface defaults".<br>Takes precedence over the root key "default_interface_mtu".<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;p2p_uplinks_mtu</samp>](## "custom_platform_settings.[].p2p_uplinks_mtu") | Integer |  |  | Min: 68<br>Max: 65535 | Set MTU on point to point uplink interfaces.<br>Takes precedence over the root key "p2p_uplinks_mtu".<br><node_type>.uplink_mtu -> platform_settings.p2p_uplinks_mtu -> p2p_uplinks_mtu -> 9214.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;feature_support</samp>](## "custom_platform_settings.[].feature_support") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1x</samp>](## "custom_platform_settings.[].feature_support.dot1x") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_bpdu_bypass</samp>](## "custom_platform_settings.[].feature_support.dot1x.protocol_bpdu_bypass") | Boolean |  | `True` |  | Support for 802.1X BPDU bypass.<br>The feature will be ignored on platforms where this is false. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_locking</samp>](## "custom_platform_settings.[].feature_support.address_locking") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;supported</samp>](## "custom_platform_settings.[].feature_support.address_locking.supported") | Boolean |  | `True` |  | Global support for Address Locking feature.<br>The feature will be ignored on platforms where this is false. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_enforcement_disabled</samp>](## "custom_platform_settings.[].feature_support.address_locking.ipv4_enforcement_disabled") | Boolean |  | `True` |  | Support for disabling enforcement for locked IPv4 addresses.<br>The feature will be ignored on platforms where this is false. |
@@ -211,6 +213,11 @@
         # <node_type>.uplink_mtu -> platform_settings.p2p_uplinks_mtu -> p2p_uplinks_mtu -> 9214.
         p2p_uplinks_mtu: <int; 68-65535>
         feature_support:
+          dot1x:
+
+            # Support for 802.1X BPDU bypass.
+            # The feature will be ignored on platforms where this is false.
+            protocol_bpdu_bypass: <bool; default=True>
           address_locking:
 
             # Global support for Address Locking feature.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
@@ -19,6 +19,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_interface_mtu</samp>](## "platform_settings.[].default_interface_mtu") | Integer |  |  | Min: 68<br>Max: 65535 | Default interface MTU configured on EOS under "interface defaults".<br>Takes precedence over the root key "default_interface_mtu".<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;p2p_uplinks_mtu</samp>](## "platform_settings.[].p2p_uplinks_mtu") | Integer |  |  | Min: 68<br>Max: 65535 | Set MTU on point to point uplink interfaces.<br>Takes precedence over the root key "p2p_uplinks_mtu".<br><node_type>.uplink_mtu -> platform_settings.p2p_uplinks_mtu -> p2p_uplinks_mtu -> 9214.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;feature_support</samp>](## "platform_settings.[].feature_support") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1x</samp>](## "platform_settings.[].feature_support.dot1x") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_bpdu_bypass</samp>](## "platform_settings.[].feature_support.dot1x.protocol_bpdu_bypass") | Boolean |  | `True` |  | Support for 802.1X BPDU bypass.<br>The feature will be ignored on platforms where this is false. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_locking</samp>](## "platform_settings.[].feature_support.address_locking") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;supported</samp>](## "platform_settings.[].feature_support.address_locking.supported") | Boolean |  | `True` |  | Global support for Address Locking feature.<br>The feature will be ignored on platforms where this is false. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_enforcement_disabled</samp>](## "platform_settings.[].feature_support.address_locking.ipv4_enforcement_disabled") | Boolean |  | `True` |  | Support for disabling enforcement for locked IPv4 addresses.<br>The feature will be ignored on platforms where this is false. |
@@ -215,6 +217,11 @@
         # <node_type>.uplink_mtu -> platform_settings.p2p_uplinks_mtu -> p2p_uplinks_mtu -> 9214.
         p2p_uplinks_mtu: <int; 68-65535>
         feature_support:
+          dot1x:
+
+            # Support for 802.1X BPDU bypass.
+            # The feature will be ignored on platforms where this is false.
+            protocol_bpdu_bypass: <bool; default=True>
           address_locking:
 
             # Global support for Address Locking feature.

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -42733,6 +42733,34 @@ class EosDesigns(EosDesignsRootModel):
         class FeatureSupport(AvdModel):
             """Subclass of AvdModel."""
 
+            class Dot1x(AvdModel):
+                """Subclass of AvdModel."""
+
+                _fields: ClassVar[dict] = {"protocol_bpdu_bypass": {"type": bool, "default": True}}
+                protocol_bpdu_bypass: bool
+                """
+                Support for 802.1X BPDU bypass.
+                The feature will be ignored on platforms where this is false.
+
+                Default value: `True`
+                """
+
+                if TYPE_CHECKING:
+
+                    def __init__(self, *, protocol_bpdu_bypass: bool | UndefinedType = Undefined) -> None:
+                        """
+                        Dot1x.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            protocol_bpdu_bypass:
+                               Support for 802.1X BPDU bypass.
+                               The feature will be ignored on platforms where this is false.
+
+                        """
+
             class AddressLocking(AvdModel):
                 """Subclass of AvdModel."""
 
@@ -43970,6 +43998,7 @@ class EosDesigns(EosDesignsRootModel):
                         """
 
             _fields: ClassVar[dict] = {
+                "dot1x": {"type": Dot1x},
                 "address_locking": {"type": AddressLocking},
                 "queue_monitor": {"type": bool, "default": True},
                 "queue_monitor_length_notify": {"type": bool, "default": True},
@@ -43996,6 +44025,8 @@ class EosDesigns(EosDesignsRootModel):
                 "hardware_validation": {"type": bool, "default": True},
                 "errdisable_causes": {"type": ErrdisableCauses},
             }
+            dot1x: Dot1x
+            """Subclass of AvdModel."""
             address_locking: AddressLocking
             """Subclass of AvdModel."""
             queue_monitor: bool
@@ -44204,6 +44235,7 @@ class EosDesigns(EosDesignsRootModel):
                 def __init__(
                     self,
                     *,
+                    dot1x: Dot1x | UndefinedType = Undefined,
                     address_locking: AddressLocking | UndefinedType = Undefined,
                     queue_monitor: bool | UndefinedType = Undefined,
                     queue_monitor_length_notify: bool | UndefinedType = Undefined,
@@ -44237,6 +44269,7 @@ class EosDesigns(EosDesignsRootModel):
                     Subclass of AvdModel.
 
                     Args:
+                        dot1x: Subclass of AvdModel.
                         address_locking: Subclass of AvdModel.
                         queue_monitor:
                            Support for LANZ.
@@ -44579,6 +44612,34 @@ class EosDesigns(EosDesignsRootModel):
         class FeatureSupport(AvdModel):
             """Subclass of AvdModel."""
 
+            class Dot1x(AvdModel):
+                """Subclass of AvdModel."""
+
+                _fields: ClassVar[dict] = {"protocol_bpdu_bypass": {"type": bool, "default": True}}
+                protocol_bpdu_bypass: bool
+                """
+                Support for 802.1X BPDU bypass.
+                The feature will be ignored on platforms where this is false.
+
+                Default value: `True`
+                """
+
+                if TYPE_CHECKING:
+
+                    def __init__(self, *, protocol_bpdu_bypass: bool | UndefinedType = Undefined) -> None:
+                        """
+                        Dot1x.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            protocol_bpdu_bypass:
+                               Support for 802.1X BPDU bypass.
+                               The feature will be ignored on platforms where this is false.
+
+                        """
+
             class AddressLocking(AvdModel):
                 """Subclass of AvdModel."""
 
@@ -45816,6 +45877,7 @@ class EosDesigns(EosDesignsRootModel):
                         """
 
             _fields: ClassVar[dict] = {
+                "dot1x": {"type": Dot1x},
                 "address_locking": {"type": AddressLocking},
                 "queue_monitor": {"type": bool, "default": True},
                 "queue_monitor_length_notify": {"type": bool, "default": True},
@@ -45842,6 +45904,8 @@ class EosDesigns(EosDesignsRootModel):
                 "hardware_validation": {"type": bool, "default": True},
                 "errdisable_causes": {"type": ErrdisableCauses},
             }
+            dot1x: Dot1x
+            """Subclass of AvdModel."""
             address_locking: AddressLocking
             """Subclass of AvdModel."""
             queue_monitor: bool
@@ -46050,6 +46114,7 @@ class EosDesigns(EosDesignsRootModel):
                 def __init__(
                     self,
                     *,
+                    dot1x: Dot1x | UndefinedType = Undefined,
                     address_locking: AddressLocking | UndefinedType = Undefined,
                     queue_monitor: bool | UndefinedType = Undefined,
                     queue_monitor_length_notify: bool | UndefinedType = Undefined,
@@ -46083,6 +46148,7 @@ class EosDesigns(EosDesignsRootModel):
                     Subclass of AvdModel.
 
                     Args:
+                        dot1x: Subclass of AvdModel.
                         address_locking: Subclass of AvdModel.
                         queue_monitor:
                            Support for LANZ.

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -16594,6 +16594,15 @@ $defs:
         feature_support:
           type: dict
           keys:
+            dot1x:
+              type: dict
+              keys:
+                protocol_bpdu_bypass:
+                  type: bool
+                  default: true
+                  description: 'Support for 802.1X BPDU bypass.
+
+                    The feature will be ignored on platforms where this is false.'
             address_locking:
               type: dict
               keys:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_platform_settings.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_platform_settings.yml
@@ -63,6 +63,15 @@ $defs:
         feature_support:
           type: dict
           keys:
+            dot1x:
+              type: dict
+              keys:
+                protocol_bpdu_bypass:
+                  type: bool
+                  default: true
+                  description: |-
+                    Support for 802.1X BPDU bypass.
+                    The feature will be ignored on platforms where this is false.
             address_locking:
               type: dict
               keys:

--- a/python-avd/pyavd/_eos_designs/structured_config/base/dot1x.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/dot1x.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Protocol
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 from pyavd._errors import AristaAvdInvalidInputsError, AristaAvdMissingVariableError
+from pyavd._utils.undefined import Undefined
 
 if TYPE_CHECKING:
     from pyavd._eos_designs.schema import EosDesigns
@@ -86,9 +87,10 @@ class Dot1xMixin(Protocol):
 
     def _configure_dot1x_global_settings(self: AvdStructuredConfigBaseProtocol, dot1x_settings: EosDesigns.Dot1xSettings) -> None:
         """Configure 802.1X global settings."""
+        feature_support = self.shared_utils.platform_settings.feature_support
         self.structured_config.dot1x = EosCliConfigGen.Dot1x(
             system_auth_control=True,
-            protocol_bpdu_bypass=dot1x_settings.bypass_bpdu,
+            protocol_bpdu_bypass=dot1x_settings.bypass_bpdu if feature_support.dot1x.protocol_bpdu_bypass else Undefined,
             protocol_lldp_bypass=dot1x_settings.bypass_lldp,
             dynamic_authorization=dot1x_settings.dynamic_authorization.enabled,
         )


### PR DESCRIPTION
## Summary
- add platform feature support for dot1x BPDU bypass
- omit dot1x BPDU bypass from generated structured config when unsupported
- set the digital_twin fabric override via custom_platform_settings and cover the omission in an existing dot1x molecule fixture

## Tests
- uv run tools/e2e-test-avd.py ./ansible_collections/arista/avd/extensions/molecule/digital_twin/e2e-test.toml
- uv run tools/e2e-test-avd.py ./ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/e2e-test.toml
- PRE_COMMIT_HOME=/private/tmp/avd-pre-commit uv run --no-project --with pre-commit pre-commit run --files <changed files>

Fixes #7407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform capability settings for 802.1X BPDU bypass support.
  * Platforms can now indicate whether 802.1X BPDU bypass is supported, defaulting to supported.

* **Bug Fixes**
  * Prevented unsupported platforms from generating 802.1X BPDU bypass configuration.
  * Preserved other 802.1X bypass settings when BPDU bypass is unavailable.

* **Documentation**
  * Documented the new platform capability setting in platform and custom platform settings references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->